### PR TITLE
Define backend-neutral DataSource interface

### DIFF
--- a/src/components/useDerivedMapFeatures.js
+++ b/src/components/useDerivedMapFeatures.js
@@ -1,110 +1,43 @@
 import { useMemo } from "react";
-import { deriveLinesFromCsv } from "./deriveLines";
-import { derivePointsFromCsv } from "./derivePoints";
-import { deriveRegionsFromCsv } from "./deriveRegions";
-import { detectFeatureTypeField } from "./featureTypes";
-import { autoDetectRangeFields, autoDetectTimelineFields } from "./timeline";
-import { buildTimelineIndex, getVisibleTimelineFeatureIds } from "./timelineIndex";
+import { createInMemoryDataSource } from "../data/inMemoryDataSource";
 
+/**
+ * Bridge hook for the current React UI.
+ * Internally queries the in-memory DataSource, but preserves the old return
+ * shape expected by App/GeoMap until those components are migrated.
+ */
 export function useDerivedMapFeatures({ files, timeline }) {
   return useMemo(() => {
-    const points = { items: [], skipped: 0 };
-    const lines = { items: [], skipped: 0 };
-    const regions = { items: [], skipped: 0 };
-    const timelineIndex = { entries: [] };
-    const enabledFiles = files.filter((item) => item.enabled);
-    const sourceRowsByFileId = new Map(
-      enabledFiles.map((file) => [file.id, file.rows ?? []]),
-    );
+    const dataSource = createInMemoryDataSource({ files });
+    const mapView = dataSource.queryMapView({ timeline });
 
     const getSourceRow = (sourceFileId, sourceRowIndex) => (
-      sourceRowsByFileId.get(sourceFileId)?.[sourceRowIndex] ?? null
+      dataSource.getFeatureDetails({
+        sourceRef: {
+          datasetId: sourceFileId,
+          rowIndex: sourceRowIndex,
+        },
+      }).row
     );
-
-    // Merge derived map features from all enabled CSV files into one map-ready result.
-    for (const file of enabledFiles) {
-      const timelineFields = autoDetectTimelineFields(file.headers ?? []);
-      const rangeFields = autoDetectRangeFields(file.headers ?? []);
-      const featureTypeField = detectFeatureTypeField(file.headers ?? []);
-
-      const commonArgs = {
-        rows: file.rows,
-        latField: file.latField,
-        lonField: file.lonField,
-        featureTypeField,
-        idPrefix: file.id,
-      };
-
-      const pointResult = derivePointsFromCsv(commonArgs);
-      const pointFeatures = pointResult.points.map((point) => ({
-        ...point,
-        sourceFileId: file.id,
-        latField: file.latField,
-        lonField: file.lonField,
-      }));
-      points.items.push(...pointFeatures);
-      points.skipped += pointResult.skipped;
-
-      const lineResult = deriveLinesFromCsv(commonArgs);
-      const lineFeatures = lineResult.lines.map((line) => ({
-        ...line,
-        sourceFileId: file.id,
-        latField: file.latField,
-        lonField: file.lonField,
-      }));
-      lines.items.push(...lineFeatures);
-      lines.skipped += lineResult.skipped;
-
-      const regionResult = deriveRegionsFromCsv(commonArgs);
-      const regionFeatures = regionResult.polygons.map((region) => ({
-        ...region,
-        sourceFileId: file.id,
-        latField: file.latField,
-        lonField: file.lonField,
-      }));
-      regions.items.push(...regionFeatures);
-      regions.skipped += regionResult.skipped;
-
-      timelineIndex.entries.push(
-        ...buildTimelineIndex({
-          features: [...pointFeatures, ...lineFeatures, ...regionFeatures],
-          getSourceRow,
-          timelineFields,
-          rangeFields,
-        }).entries,
-      );
-    }
-
-    const visibleTimelineFeatureIds = timeline?.timelineEnabled
-      ? getVisibleTimelineFeatureIds(timelineIndex, timeline)
-      : null;
-    const visiblePoints = filterByVisibleIds(points.items, visibleTimelineFeatureIds);
-    const visibleLines = filterByVisibleIds(lines.items, visibleTimelineFeatureIds);
-    const visibleRegions = filterByVisibleIds(regions.items, visibleTimelineFeatureIds);
 
     return {
       points: {
-        points: visiblePoints,
-        skipped: points.skipped,
-        skippedByTimeline: points.items.length - visiblePoints.length,
+        points: mapView.points,
+        skipped: mapView.stats.skippedPoints,
+        skippedByTimeline: mapView.stats.skippedPointsByTimeline,
       },
       lines: {
-        lines: visibleLines,
-        skipped: lines.skipped,
-        skippedByTimeline: lines.items.length - visibleLines.length,
+        lines: mapView.lines,
+        skipped: mapView.stats.skippedLines,
+        skippedByTimeline: mapView.stats.skippedLinesByTimeline,
       },
       regions: {
-        polygons: visibleRegions,
-        skipped: regions.skipped,
-        skippedByTimeline: regions.items.length - visibleRegions.length,
+        polygons: mapView.regions,
+        skipped: mapView.stats.skippedRegions,
+        skippedByTimeline: mapView.stats.skippedRegionsByTimeline,
       },
       getSourceRow,
-      timelineIndex,
+      timelineIndex: mapView.timelineIndex,
     };
   }, [files, timeline]);
-}
-
-function filterByVisibleIds(features, visibleIds) {
-  if (!visibleIds) return features;
-  return features.filter((feature) => visibleIds.has(feature.id));
 }

