### PR TITLE
Parse uploaded CSV files with worker chunks

### DIFF
--- a/src/components/csvParse.js
+++ b/src/components/csvParse.js
@@ -13,6 +13,19 @@ const MAX_PREVIEW_ROWS = 25;
 const MAX_ERRORS = 200;
 
 /**
+ * Size of each uploaded file chunk PapaParse reads at a time.
+ * Keeping this explicit makes import tuning easier later.
+ */
+const CSV_UPLOAD_CHUNK_SIZE_BYTES = 1 * 1024 * 1024; // 1 MB
+
+/**
+ * Temporary safety cap for likely mobile/small-device large imports.
+ * Full mobile optimization belongs in #60.
+ */
+const MOBILE_ROW_CAP = 500;
+const MOBILE_LARGE_FILE_BYTES = 1 * 1024 * 1024;
+
+/**
  * Parse a CSV file in a tolerant way.
  * - Uses what works
  * - Skips broken rows
@@ -22,46 +35,44 @@ const MAX_ERRORS = 200;
  * @returns {Promise<object>} Parsed CSV result
  */
 export async function parseCsvFile(file) {
-  // Read file as plain text (client-side only)
-  const text = await file.text();
+  return new Promise((resolve) => {
+    const state = createChunkParserState({
+      rowCap: shouldApplyMobileRowCap(file) ? MOBILE_ROW_CAP : null,
+    });
 
-  // Delegate to the shared string parser so we can also parse fetched examples.
-  return parseCsvText(text);
+    Papa.parse(file, {
+      delimiter: "", // auto-detect delimiter
+      skipEmptyLines: true,
+      quoteChar: '"',
+      escapeChar: '"',
+      worker: true,
+      chunkSize: CSV_UPLOAD_CHUNK_SIZE_BYTES,
+      chunk: (result) => {
+        processParsedChunk(state, result);
+      },
+      complete: () => {
+        resolve(finalizeChunkedCsvResult(state));
+      },
+      error: (error) => {
+        resolve(createParseFailureResult(error));
+      },
+    });
+  });
 }
 
 /**
  * Parse CSV content from a string.
- * Used for:
- * - normal file uploads (File.text())
- * - loading example CSVs via fetch() from /public/examples
+ * Used for loading example CSVs via fetch() from /public/examples.
  *
  * @param {string} text - raw CSV text
  * @returns {object} Parsed CSV result
  */
 export function parseCsvText(text) {
-  /**
-   * Clean input before parsing:
-   * - Split into lines
-   * - Trim whitespace
-   * - Remove empty lines
-   *
-   * This avoids many common CSV problems early.
-   */
-  const cleaned = String(text ?? "")
-    .split(/\r\n|\n|\r/)
-    .map((l) => l.trim())
-    .filter((l) => l.length > 0)
-    .join("\n");
+  const cleaned = prepareCsvText(text);
 
   // If nothing remains after cleaning, file is empty
   if (!cleaned) {
-    return {
-      headers: [],
-      rows: [],
-      previewRows: [],
-      totalRows: 0,
-      parseErrors: ["File is empty (or only blank lines)."],
-    };
+    return createEmptyResult(["File is empty (or only blank lines)."]);
   }
 
   // Collect human-readable warnings and errors
@@ -73,45 +84,190 @@ export function parseCsvText(text) {
    * - We want full control over broken rows
    * - We want to allow truncation and repair
    */
-  const result = Papa.parse(cleaned, {
+  const result = parseTextToArrays(cleaned);
+
+  // Convert PapaParse errors into user-friendly messages
+  collectParserErrors(parseErrors, result.errors);
+
+  // Ensure parsed data is an array
+  const data = Array.isArray(result.data) ? result.data : [];
+  if (data.length === 0) {
+    return createEmptyResult([...parseErrors, "No rows detected."]);
+  }
+
+  return buildParsedCsvResult(data, parseErrors);
+}
+
+/**
+ * Clean input before parsing:
+ * - Split into lines
+ * - Trim whitespace
+ * - Remove empty lines
+ *
+ * This avoids many common CSV problems early.
+ */
+function prepareCsvText(text) {
+  return String(text ?? "")
+    .split(/\r\n|\n|\r/)
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0)
+    .join("\n");
+}
+
+/**
+ * Parse cleaned CSV text into arrays.
+ * This path is used by example CSV files, not uploaded files.
+ */
+function parseTextToArrays(text) {
+  return Papa.parse(text, {
     delimiter: "", // auto-detect delimiter
     skipEmptyLines: true,
     quoteChar: '"',
     escapeChar: '"',
   });
+}
 
-  // Convert PapaParse errors into user-friendly messages
-  if (result.errors?.length) {
-    for (const e of result.errors.slice(0, MAX_ERRORS)) {
-      parseErrors.push(`Parser: ${e.message} (row ${e.row ?? "?"})`);
-    }
+/**
+ * Add PapaParse errors to our user-facing warning list.
+ * The list is capped so a broken file cannot flood the UI.
+ */
+function collectParserErrors(parseErrors, errors) {
+  if (!errors?.length) return;
+
+  for (const e of errors.slice(0, MAX_ERRORS)) {
+    pushErr(parseErrors, `Parser: ${e.message} (row ${e.row ?? "?"})`);
   }
+}
 
-  // Ensure parsed data is an array
+/**
+ * Create the shared state used while PapaParse sends file chunks.
+ * This keeps upload parsing incremental without changing React state per row.
+ */
+function createChunkParserState({ rowCap = null } = {}) {
+  return {
+    headers: null,
+    rows: [],
+    parseErrors: [],
+    skipped: 0,
+    parsedRowCount: 0,
+    usableRowCount: 0,
+    sawParsedRows: false,
+    rowCap,
+  };
+}
+
+/**
+ * Process one parsed file chunk.
+ * Each chunk may contain parser errors and many CSV rows.
+ */
+function processParsedChunk(state, result) {
+  collectParserErrors(state.parseErrors, result.errors);
+
   const data = Array.isArray(result.data) ? result.data : [];
-  if (data.length === 0) {
-    return {
-      headers: [],
-      rows: [],
-      previewRows: [],
-      totalRows: 0,
-      parseErrors: [...parseErrors, "No rows detected."],
-    };
+  for (const rowArr of data) {
+    state.sawParsedRows = true;
+    state.parsedRowCount += 1;
+    processParsedChunkRow(state, rowArr, state.parsedRowCount);
+  }
+}
+
+/**
+ * Process one parsed CSV row from an uploaded file.
+ * The first non-empty row becomes the header; later rows become data objects.
+ */
+function processParsedChunkRow(state, rowArr, lineNumber) {
+  if (!Array.isArray(rowArr)) {
+    if (state.headers) {
+      state.skipped++;
+      pushErr(state.parseErrors, `Skipped non-row at line ${lineNumber}.`);
+    }
+    return;
   }
 
+  if (isEmptyRow(rowArr)) {
+    return;
+  }
+
+  // The first non-empty row in the upload becomes the header row.
+  if (!state.headers) {
+    const rawHeaders = rowArr.map((h) => String(h ?? "").trim());
+    const headers = normalizeHeaders(rawHeaders);
+
+    if (headers.length === 0) {
+      pushErr(state.parseErrors, "Header row is empty.");
+      return;
+    }
+
+    state.headers = headers;
+    return;
+  }
+
+  if (rowArr.length > state.headers.length) {
+    pushErr(
+      state.parseErrors,
+      `Line ${lineNumber}: had ${rowArr.length} values; truncated to ${state.headers.length}.`
+    );
+  }
+
+  // Count every usable data row, even if mobile safety stops storing later rows.
+  state.usableRowCount += 1;
+
+  // rows is what the preview and map use, so cap only this stored array.
+  if (state.rowCap == null || state.rows.length < state.rowCap) {
+    state.rows.push(rowArrayToObject(rowArr, state.headers));
+  }
+}
+
+/**
+ * Build the final parsed result after all file chunks have finished.
+ * This keeps the same result shape used by the rest of the app.
+ */
+function finalizeChunkedCsvResult(state) {
+  if (!state.sawParsedRows) {
+    return createEmptyResult([...state.parseErrors, "No rows detected."]);
+  }
+
+  if (!state.headers) {
+    return createEmptyResult([...state.parseErrors, "No header row detected."]);
+  }
+
+  if (state.usableRowCount === 0) {
+    pushErr(state.parseErrors, "No usable data rows were parsed.");
+  }
+
+  if (state.skipped > 0) {
+    pushErr(state.parseErrors, `Skipped ${state.skipped} malformed row(s).`);
+  }
+
+  // Show the cap as a normal parse warning instead of interrupting the user.
+  if (state.rowCap != null && state.usableRowCount > state.rows.length) {
+    pushErr(
+      state.parseErrors,
+      `Mobile safety: this large CSV was limited to the first ${state.rowCap} usable rows on this device. Use a desktop browser for the full dataset.`
+    );
+  }
+
+  // totalRows reports all usable rows, even when rows is capped.
+  return createParsedResult(
+    state.headers,
+    state.rows,
+    state.parseErrors,
+    state.usableRowCount
+  );
+}
+
+/**
+ * Build a parsed result from already-loaded CSV array data.
+ * This is the string/example CSV path, so it keeps the old behavior.
+ */
+function buildParsedCsvResult(data, parseErrors) {
   /**
    * Find the first non-empty row.
    * This row is treated as the header row.
    */
   const headerRow = firstNonEmptyArrayRow(data);
   if (!headerRow) {
-    return {
-      headers: [],
-      rows: [],
-      previewRows: [],
-      totalRows: 0,
-      parseErrors: [...parseErrors, "No header row detected."],
-    };
+    return createEmptyResult([...parseErrors, "No header row detected."]);
   }
 
   // Normalize header names (trim, remove empty, ensure uniqueness)
@@ -119,19 +275,11 @@ export function parseCsvText(text) {
   const headers = normalizeHeaders(rawHeaders);
 
   if (headers.length === 0) {
-    return {
-      headers: [],
-      rows: [],
-      previewRows: [],
-      totalRows: 0,
-      parseErrors: [...parseErrors, "Header row is empty."],
-    };
+    return createEmptyResult([...parseErrors, "Header row is empty."]);
   }
 
   // All rows after the header are treated as data rows
   const headerIndex = data.indexOf(headerRow);
-  const body = data.slice(headerIndex + 1);
-
   const rows = [];
   let skipped = 0;
 
@@ -142,42 +290,31 @@ export function parseCsvText(text) {
    * - Truncate extra columns
    * - Fill missing values with empty strings
    */
-  for (let i = 0; i < body.length; i++) {
-    const rowArr = body[i];
+  for (let i = headerIndex + 1; i < data.length; i++) {
+    const rowArr = data[i];
+    const lineNumber = i + 1;
 
     // Skip rows that are not arrays
     if (!Array.isArray(rowArr)) {
       skipped++;
-      pushErr(parseErrors, `Skipped non-row at line ${headerIndex + 2 + i}.`);
+      pushErr(parseErrors, `Skipped non-row at line ${lineNumber}.`);
       continue;
     }
 
     // Skip fully empty rows
-    if (rowArr.every((v) => String(v ?? "").trim() === "")) {
+    if (isEmptyRow(rowArr)) {
       continue;
-    }
-
-    // Normalize row length to match header length
-    const normalizedValues = [];
-    for (let c = 0; c < headers.length; c++) {
-      normalizedValues[c] = String(rowArr[c] ?? "").trim();
     }
 
     // Warn if row had too many values
     if (rowArr.length > headers.length) {
       pushErr(
         parseErrors,
-        `Line ${headerIndex + 2 + i}: had ${rowArr.length} values; truncated to ${headers.length}.`
+        `Line ${lineNumber}: had ${rowArr.length} values; truncated to ${headers.length}.`
       );
     }
 
-    // Convert array row into object using headers as keys
-    const obj = {};
-    for (let c = 0; c < headers.length; c++) {
-      obj[headers[c]] = normalizedValues[c];
-    }
-
-    rows.push(obj);
+    rows.push(rowArrayToObject(rowArr, headers));
   }
 
   // If no usable rows were parsed, report it
@@ -190,14 +327,55 @@ export function parseCsvText(text) {
     pushErr(parseErrors, `Skipped ${skipped} malformed row(s).`);
   }
 
-  // Final parsed result
+  return createParsedResult(headers, rows, parseErrors);
+}
+
+/**
+ * Create the object shape that the CSV panel and map already expect.
+ * totalRows can be larger than rows.length when mobile safety caps stored rows.
+ */
+function createParsedResult(headers, rows, parseErrors, totalRows = rows.length) {
   return {
     headers,
     rows,
     previewRows: rows.slice(0, MAX_PREVIEW_ROWS),
-    totalRows: rows.length,
+    totalRows,
     parseErrors,
   };
+}
+
+/**
+ * Create an empty parse result with one or more user-facing warnings.
+ */
+function createEmptyResult(parseErrors) {
+  return createParsedResult([], [], parseErrors);
+}
+
+/**
+ * Convert a hard parser failure into the normal parsed result shape.
+ * This lets the UI show an error without crashing the import flow.
+ */
+function createParseFailureResult(error) {
+  const message = error?.message ? String(error.message) : "Unknown parser error.";
+  return createEmptyResult([`Parser: ${message}`]);
+}
+
+/**
+ * Decide whether this large upload should use the temporary mobile row cap.
+ * The check is conservative and only protects likely small/mobile devices.
+ */
+function shouldApplyMobileRowCap(file) {
+  if (!file || Number(file.size) < MOBILE_LARGE_FILE_BYTES) return false;
+
+  const nav = globalThis.navigator;
+  const screen = globalThis.screen;
+  const hasCoarsePointer =
+    typeof globalThis.matchMedia === "function" &&
+    globalThis.matchMedia("(pointer: coarse)").matches;
+  const narrowScreen = Number(screen?.width) > 0 && screen.width <= 900;
+  const lowMemory = Number(nav?.deviceMemory) > 0 && nav.deviceMemory <= 4;
+
+  return hasCoarsePointer || narrowScreen || lowMemory;
 }
 
 /**
@@ -208,10 +386,30 @@ export function parseCsvText(text) {
 function firstNonEmptyArrayRow(data) {
   for (const row of data) {
     if (!Array.isArray(row)) continue;
-    const any = row.some((v) => String(v ?? "").trim() !== "");
-    if (any) return row;
+    if (!isEmptyRow(row)) return row;
   }
   return null;
+}
+
+/**
+ * True when every cell in a parsed row is blank after trimming.
+ */
+function isEmptyRow(row) {
+  return row.every((v) => String(v ?? "").trim() === "");
+}
+
+/**
+ * Convert one parsed row into an object using normalized headers.
+ * Missing cells become empty strings; extra cells are ignored after warning.
+ */
+function rowArrayToObject(rowArr, headers) {
+  const obj = {};
+
+  for (let c = 0; c < headers.length; c++) {
+    obj[headers[c]] = String(rowArr[c] ?? "").trim();
+  }
+
+  return obj;
 }
 
 /**
@@ -221,7 +419,7 @@ function firstNonEmptyArrayRow(data) {
  * - Ensure uniqueness
  *
  * Example:
- * ["lat", "lon", "lat"] → ["lat", "lon", "lat_2"]
+ * ["lat", "lon", "lat"] -> ["lat", "lon", "lat_2"]
  */
 function normalizeHeaders(raw) {
   const seen = new Map();
@@ -249,5 +447,3 @@ function pushErr(list, msg) {
     list.push(msg);
   }
 }
-
-


### PR DESCRIPTION
## Summary

- Parse uploaded CSV files directly with PapaParse `File` input instead of `file.text()`
- Enable PapaParse worker mode and 1 MB chunk parsing for uploaded files
- Preserve the existing parsed CSV result shape for headers, rows, preview rows, row counts, and parse warnings
- Add a temporary mobile/small-device safety cap with a user-visible parse warning

## Notes

Example CSV loading still uses the existing `parseCsvText` path. This PR stays focused on the CSV import layer and does not change marker rendering, viewport behavior, or derived map feature logic.

Closes #70

## Verification

- `npm run lint`
- `npm run build`
- Smoke-tested CSV upload and example CSV loading