### PR TITLE
Improve marker clustering for large point datasets

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from "react";
+import React, { useCallback, useEffect, useMemo } from "react";
 import "./App.css";
 import GeoMap from "./components/GeoMap";
 import CsvPanel from "./components/CsvPanel";
@@ -16,6 +16,8 @@ import { CsvPanelOverlay } from "./components/CsvPanelOverlay";
 import { useCsvFileDrop } from "./components/useCsvFileDrop";
 import { useExampleCsvFilesFromUrl } from "./components/useExampleCsvFilesFromUrl";
 import { useTimelinePlayback } from "./components/useTimelinePlayback";
+
+const LARGE_RAW_MARKER_WARNING_THRESHOLD = 3000;
 
 export default function App() {
   /**
@@ -68,6 +70,33 @@ export default function App() {
 
   const selectedHeaders = selected?.headers;
   const selectedRows = selected?.rows;
+  const visibleMarkerPointCount = useMemo(
+    () => derivedMapFeatures.points.points.filter((point) => !point.image).length,
+    [derivedMapFeatures.points.points],
+  );
+
+  // Warn before disabling clustering when raw marker rendering is likely to be expensive.
+  const patchMapToolsWithSafeguards = useCallback((partial) => {
+    const disablingClusterMarkers =
+      partial?.clusterMarkersEnabled === false &&
+      !!mapToolsApi.state.clusterMarkersEnabled;
+
+    if (
+      disablingClusterMarkers &&
+      visibleMarkerPointCount > LARGE_RAW_MARKER_WARNING_THRESHOLD
+    ) {
+      const confirmed = window.confirm(
+        `This will render ${visibleMarkerPointCount.toLocaleString()} individual markers and may slow down the browser. Continue?`,
+      );
+
+      if (!confirmed) return;
+    }
+
+    mapToolsApi.patch(partial);
+  }, [
+    mapToolsApi,
+    visibleMarkerPointCount,
+  ]);
 
   const timelineFields = useMemo(() => {
     if (!selectedHeaders) {
@@ -190,7 +219,7 @@ export default function App() {
                 (derivedMapFeatures.lines.skippedByTimeline ?? 0),
             }}
             mapToolsState={mapToolsApi.state}
-            onMapToolsPatch={mapToolsApi.patch}
+            onMapToolsPatch={patchMapToolsWithSafeguards}
           />
         </CsvPanelOverlay>
       </div>

--- a/src/components/GeoMap.jsx
+++ b/src/components/GeoMap.jsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 // Import core components from react-leaflet.
 // MapContainer is the main map wrapper.
 // TileLayer is used to load map tiles (images).
@@ -24,7 +24,7 @@ import MarkerClusterGroup from "react-leaflet-cluster";
 import L from "leaflet";
 import "leaflet-polylinedecorator";
 
-import { getMarkerIcon } from "./markerIcons";
+import { getClusterMarkerIcon, getMarkerIcon } from "./markerIcons";
 
 /**
  * Build a list of fields to show in the popup.
@@ -76,6 +76,47 @@ function renderPointPopup(p, latField, lonField) {
       </div>
     </Popup>
   );
+}
+
+/**
+ * Attach the CSV marker value to the Leaflet marker instance.
+ * MarkerClusterGroup only sees Leaflet markers, so the cluster icon code reads this later.
+ */
+function setCsvMarkerValue(marker, markerValue) {
+  if (marker) {
+    marker.options.csvMarkerValue = markerValue;
+  }
+}
+
+/**
+ * Build a custom cluster icon from the first marker in the cluster.
+ * This preserves the first row marker style and adds the cluster count badge.
+ */
+function createMarkerClusterIcon(cluster) {
+  const childMarkers = typeof cluster?.getAllChildMarkers === "function"
+    ? cluster.getAllChildMarkers()
+    : [];
+  const firstMarkerValue = childMarkers[0]?.options?.csvMarkerValue;
+  const count = typeof cluster?.getChildCount === "function"
+    ? cluster.getChildCount()
+    : childMarkers.length;
+
+  return getClusterMarkerIcon(firstMarkerValue, count);
+}
+
+/**
+ * Hide the original cluster icon while spiderfied markers are spread out.
+ * The spread markers remain visible; the center marker would just add visual noise.
+ */
+function setClusterIconVisibility(cluster, isVisible) {
+  const iconElement =
+    typeof cluster?.getElement === "function"
+      ? cluster.getElement()
+      : cluster?._icon;
+
+  if (iconElement) {
+    iconElement.style.visibility = isVisible ? "" : "hidden";
+  }
 }
 
 function renderRegionPopup(region, latField, lonField) {
@@ -239,8 +280,31 @@ export default function GeoMap({
   clusterRadius = 80,   // default strength
 }) {
   const { BaseLayer, Overlay } = LayersControl;
+  const markerClusterGroupRef = useRef(null);
   const markerPoints = points.filter((p) => !p.image);
   const imagePoints = points.filter((p) => !!p.image);
+
+  // Hide the original cluster icon while MarkerClusterGroup spiderfies exact-overlap markers.
+  useEffect(() => {
+    const group = markerClusterGroupRef.current;
+    if (!group) return undefined;
+
+    const handleSpiderfied = (event) => {
+      setClusterIconVisibility(event?.cluster, false);
+    };
+
+    const handleUnspiderfied = (event) => {
+      setClusterIconVisibility(event?.cluster, true);
+    };
+
+    group.on("spiderfied", handleSpiderfied);
+    group.on("unspiderfied", handleUnspiderfied);
+
+    return () => {
+      group.off("spiderfied", handleSpiderfied);
+      group.off("unspiderfied", handleUnspiderfied);
+    };
+  }, [clusterMarkersEnabled, clusterRadius]);
 
   return (
     // MapContainer must have a fixed height and width.
@@ -317,12 +381,14 @@ export default function GeoMap({
       */}
       {clusterMarkersEnabled ? (
         <MarkerClusterGroup
+          ref={markerClusterGroupRef}
           // Force a re-init when clustering settings change.
           // Leaflet.markercluster does not always apply maxClusterRadius updates dynamically.
           key={`cluster:${clusterMarkersEnabled ? 1 : 0}:${clusterRadius}`}
           // chunkedLoading improves responsiveness when there are many markers.
           // It progressively adds markers to the map instead of blocking the UI.
           chunkedLoading
+          iconCreateFunction={createMarkerClusterIcon}
           maxClusterRadius={clusterRadius}
         >
           {markerPoints.map((p) => {
@@ -331,6 +397,7 @@ export default function GeoMap({
             return (
               <Marker
                 key={p.id}
+                ref={(marker) => setCsvMarkerValue(marker, p.marker)}
                 position={[p.lat, p.lon]}
                 {...(icon ? { icon } : {})}
               >

--- a/src/components/markerIcons.js
+++ b/src/components/markerIcons.js
@@ -4,8 +4,10 @@ const IMAGE_EXTENSION_RE = /\.(png|jpe?g|svg|webp|gif)$/i;
 const DEFAULT_IMAGE_SIZE = [32, 32];
 const DEFAULT_IMAGE_ANCHOR = [16, 32];
 const DEFAULT_TEXT_ANCHOR = [0, 16];
+const DEFAULT_GROUPED_ANCHOR = [16, 16];
 
 const iconCache = new Map();
+const clusterIconCache = new Map();
 const DEFAULT_LEAFLET_ICON = new L.Icon.Default();
 
 function isImageMarkerValue(value) {
@@ -30,6 +32,10 @@ function escapeHtml(value) {
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;");
+}
+
+function escapeAttribute(value) {
+  return escapeHtml(value).replace(/"/g, "&quot;");
 }
 
 function createTextMarkerIcon(value) {
@@ -79,6 +85,52 @@ function createImageMarkerIcon(value) {
 }
 
 /**
+ * Create the Leaflet divIcon used for marker clusters.
+ * It shows the chosen marker style plus a compact count badge.
+ */
+function createClusterMarkerIcon(markerValue, count) {
+  const normalized = String(markerValue ?? "").trim();
+  const safeCount = formatGroupedPointCount(count);
+  const bodyHtml = createClusterMarkerBodyHtml(normalized);
+
+  return L.divIcon({
+    className: "csv-marker-group-icon",
+    html: `<span class="csv-marker-group">${bodyHtml}<span class="csv-marker-group-count">${safeCount}</span></span>`,
+    iconSize: [32, 32],
+    iconAnchor: DEFAULT_GROUPED_ANCHOR,
+    popupAnchor: [0, -16],
+  });
+}
+
+/**
+ * Render the visual body of a cluster icon.
+ * Empty marker values get a neutral badge body; image/text markers keep their style.
+ */
+function createClusterMarkerBodyHtml(normalized) {
+  if (!normalized) {
+    return `<span class="csv-marker-group-body csv-marker-group-body-neutral"></span>`;
+  }
+
+  if (isImageMarkerValue(normalized)) {
+    return `<span class="csv-marker-group-body"><img class="csv-marker-group-image" src="${escapeAttribute(resolveImageUrl(normalized))}" alt="" /></span>`;
+  }
+
+  return `<span class="csv-marker-group-body">${escapeHtml(normalized)}</span>`;
+}
+
+/**
+ * Keep cluster counts compact enough to fit inside the small badge.
+ */
+function formatGroupedPointCount(count) {
+  const parsed = Number(count);
+
+  if (!Number.isFinite(parsed) || parsed < 1) return "1";
+  if (parsed > 9999) return "9999+";
+
+  return String(Math.floor(parsed));
+}
+
+/**
  * Create icon for marker value.
  * Returns null to use Leaflet default marker.
  */
@@ -97,6 +149,28 @@ export function getMarkerIcon(markerValue) {
       : createTextMarkerIcon(normalized);
 
     iconCache.set(normalized, icon);
+    return icon;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Public cluster icon factory used by GeoMap.
+ * Icons are cached by marker value and count to avoid rebuilding divIcons repeatedly.
+ */
+export function getClusterMarkerIcon(markerValue, count) {
+  try {
+    const normalized = String(markerValue ?? "").trim();
+    const safeCount = formatGroupedPointCount(count);
+    const cacheKey = `${normalized}:${safeCount}`;
+
+    if (clusterIconCache.has(cacheKey)) {
+      return clusterIconCache.get(cacheKey);
+    }
+
+    const icon = createClusterMarkerIcon(normalized, safeCount);
+    clusterIconCache.set(cacheKey, icon);
     return icon;
   } catch {
     return null;

--- a/src/components/useMapToolsState.js
+++ b/src/components/useMapToolsState.js
@@ -2,18 +2,9 @@ import { useMemo, useState } from "react";
 
 const DEFAULT_CLUSTER_RADIUS = 80;
 
-function getInitialStateFromUrl() {
-  const params = new URLSearchParams(window.location.search);
-  const exampleValues = params.getAll("example");
-
-  // Only enable clustering by default when example is present AND looks like a CSV filename.
-  const hasValidExample = exampleValues.some((value) => {
-    const trimmed = String(value ?? "").trim();
-    return /^[a-zA-Z0-9._-]+\.csv$/.test(trimmed);
-  });
-
+function getInitialState() {
   return {
-    clusterMarkersEnabled: hasValidExample, // true only for ?example=valid.csv
+    clusterMarkersEnabled: true,
     clusterRadius: DEFAULT_CLUSTER_RADIUS,
     clusterRadiusDraft: DEFAULT_CLUSTER_RADIUS,
   };
@@ -21,7 +12,7 @@ function getInitialStateFromUrl() {
 
 export function useMapToolsState() {
   // Initialize ONCE on first render (no persistence)
-  const initial = useMemo(() => getInitialStateFromUrl(), []);
+  const initial = useMemo(() => getInitialState(), []);
   const [state, setState] = useState(initial);
 
   function patch(partial) {
@@ -30,4 +21,3 @@ export function useMapToolsState() {
 
   return { state, patch };
 }
-

--- a/src/index.css
+++ b/src/index.css
@@ -35,3 +35,62 @@ body {
   /* Shift marker left by half its width to keep it centered on map point */
   transform: translateX(-50%);
 }
+
+/* Cluster icons reuse the marker body and add a count badge. */
+.csv-marker-group {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+}
+
+/* Body can be text, emoji, an image marker, or a neutral fallback. */
+.csv-marker-group-body {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 28px;
+  height: 28px;
+  padding: 0 3px;
+  font-size: 20px;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+/* Keep image-based marker values inside the same cluster icon footprint. */
+.csv-marker-group-image {
+  width: 28px;
+  height: 28px;
+  object-fit: contain;
+}
+
+/* Used when the first marker in a cluster has no marker value. */
+.csv-marker-group-body-neutral {
+  width: 28px;
+  min-width: 28px;
+  border: 2px solid #ffffff;
+  border-radius: 999px;
+  background: #334155;
+  box-shadow: 0 1px 4px rgba(15, 23, 42, 0.35);
+}
+
+/* Small count bubble layered over the chosen marker style. */
+.csv-marker-group-count {
+  position: absolute;
+  right: -7px;
+  top: -7px;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 4px;
+  border: 2px solid #ffffff;
+  border-radius: 999px;
+  background: #ef4444;
+  color: #ffffff;
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 14px;
+  text-align: center;
+  box-shadow: 0 1px 4px rgba(15, 23, 42, 0.35);
+}


### PR DESCRIPTION
## Summary

- Customize Leaflet marker cluster icons so grouped CSV markers keep the first marker style when possible
- Show count badges on custom emoji/text/image cluster markers
- Hide the original center cluster marker while exact-overlap markers are spiderfied
- Enable marker clustering by default
- Add a safeguard warning before disabling clustering when many raw markers would be rendered

## Notes

The first approach considered a custom zoom-aware marker budget / viewport query layer, but that overlapped heavily with what Leaflet marker clustering already provides. This PR keeps the #71 work on the existing clustering path and customizes the cluster rendering behavior instead.

Truly huge dataset querying/rendering should stay in the later indexed data source work.

## Testing

- `npm run lint`
- `npm run build`
- Manual smoke test with clustered markers, exact-coordinate spiderfy, and disabling clustering safeguard

Closes #71