--- a/src/data/dataSource.js
+++ b/src/data/dataSource.js
@@ -1,0 +1,189 @@
+/**
+ * Backend-neutral data source contract for map/viewer data.
+ *
+ * This module defines the app-facing boundary between the React/Leaflet UI and
+ * whichever storage model provides the data. Implementations may be backed by
+ * in-memory CSV rows, a local database, browser storage, or a remote service,
+ * but callers should only depend on the viewer-oriented methods below.
+ */
+
+export const DATA_SOURCE_METHODS = Object.freeze({
+  queryMapView: "queryMapView",
+  getFeatureDetails: "getFeatureDetails",
+  getGroupRows: "getGroupRows",
+  getDatasetSummary: "getDatasetSummary",
+});
+
+/**
+ * @typedef {object} DataSource
+ * @property {(query: MapViewQuery) => MapViewResult | Promise<MapViewResult>} queryMapView
+ *   Returns compact map render data for the current viewer state.
+ * @property {(query: FeatureDetailsQuery) => FeatureDetailsResult | Promise<FeatureDetailsResult>} getFeatureDetails
+ *   Returns row/detail data for a selected map feature.
+ * @property {(query: GroupRowsQuery) => GroupRowsResult | Promise<GroupRowsResult>} getGroupRows
+ *   Returns a page of backing rows for a dataset or future grouped detail view.
+ * @property {() => DatasetSummary | Promise<DatasetSummary>} getDatasetSummary
+ *   Returns dataset metadata and summary information needed by the UI.
+ */
+
+/**
+ * @typedef {object} MapViewQuery
+ * @property {MapBounds|null} [bounds]
+ *   Current map bounds. Implementations may ignore this when they cannot query
+ *   spatially yet, but future indexed backends should use it to limit work.
+ * @property {number|null} [zoom]
+ *   Current map zoom level.
+ * @property {TimelineFilter|null} [timeline]
+ *   Current timeline filter state in app terms.
+ * @property {number|null} [renderBudget]
+ *   Soft maximum number of render items the caller wants back.
+ */
+
+/**
+ * @typedef {object} MapBounds
+ * @property {number} north
+ * @property {number} south
+ * @property {number} east
+ * @property {number} west
+ */
+
+/**
+ * @typedef {object} TimelineFilter
+ * @property {boolean} [timelineEnabled]
+ * @property {number|null} [startYear]
+ * @property {number|null} [endYear]
+ * @property {number|null} [yearMin]
+ * @property {number|null} [yearMax]
+ */
+
+/**
+ * @typedef {object} MapViewResult
+ * @property {PointFeature[]} points
+ * @property {LineFeature[]} lines
+ * @property {RegionFeature[]} regions
+ * @property {MapViewStats} stats
+ * @property {TimelineIndex} timelineIndex
+ */
+
+/**
+ * @typedef {object} PointFeature
+ * @property {string} id
+ * @property {number} lat
+ * @property {number} lon
+ * @property {FeatureSourceRef|null} [sourceRef]
+ * @property {string|null} [marker]
+ * @property {string|null} [image]
+ * @property {number|null} [imageWidthMeters]
+ * @property {number|null} [imageHeightMeters]
+ * @property {string|null} [latField]
+ * @property {string|null} [lonField]
+ */
+
+/**
+ * @typedef {object} LineFeature
+ * @property {string} id
+ * @property {string|null} [featureId]
+ * @property {Array<[number, number]>} coordinates
+ * @property {object|null} [style]
+ * @property {"none"|"start"|"end"|"both"|null} [arrow]
+ * @property {FeatureSourceRef|null} [sourceRef]
+ * @property {string|null} [latField]
+ * @property {string|null} [lonField]
+ */
+
+/**
+ * @typedef {object} RegionFeature
+ * @property {string} id
+ * @property {string|null} [featureId]
+ * @property {string|null} [part]
+ * @property {Array<[number, number]>} coordinates
+ * @property {object|null} [style]
+ * @property {FeatureSourceRef|null} [sourceRef]
+ * @property {string|null} [latField]
+ * @property {string|null} [lonField]
+ */
+
+/**
+ * @typedef {object} FeatureSourceRef
+ * @property {string} datasetId
+ * @property {number} rowIndex
+ */
+
+/**
+ * @typedef {object} MapViewStats
+ * @property {number} skippedPoints
+ * @property {number} skippedLines
+ * @property {number} skippedRegions
+ * @property {number} skippedPointsByTimeline
+ * @property {number} skippedLinesByTimeline
+ * @property {number} skippedRegionsByTimeline
+ * @property {number} skippedByTimeline
+ * @property {number|null} [limitedToRenderBudget]
+ */
+
+/**
+ * @typedef {object} TimelineIndex
+ * @property {TimelineIndexEntry[]} entries
+ */
+
+/**
+ * @typedef {object} TimelineIndexEntry
+ * @property {string} featureId
+ * @property {number} startYear
+ * @property {number} endYear
+ */
+
+/**
+ * @typedef {object} FeatureDetailsQuery
+ * @property {string|null} [featureId]
+ * @property {FeatureSourceRef|null} [sourceRef]
+ */
+
+/**
+ * @typedef {object} FeatureDetailsResult
+ * @property {string|null} featureId
+ * @property {Record<string, string>|null} row
+ * @property {string|null} [latField]
+ * @property {string|null} [lonField]
+ */
+
+/**
+ * @typedef {object} GroupRowsQuery
+ * @property {string|null} [datasetId]
+ * @property {string|null} [groupId]
+ * @property {number} [offset]
+ * @property {number} [limit]
+ */
+
+/**
+ * @typedef {object} GroupRowsResult
+ * @property {Record<string, string>[]} rows
+ * @property {number} offset
+ * @property {number} limit
+ * @property {number|null} totalRows
+ */
+
+/**
+ * @typedef {object} DatasetSummary
+ * @property {DatasetSummaryItem[]} datasets
+ * @property {TimelineSummary|null} timeline
+ */
+
+/**
+ * @typedef {object} DatasetSummaryItem
+ * @property {string} id
+ * @property {string} name
+ * @property {boolean} enabled
+ * @property {string[]} headers
+ * @property {number} rowCount
+ * @property {number} totalRows
+ * @property {string|null} latField
+ * @property {string|null} lonField
+ * @property {string[]} parseErrors
+ */
+
+/**
+ * @typedef {object} TimelineSummary
+ * @property {number|null} yearMin
+ * @property {number|null} yearMax
+ */

