### PR TITLE
Map CSV rows to point coordinates

### DIFF
--- a/src/components/CsvPanel.jsx
+++ b/src/components/CsvPanel.jsx
@@ -18,6 +18,7 @@ export default function CsvPanel({
   onSelect,         // Callback to change selected CSV
   onImportFiles,    // Callback to import new CSV files
   onUnloadSelected, // Callback to unload the selected CSV
+  onUpdateMapping,  // Callback when user changes latitude/longitude fields
 }) {
   /**
    * Hidden file input reference.
@@ -160,6 +161,93 @@ export default function CsvPanel({
               <div>
                 <span className="csvMetaLabel">Columns:</span>{" "}
                 {selected.headers.length}
+              </div>
+            </div>
+
+            {/* =========================
+                Coordinate mapping
+                =========================
+                This section lets the user choose which CSV columns
+                should be used as latitude and longitude.
+
+                The choices are saved per file and used later
+                to create map points.
+            */}
+            <div className="csvMeta" style={{ marginTop: 10 }}>
+              {/* Latitude column selector */}
+              <div>
+                <span className="csvMetaLabel">
+                  Latitude field:
+                </span>
+
+                {/* Dropdown with all CSV headers */}
+                <select
+                  className="csvSelect"
+
+                  // Current selected latitude column (or empty)
+                  value={selected.latField || ""}
+
+                  // Update the selected file when user changes the value
+                  onChange={(e) =>
+                    onUpdateMapping?.(
+                      selected.id,
+                      { latField: e.target.value || null }
+                    )
+                  }
+
+                  aria-label="Select latitude field"
+                  style={{ marginTop: 6 }}
+                >
+                  {/* No column selected */}
+                  <option value="">
+                    (not set)
+                  </option>
+
+                  {/* One option for each CSV header */}
+                  {selected.headers.map((h) => (
+                    <option key={h} value={h}>
+                      {h}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              {/* Longitude column selector */}
+              <div>
+                <span className="csvMetaLabel">
+                  Longitude field:
+                </span>
+
+                {/* Dropdown with all CSV headers */}
+                <select
+                  className="csvSelect"
+
+                  // Current selected longitude column (or empty)
+                  value={selected.lonField || ""}
+
+                  // Update the selected file when user changes the value
+                  onChange={(e) =>
+                    onUpdateMapping?.(
+                      selected.id,
+                      { lonField: e.target.value || null }
+                    )
+                  }
+
+                  aria-label="Select longitude field"
+                  style={{ marginTop: 6 }}
+                >
+                  {/* No column selected */}
+                  <option value="">
+                    (not set)
+                  </option>
+
+                  {/* One option for each CSV header */}
+                  {selected.headers.map((h) => (
+                    <option key={h} value={h}>
+                      {h}
+                    </option>
+                  ))}
+                </select>
               </div>
             </div>
 

--- a/src/components/GeoMap.jsx
+++ b/src/components/GeoMap.jsx
@@ -1,12 +1,34 @@
 // Import core components from react-leaflet.
 // MapContainer is the main map wrapper.
 // TileLayer is used to load map tiles (images).
-import { MapContainer, TileLayer } from 'react-leaflet';
+// Marker and Popup are used to show points on the map.
+import { MapContainer, TileLayer, Marker, Popup } from "react-leaflet";
 
-// GeoMap is a simple map component.
-// It only shows a base map for now.
-// Other layers (points, lines, areas) will be added later.
-export default function GeoMap() {
+/**
+ * Build a list of fields to show in the popup.
+ *
+ * - row: one CSV row (object with key/value pairs)
+ * - latField / lonField: column names used for coordinates
+ * - limit: max number of fields to show
+ *
+ * Latitude and longitude fields are skipped,
+ * because they are already shown at the top.
+ */
+function buildPopupFields(row, latField, lonField, limit = 8) {
+  if (!row || typeof row !== "object") return [];
+
+  // Get all column names except lat/lon
+  const keys = Object.keys(row).filter(
+    (k) => k !== latField && k !== lonField
+  );
+
+  // Keep only the first few fields to keep popup readable
+  return keys.slice(0, limit).map((k) => [k, row[k]]);
+}
+
+// GeoMap is the main map component.
+// It shows the base map and point markers from CSV data.
+export default function GeoMap({ points = [] }) {
   return (
     // MapContainer must have a fixed height and width.
     // If not, the map will not render correctly.
@@ -20,9 +42,9 @@ export default function GeoMap() {
       zoom={5}
 
       // Make the map fill its parent container.
-      style={{ height: '100%', width: '100%' }}
+      style={{ height: "100%", width: "100%" }}
     >
-      {/* 
+      {/*
         TileLayer defines where the map images come from.
         This uses free OpenStreetMap tiles.
         {s}, {z}, {x}, {y} are replaced automatically by Leaflet.
@@ -34,6 +56,45 @@ export default function GeoMap() {
         // Standard OpenStreetMap tile server URL.
         url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
       />
+
+      {/*
+        Render one marker for each point.
+        Each point comes from one CSV row with valid lat/lon values.
+      */}
+      {points.map((p) => (
+        <Marker
+          key={p.id}
+          position={[p.lat, p.lon]}
+        >
+          {/* Popup shown when the marker is clicked */}
+          <Popup>
+            <div style={{ minWidth: 220 }}>
+              {/* Title */}
+              <div style={{ fontWeight: 700, marginBottom: 6 }}>
+                Point
+              </div>
+
+              {/* Always show coordinates */}
+              <div>
+                <b>lat:</b> {p.lat}
+              </div>
+              <div>
+                <b>lon:</b> {p.lon}
+              </div>
+
+              <hr style={{ opacity: 0.25 }} />
+
+              {/* Show some extra fields from the CSV row */}
+              {buildPopupFields(p.row, "latField", "lonField")
+                .map(([k, v]) => (
+                  <div key={k} style={{ marginBottom: 4 }}>
+                    <b>{k}:</b> {String(v ?? "")}
+                  </div>
+                ))}
+            </div>
+          </Popup>
+        </Marker>
+      ))}
     </MapContainer>
   );
 }

--- a/src/components/derivePoints.js
+++ b/src/components/derivePoints.js
@@ -1,0 +1,37 @@
+import { isValidLat, isValidLon, parseFlexibleFloat } from "./geoColumns";
+
+/**
+ * Derive point features from CSV rows using chosen lat/lon fields.
+ * Skips invalid rows and returns a summary.
+ */
+export function derivePointsFromCsv({ rows, latField, lonField }) {
+  const points = [];
+  let skipped = 0;
+
+  if (!Array.isArray(rows) || !latField || !lonField) {
+    return { points, skipped, reason: "Missing rows or lat/lon mapping." };
+  }
+
+  for (let i = 0; i < rows.length; i++) {
+    const r = rows[i];
+
+    const lat = parseFlexibleFloat(r?.[latField]);
+    const lon = parseFlexibleFloat(r?.[lonField]);
+
+    if (!isValidLat(lat) || !isValidLon(lon)) {
+      skipped++;
+      continue;
+    }
+
+    points.push({
+      id: `${i}`,       // stable per file (index-based)
+      lat,
+      lon,
+      row: r,           // original row data for popup
+    });
+  }
+
+  return { points, skipped, reason: null };
+}
+
+

--- a/src/components/geoColumns.js
+++ b/src/components/geoColumns.js
@@ -1,0 +1,95 @@
+const LAT_SYNONYMS = [
+  "lat",
+  "latitude",
+  "y",
+  "northing",
+];
+
+const LON_SYNONYMS = [
+  "lon",
+  "lng",
+  "long",
+  "longitude",
+  "x",
+  "easting",
+];
+
+function normalizeKey(h) {
+  // "Latitude_2" -> "latitude"
+  return String(h ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, "")
+    .replace(/_\d+$/g, "");
+}
+
+function scoreHeader(normalized, synonyms) {
+  // Prefer exact matches, then "contains" matches.
+  // This helps with headers like "gps_latitude" etc.
+  for (const s of synonyms) {
+    if (normalized === s) return 100;
+  }
+  for (const s of synonyms) {
+    if (normalized.includes(s)) return 50;
+  }
+  return 0;
+}
+
+function pickBest(headers, synonyms) {
+  let best = { field: null, score: 0, index: -1 };
+
+  for (let i = 0; i < headers.length; i++) {
+    const h = headers[i];
+    const n = normalizeKey(h);
+    const s = scoreHeader(n, synonyms);
+
+    if (s > best.score) best = { field: h, score: s, index: i };
+  }
+
+  return best.field;
+}
+
+export function autoDetectLatLon(headers) {
+  if (!Array.isArray(headers) || headers.length === 0) {
+    return { latField: null, lonField: null };
+  }
+
+  const latField = pickBest(headers, LAT_SYNONYMS);
+  const lonField = pickBest(headers, LON_SYNONYMS);
+
+  return {
+    latField: latField ?? null,
+    lonField: lonField ?? null,
+  };
+}
+
+export function parseFlexibleFloat(value) {
+  if (value === null || value === undefined) return NaN;
+
+  // Handle numbers already
+  if (typeof value === "number") return Number.isFinite(value) ? value : NaN;
+
+  const s = String(value).trim();
+  if (!s) return NaN;
+
+  // Replace decimal comma with dot if it looks like a decimal comma.
+  // Examples:
+  // "59,3293" -> "59.3293"
+  // "1 234,56" -> "1234.56"
+  const normalized = s
+    .replace(/\s+/g, "")     // remove spaces
+    .replace(/,/g, ".");     // decimal comma -> dot (simple + effective)
+
+  const n = Number.parseFloat(normalized);
+  return Number.isFinite(n) ? n : NaN;
+}
+
+export function isValidLat(lat) {
+  return Number.isFinite(lat) && lat >= -90 && lat <= 90;
+}
+
+export function isValidLon(lon) {
+  return Number.isFinite(lon) && lon >= -180 && lon <= 180;
+}
+
+

--- a/src/leafletIconFix.js
+++ b/src/leafletIconFix.js
@@ -1,0 +1,15 @@
+import L from "leaflet";
+
+import markerIcon2x from "leaflet/dist/images/marker-icon-2x.png";
+import markerIcon from "leaflet/dist/images/marker-icon.png";
+import markerShadow from "leaflet/dist/images/marker-shadow.png";
+
+delete L.Icon.Default.prototype._getIconUrl;
+
+L.Icon.Default.mergeOptions({
+  iconRetinaUrl: markerIcon2x,
+  iconUrl: markerIcon,
+  shadowUrl: markerShadow,
+});
+
+

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,4 +1,5 @@
 import 'leaflet/dist/leaflet.css';
+import "./leafletIconFix";
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
@@ -9,3 +10,5 @@ createRoot(document.getElementById('root')).render(
     <App />
   </StrictMode>,
 )
+
+


### PR DESCRIPTION
1. Auto-detect latitude and longitude columns from CSV headers
2. Allow manual selection of latitude and longitude fields
3. Convert CSV rows to map points with validation
4. Skip invalid coordinate rows safely
5. Show points on the map with popups
6. Fix Leaflet marker icons for Vite builds