### PR TITLE
Extract shared CSV feature helpers

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,10 +7,9 @@ import { useTimelineFilterState } from "./components/useTimelineFilterState";
 import {
   autoDetectRangeFields,
   autoDetectTimelineFields,
-  parseDateValue,
-  parseYearValue,
   tryGetYear,
 } from "./components/timeline";
+import { getRangeYear } from "./components/csvFeatureValueHelpers";
 import { useMapToolsState } from "./components/useMapToolsState";
 import { useDerivedMapFeatures } from "./components/useDerivedMapFeatures";
 import { CsvPanelOverlay } from "./components/CsvPanelOverlay";
@@ -237,24 +236,4 @@ function getRowTimelineExtent(row, timelineFields, rangeFields) {
   if (year == null) return null;
 
   return { min: year, max: year };
-}
-
-/**
- * Extract a year value from either a numeric year field or a date field.
- * Returns null when no usable value is present.
- */
-function getRangeYear(row, yearField, dateField) {
-  if (!row || typeof row !== "object") return null;
-
-  if (yearField) {
-    const y = parseYearValue(row[yearField]);
-    if (y != null) return y;
-  }
-
-  if (dateField) {
-    const d = parseDateValue(row[dateField]);
-    if (d) return d.getUTCFullYear();
-  }
-
-  return null;
 }

--- a/src/components/csvFeatureValueHelpers.js
+++ b/src/components/csvFeatureValueHelpers.js
@@ -1,0 +1,44 @@
+import { parseDateValue, parseYearValue } from "./timeline";
+
+/**
+ * Extract a year value from either a numeric year field or a date field.
+ * Returns null when no usable value is present.
+ */
+export function getRangeYear(row, yearField, dateField) {
+  if (!row || typeof row !== "object") return null;
+
+  if (yearField) {
+    const y = parseYearValue(row[yearField]);
+    if (y != null) return y;
+  }
+
+  if (dateField) {
+    const d = parseDateValue(row[dateField]);
+    if (d) return d.getUTCFullYear();
+  }
+
+  return null;
+}
+
+/**
+ * Parse an order value. Return null so callers can fall back to row order.
+ */
+export function parseOrderValue(value) {
+  const n = Number.parseFloat(String(value ?? "").trim());
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * Set a style value only once, using the first non-empty row value that can be parsed.
+ */
+export function applyFirstNonEmpty(target, key, value, parser) {
+  if (target[key] != null && target[key] !== "") return;
+
+  const raw = String(value ?? "").trim();
+  if (!raw) return;
+
+  const parsed = parser ? parser(raw) : raw;
+  if (parsed == null || parsed === "") return;
+
+  target[key] = parsed;
+}

--- a/src/components/deriveLines.js
+++ b/src/components/deriveLines.js
@@ -1,6 +1,7 @@
 import { isValidLat, isValidLon, parseFlexibleFloat } from "./geoColumns";
 import { getRowFeatureType } from "./featureTypes";
 import { isRowVisibleForTimeline } from "./timelineVisibility";
+import { applyFirstNonEmpty, parseOrderValue } from "./csvFeatureValueHelpers";
 
 const DEFAULT_LINE_STYLE = {
   color: "#3388ff",
@@ -142,11 +143,6 @@ export function deriveLinesFromCsv({
   return { lines, skipped, skippedByTimeline, reason: null };
 }
 
-function parseOrderValue(value) {
-  const n = Number.parseFloat(String(value ?? "").trim());
-  return Number.isFinite(n) ? n : null;
-}
-
 function getOrderKey(item) {
   return item.orderValue ?? item.index;
 }
@@ -172,18 +168,6 @@ function resolveArrowMode(rows) {
   }
 
   return "none";
-}
-
-function applyFirstNonEmpty(target, key, value, parser) {
-  if (target[key] != null && target[key] !== "") return;
-
-  const raw = String(value ?? "").trim();
-  if (!raw) return;
-
-  const parsed = parser ? parser(raw) : raw;
-  if (parsed == null || parsed === "") return;
-
-  target[key] = parsed;
 }
 
 function parseWeight(value) {

--- a/src/components/deriveRegions.js
+++ b/src/components/deriveRegions.js
@@ -1,6 +1,7 @@
 import { isValidLat, isValidLon, parseFlexibleFloat } from "./geoColumns";
 import { getRowFeatureType } from "./featureTypes";
 import { isRowVisibleForTimeline } from "./timelineVisibility";
+import { applyFirstNonEmpty, parseOrderValue } from "./csvFeatureValueHelpers";
 
 const DEFAULT_STYLE = {
   color: "#3388ff",
@@ -185,11 +186,6 @@ export function deriveRegionsFromCsv({
   return { polygons, skipped, skippedByTimeline, reason: null };
 }
 
-function parseOrderValue(value) {
-  const n = Number.parseFloat(String(value ?? "").trim());
-  return Number.isFinite(n) ? n : null;
-}
-
 function getOrderKey(item) {
   return item.orderValue ?? item.index;
 }
@@ -226,18 +222,6 @@ function resolveStyle(rows) {
   }
 
   return resolved;
-}
-
-function applyFirstNonEmpty(target, key, value, parser) {
-  if (target[key] != null && target[key] !== "") return;
-
-  const raw = String(value ?? "").trim();
-  if (!raw) return;
-
-  const parsed = parser ? parser(raw) : raw;
-  if (parsed == null || parsed === "") return;
-
-  target[key] = parsed;
 }
 
 function parseNumber(value) {

--- a/src/components/timelineVisibility.js
+++ b/src/components/timelineVisibility.js
@@ -1,4 +1,5 @@
-import { parseDateValue, parseYearValue, tryGetYear, tryParseDayOfYear } from "./timeline";
+import { tryGetYear, tryParseDayOfYear } from "./timeline";
+import { getRangeYear } from "./csvFeatureValueHelpers";
 
 export function isRowVisibleForTimeline({
   row,
@@ -57,20 +58,4 @@ export function isRowVisibleForTimeline({
   }
 
   return true;
-}
-
-export function getRangeYear(row, yearField, dateField) {
-  if (!row || typeof row !== "object") return null;
-
-  if (yearField) {
-    const y = parseYearValue(row[yearField]);
-    if (y != null) return y;
-  }
-
-  if (dateField) {
-    const d = parseDateValue(row[dateField]);
-    if (d) return d.getUTCFullYear();
-  }
-
-  return null;
 }


### PR DESCRIPTION
## Summary
- Extract shared CSV feature value helpers into `csvFeatureValueHelpers.js`.
- Reuse `getRangeYear` from `App.jsx` and `timelineVisibility.js`.
- Reuse `parseOrderValue` and `applyFirstNonEmpty` from line and region derivation.

## Testing
- `npm run lint`
- `npm run build`
- Manual smoke test for point, line, region, and timeline behavior.

Closes #68