--- a/src/data/inMemoryDataSource.js
+++ b/src/data/inMemoryDataSource.js
@@ -1,0 +1,141 @@
+/**
+ * Browser DataSource backed by CSV files already loaded in memory.
+ * It keeps current map behavior while giving the UI a backend-neutral API.
+ */
+import { deriveMapFeaturesFromFiles } from "./mapFeatureDerivation";
+
+const DEFAULT_GROUP_ROWS_LIMIT = 30;
+
+export function createInMemoryDataSource({ files }) {
+  const datasets = Array.isArray(files) ? files : [];
+
+  return {
+    // Build the compact map data that Leaflet needs to render the current view.
+    queryMapView(query = {}) {
+      const derived = deriveMapFeaturesFromFiles({
+        files: datasets,
+        timeline: query.timeline ?? null,
+      });
+
+      return {
+        points: derived.points.points.map(toDataSourceFeature),
+        lines: derived.lines.lines.map(toDataSourceFeature),
+        regions: derived.regions.polygons.map(toDataSourceFeature),
+        stats: {
+          skippedPoints: derived.points.skipped,
+          skippedLines: derived.lines.skipped,
+          skippedRegions: derived.regions.skipped,
+          skippedPointsByTimeline: derived.points.skippedByTimeline,
+          skippedLinesByTimeline: derived.lines.skippedByTimeline,
+          skippedRegionsByTimeline: derived.regions.skippedByTimeline,
+          skippedByTimeline:
+            (derived.points.skippedByTimeline ?? 0) +
+            (derived.lines.skippedByTimeline ?? 0) +
+            (derived.regions.skippedByTimeline ?? 0),
+          limitedToRenderBudget: null,
+        },
+        timelineIndex: derived.timelineIndex,
+      };
+    },
+
+    // Return the original CSV row for a selected feature popup/detail view.
+    getFeatureDetails(query = {}) {
+      const sourceRef = query.sourceRef ?? null;
+      const row = getSourceRow(datasets, sourceRef);
+      const dataset = getDataset(datasets, sourceRef?.datasetId);
+
+      return {
+        featureId: query.featureId ?? null,
+        row,
+        latField: dataset?.latField ?? null,
+        lonField: dataset?.lonField ?? null,
+      };
+    },
+
+    // Return one page of source rows. Today this is dataset-based, not grouped markers.
+    getGroupRows(query = {}) {
+      const dataset = getDataset(datasets, query.datasetId ?? query.groupId);
+      const rows = dataset?.rows ?? [];
+      const offset = Math.max(0, Number.parseInt(query.offset ?? 0, 10) || 0);
+      const limit = Math.max(
+        0,
+        Number.parseInt(query.limit ?? DEFAULT_GROUP_ROWS_LIMIT, 10) || 0,
+      );
+
+      return {
+        rows: rows.slice(offset, offset + limit),
+        offset,
+        limit,
+        totalRows: dataset?.totalRows ?? rows.length,
+      };
+    },
+
+    // Return file-level metadata used by panels and future dataset-aware UI.
+    getDatasetSummary() {
+      return {
+        datasets: datasets.map((file) => ({
+          id: file.id,
+          name: file.name,
+          enabled: !!file.enabled,
+          headers: file.headers ?? [],
+          rowCount: file.rows?.length ?? 0,
+          totalRows: file.totalRows ?? file.rows?.length ?? 0,
+          latField: file.latField ?? null,
+          lonField: file.lonField ?? null,
+          parseErrors: file.parseErrors ?? [],
+        })),
+        timeline: getTimelineSummary(datasets),
+      };
+    },
+  };
+}
+
+function toDataSourceFeature(feature) {
+  // Keep legacy sourceFileId/sourceRowIndex while GeoMap still reads them.
+  // Future UI cleanup can switch detail lookups to sourceRef directly.
+  return {
+    ...feature,
+    sourceRef: getFeatureSourceRef(feature),
+  };
+}
+
+function getFeatureSourceRef(feature) {
+  if (!feature?.sourceFileId || feature.sourceRowIndex == null) {
+    return null;
+  }
+
+  return {
+    datasetId: feature.sourceFileId,
+    rowIndex: feature.sourceRowIndex,
+  };
+}
+
+function getSourceRow(files, sourceRef) {
+  const dataset = getDataset(files, sourceRef?.datasetId);
+  if (!dataset || sourceRef?.rowIndex == null) return null;
+
+  return dataset.rows?.[sourceRef.rowIndex] ?? null;
+}
+
+function getDataset(files, datasetId) {
+  if (!datasetId) return null;
+  return files.find((file) => file.id === datasetId) ?? null;
+}
+
+function getTimelineSummary(files) {
+  let yearMin = null;
+  let yearMax = null;
+  const timelineIndex = deriveMapFeaturesFromFiles({
+    files,
+    timeline: null,
+  }).timelineIndex;
+
+  for (const entry of timelineIndex.entries) {
+    if (yearMin == null || entry.startYear < yearMin) yearMin = entry.startYear;
+    if (yearMax == null || entry.endYear > yearMax) yearMax = entry.endYear;
+  }
+
+  if (yearMin == null || yearMax == null) return null;
+
+  return { yearMin, yearMax };
+}

