### PR TITLE
Add Map tools and Debug tools dropdown menus to CSV panel

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -271,4 +271,111 @@
   opacity: 0.85;
 }
 
+/* --- Tool menus (Map tools / Debug tools) --- */
+.csvToolMenus {
+  /* This row exists in layout, but dropdown bodies are absolute overlays */
+  position: relative;
+  z-index: 1400; /* above the panel header/content */
+  display: flex;
+  gap: 8px;
+  padding: 10px 10px 8px 10px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.csvToolMenu {
+  position: relative; /* anchor for the absolute dropdown */
+  flex: 1;
+  min-width: 0;
+}
+
+.csvToolMenuHeader {
+  width: 100%;
+  height: 32px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(15, 23, 42, 0.8);
+  color: #e2e8f0;
+  cursor: pointer;
+  user-select: none;
+
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 10px;
+
+  font-weight: 700;
+  font-size: 12px;
+  letter-spacing: 0.2px;
+}
+
+.csvToolMenuHeader:hover {
+  background: rgba(15, 23, 42, 1);
+}
+
+.csvToolMenuTitle {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.csvToolMenuChevron {
+  opacity: 0.9;
+  font-weight: 900;
+  margin-left: 10px;
+}
+
+/* Dropdown overlay: does NOT push content below */
+.csvToolMenuBody {
+  position: absolute;
+  top: calc(32px + 8px);
+  left: 0;
+  width: 100%;
+  z-index: 1500;
+
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(15, 23, 42, 0.98);
+  color: #e2e8f0;
+
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.45);
+  padding: 10px;
+
+  /* Keep the dropdown from getting too tall */
+  max-height: 55vh;
+  overflow: auto;
+}
+
+.csvToolToggle {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+
+  padding: 8px 6px;
+  border-radius: 10px;
+  cursor: pointer;
+  user-select: none;
+
+  font-size: 12px;
+  line-height: 1.2;
+}
+
+.csvToolToggle:hover {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.csvToolToggle input {
+  width: 14px;
+  height: 14px;
+}
+
+.csvToolMenuHint {
+  margin-top: 8px;
+  font-size: 12px;
+  opacity: 0.8;
+  padding: 6px;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.04);
+}
+
 

--- a/src/components/useSessionStorageState.js
+++ b/src/components/useSessionStorageState.js
@@ -1,0 +1,32 @@
+import { useEffect, useState } from "react";
+
+/**
+ * useSessionStorageState
+ * - Persists a piece of state in sessionStorage
+ * - Safe JSON parsing
+ * - Cross-tab sync is NOT needed for sessionStorage (per-tab), so we keep it simple.
+ */
+export function useSessionStorageState(key, initialValue) {
+  const [value, setValue] = useState(() => {
+    try {
+      const raw = sessionStorage.getItem(key);
+      if (raw == null) return initialValue;
+      return JSON.parse(raw);
+    } catch {
+      return initialValue;
+    }
+  });
+
+  useEffect(() => {
+    try {
+      sessionStorage.setItem(key, JSON.stringify(value));
+    } catch {
+      // If storage is full or blocked, fail silently.
+      // UI still works; persistence just won't.
+    }
+  }, [key, value]);
+
+  return [value, setValue];
+}
+
+


### PR DESCRIPTION
1. Two tool menus: Map tools and Debug tools
2. Side-by-side menu headers
3. Dropdowns overlay panel content (no layout reflow)
4. Only one menu can be open at a time
5. Menus close on outside click and Escape
6. Open/close state and toggle state persisted in sessionStorage

This change introduces a structured, extensible UI for future map and developer tools without implementing feature logic yet. This PR is UI-only by design. No map behavior or debug logic is implemented yet. Structure is intended to support future features incrementally.