--- a/src/data/mapFeatureDerivation.js
+++ b/src/data/mapFeatureDerivation.js
@@ -1,0 +1,121 @@
+/**
+ * Current browser/in-memory map feature derivation shared by the DataSource adapter.
+ */
+
+import { deriveLinesFromCsv } from "../components/deriveLines";
+import { derivePointsFromCsv } from "../components/derivePoints";
+import { deriveRegionsFromCsv } from "../components/deriveRegions";
+import { detectFeatureTypeField } from "../components/featureTypes";
+import {
+  autoDetectRangeFields,
+  autoDetectTimelineFields,
+} from "../components/timeline";
+import {
+  buildTimelineIndex,
+  getVisibleTimelineFeatureIds,
+} from "../components/timelineIndex";
+
+export function deriveMapFeaturesFromFiles({ files, timeline }) {
+  const points = { items: [], skipped: 0 };
+  const lines = { items: [], skipped: 0 };
+  const regions = { items: [], skipped: 0 };
+  const timelineIndex = { entries: [] };
+  // Only enabled files should create map features.
+  const enabledFiles = (files ?? []).filter((item) => item.enabled);
+  const sourceRowsByFileId = new Map(
+    enabledFiles.map((file) => [file.id, file.rows ?? []]),
+  );
+
+  const getSourceRow = (sourceFileId, sourceRowIndex) => (
+    sourceRowsByFileId.get(sourceFileId)?.[sourceRowIndex] ?? null
+  );
+
+  // Merge derived map features from all enabled CSV files into one map-ready result.
+  for (const file of enabledFiles) {
+    const timelineFields = autoDetectTimelineFields(file.headers ?? []);
+    const rangeFields = autoDetectRangeFields(file.headers ?? []);
+    const featureTypeField = detectFeatureTypeField(file.headers ?? []);
+
+    const commonArgs = {
+      rows: file.rows,
+      latField: file.latField,
+      lonField: file.lonField,
+      featureTypeField,
+      idPrefix: file.id,
+    };
+
+    // Reuse the existing CSV-to-map helpers so behavior stays the same.
+    const pointResult = derivePointsFromCsv(commonArgs);
+    const pointFeatures = pointResult.points.map((point) => ({
+      ...point,
+      sourceFileId: file.id,
+      latField: file.latField,
+      lonField: file.lonField,
+    }));
+    points.items.push(...pointFeatures);
+    points.skipped += pointResult.skipped;
+
+    const lineResult = deriveLinesFromCsv(commonArgs);
+    const lineFeatures = lineResult.lines.map((line) => ({
+      ...line,
+      sourceFileId: file.id,
+      latField: file.latField,
+      lonField: file.lonField,
+    }));
+    lines.items.push(...lineFeatures);
+    lines.skipped += lineResult.skipped;
+
+    const regionResult = deriveRegionsFromCsv(commonArgs);
+    const regionFeatures = regionResult.polygons.map((region) => ({
+      ...region,
+      sourceFileId: file.id,
+      latField: file.latField,
+      lonField: file.lonField,
+    }));
+    regions.items.push(...regionFeatures);
+    regions.skipped += regionResult.skipped;
+
+    // The timeline index stores feature ids and year ranges, not full rows.
+    timelineIndex.entries.push(
+      ...buildTimelineIndex({
+        features: [...pointFeatures, ...lineFeatures, ...regionFeatures],
+        getSourceRow,
+        timelineFields,
+        rangeFields,
+      }).entries,
+    );
+  }
+
+  // If timeline filtering is on, keep only features in the selected year range.
+  const visibleTimelineFeatureIds = timeline?.timelineEnabled
+    ? getVisibleTimelineFeatureIds(timelineIndex, timeline)
+    : null;
+  const visiblePoints = filterByVisibleIds(points.items, visibleTimelineFeatureIds);
+  const visibleLines = filterByVisibleIds(lines.items, visibleTimelineFeatureIds);
+  const visibleRegions = filterByVisibleIds(regions.items, visibleTimelineFeatureIds);
+
+  return {
+    points: {
+      points: visiblePoints,
+      skipped: points.skipped,
+      skippedByTimeline: points.items.length - visiblePoints.length,
+    },
+    lines: {
+      lines: visibleLines,
+      skipped: lines.skipped,
+      skippedByTimeline: lines.items.length - visibleLines.length,
+    },
+    regions: {
+      polygons: visibleRegions,
+      skipped: regions.skipped,
+      skippedByTimeline: regions.items.length - visibleRegions.length,
+    },
+    getSourceRow,
+    timelineIndex,
+  };
+}
+
+function filterByVisibleIds(features, visibleIds) {
+  if (!visibleIds) return features;
+  return features.filter((feature) => visibleIds.has(feature.id));
+}


### PR DESCRIPTION
## Summary

- Define a backend-neutral `DataSource` contract for map/viewer data
- Add an in-memory `DataSource` implementation backed by current CSV file state
- Move current map feature derivation into a shared data-layer helper
- Route `useDerivedMapFeatures` through the in-memory `DataSource` while preserving the existing UI return shape

## Notes

- No user-facing behavior changes intended
- `GeoMap` still uses the legacy `sourceFileId` / `sourceRowIndex` bridge for now
- New `sourceRef` support gives future UI/backend work a cleaner detail lookup path

## Verification

- `npm run lint`
- `npm run build`
- Manual smoke test: existing app behavior works as usual

Closes #79
