### PR TITLE
Prototype SQLite import for local CSV files

### DIFF
--- a/desktop/csvImportService.cjs
+++ b/desktop/csvImportService.cjs
@@ -1,0 +1,427 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+const { randomUUID } = require("node:crypto");
+const Papa = require("papaparse");
+
+const LAT_SYNONYMS = ["lat", "latitude", "y", "northing"];
+const LON_SYNONYMS = ["lon", "lng", "long", "longitude", "x", "easting"];
+const YEAR_SYNONYMS = ["year", "yyyy", "yr", "ar"];
+const DATE_SYNONYMS = ["date", "datetime", "timestamp", "time", "created", "createdat"];
+// These fields are small enough to keep beside each imported point. Later map queries can read them without loading the full row.
+const COMPACT_FIELD_NAMES = [
+  "featureType",
+  "featureId",
+  "part",
+  "order",
+  "name",
+  "title",
+  "label",
+  "comment",
+  "marker",
+  "image",
+  "color",
+  "weight",
+];
+
+/**
+ * Import one local CSV file into the desktop SQLite store.
+ * This does not update the Leaflet map. It only writes data for later query work.
+ */
+function importCsvFileToSqlite({ db, filePath }) {
+  if (!db?.open) {
+    throw new TypeError("An open SQLite database is required.");
+  }
+
+  if (!filePath || typeof filePath !== "string") {
+    throw new TypeError("A CSV file path is required.");
+  }
+
+  const csvText = fs.readFileSync(filePath, "utf8");
+  const parsed = parseCsvText(csvText);
+  const detectedFields = detectFields(parsed.headers);
+  const datasetId = randomUUID();
+
+  const importRows = buildImportRows({
+    datasetId,
+    rows: parsed.rows,
+    detectedFields,
+  });
+
+  const summary = {
+    ok: true,
+    datasetId,
+    fileName: path.basename(filePath),
+    sourcePath: filePath,
+    rowCount: parsed.rows.length,
+    importedFeatureCount: importRows.features.length,
+    skippedRowCount: importRows.skippedRowCount,
+    columns: parsed.headers,
+    detectedFields,
+    parseErrors: parsed.parseErrors,
+  };
+
+  insertImportResult(db, summary, importRows.features);
+
+  return summary;
+}
+
+/**
+ * Parse CSV text into headers and row objects.
+ * This mirrors the browser parser shape, but runs in Electron main process code.
+ */
+function parseCsvText(csvText) {
+  const result = Papa.parse(csvText, {
+    delimiter: "",
+    skipEmptyLines: true,
+    quoteChar: '"',
+    escapeChar: '"',
+  });
+
+  const parseErrors = (result.errors ?? []).map(
+    (error) => `Parser: ${error.message} (row ${error.row ?? "?"})`,
+  );
+  const data = Array.isArray(result.data) ? result.data : [];
+  const firstNonEmptyRowIndex = data.findIndex((row) => Array.isArray(row) && !isEmptyRow(row));
+
+  if (firstNonEmptyRowIndex < 0) {
+    return { headers: [], rows: [], parseErrors: [...parseErrors, "No rows detected."] };
+  }
+
+  const headers = normalizeHeaders(data[firstNonEmptyRowIndex].map((value) => String(value ?? "")));
+  if (headers.length === 0) {
+    return { headers: [], rows: [], parseErrors: [...parseErrors, "Header row is empty."] };
+  }
+
+  const rows = [];
+  for (const rowArr of data.slice(firstNonEmptyRowIndex + 1)) {
+    if (!Array.isArray(rowArr) || isEmptyRow(rowArr)) continue;
+    rows.push(rowArrayToObject(rowArr, headers));
+  }
+
+  return { headers, rows, parseErrors };
+}
+
+/**
+ * Find useful columns by common names, such as latitude, longitude, year, and date.
+ */
+function detectFields(headers) {
+  return {
+    latField: pickBest(headers, LAT_SYNONYMS),
+    lonField: pickBest(headers, LON_SYNONYMS),
+    yearField: pickBest(headers, YEAR_SYNONYMS),
+    dateField: pickBest(headers, DATE_SYNONYMS),
+    yearFromField: findExactKey(headers, "yearfrom"),
+    yearToField: findExactKey(headers, "yearto"),
+    dateFromField: findExactKey(headers, "datefrom"),
+    dateToField: findExactKey(headers, "dateto"),
+  };
+}
+
+/**
+ * Convert parsed CSV rows into rows that match the prototype SQLite schema.
+ * Rows without valid coordinates are counted as skipped.
+ */
+function buildImportRows({ datasetId, rows, detectedFields }) {
+  const features = [];
+  let skippedRowCount = 0;
+
+  const latField = detectedFields.latField;
+  const lonField = detectedFields.lonField;
+
+  if (!latField || !lonField) {
+    return {
+      features,
+      skippedRowCount: rows.length,
+    };
+  }
+
+  for (let rowIndex = 0; rowIndex < rows.length; rowIndex += 1) {
+    const row = rows[rowIndex];
+    const lat = parseFlexibleFloat(row?.[latField]);
+    const lon = parseFlexibleFloat(row?.[lonField]);
+
+    if (!isValidLat(lat) || !isValidLon(lon)) {
+      skippedRowCount += 1;
+      continue;
+    }
+
+    const timelineExtent = getRowTimelineExtent(row, detectedFields);
+    const id = `${datasetId}:${rowIndex}`;
+
+    features.push({
+      id,
+      datasetId,
+      sourceRowIndex: rowIndex,
+      lat,
+      lon,
+      timelineStartYear: timelineExtent?.startYear ?? null,
+      timelineEndYear: timelineExtent?.endYear ?? null,
+      compactJson: JSON.stringify(getCompactFields(row, detectedFields)),
+      rowJson: JSON.stringify(row),
+    });
+  }
+
+  return {
+    features,
+    skippedRowCount,
+  };
+}
+
+/**
+ * Store dataset metadata and feature rows in one transaction.
+ * This keeps partial imports out of the database if an insert fails.
+ */
+function insertImportResult(db, summary, features) {
+  const insertDataset = db.prepare(`
+    INSERT INTO datasets (
+      id,
+      file_name,
+      source_path,
+      row_count,
+      imported_feature_count,
+      skipped_row_count,
+      columns_json,
+      imported_at
+    )
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+
+  const insertFeature = db.prepare(`
+    INSERT INTO features (
+      id,
+      dataset_id,
+      source_row_index,
+      lat,
+      lon,
+      timeline_start_year,
+      timeline_end_year,
+      compact_json,
+      row_json
+    )
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+
+  const runImport = db.transaction(() => {
+    insertDataset.run(
+      summary.datasetId,
+      summary.fileName,
+      summary.sourcePath,
+      summary.rowCount,
+      summary.importedFeatureCount,
+      summary.skippedRowCount,
+      JSON.stringify(summary.columns),
+      new Date().toISOString(),
+    );
+
+    for (const feature of features) {
+      insertFeature.run(
+        feature.id,
+        feature.datasetId,
+        feature.sourceRowIndex,
+        feature.lat,
+        feature.lon,
+        feature.timelineStartYear,
+        feature.timelineEndYear,
+        feature.compactJson,
+        feature.rowJson,
+      );
+    }
+  });
+
+  runImport();
+}
+
+function normalizeHeaders(rawHeaders) {
+  const seen = new Map();
+  const headers = [];
+
+  for (const rawHeader of rawHeaders) {
+    const base = String(rawHeader ?? "").trim();
+    if (!base) continue;
+
+    const count = (seen.get(base) ?? 0) + 1;
+    seen.set(base, count);
+    headers.push(count === 1 ? base : `${base}_${count}`);
+  }
+
+  return headers;
+}
+
+function rowArrayToObject(rowArr, headers) {
+  const row = {};
+
+  for (let index = 0; index < headers.length; index += 1) {
+    row[headers[index]] = String(rowArr[index] ?? "").trim();
+  }
+
+  return row;
+}
+
+function isEmptyRow(row) {
+  return row.every((value) => String(value ?? "").trim() === "");
+}
+
+function normalizeKey(value) {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, "")
+    .replace(/[_-]+/g, "")
+    .replace(/\d+$/g, "");
+}
+
+function pickBest(headers, synonyms) {
+  let best = { field: null, score: 0 };
+
+  for (const header of headers) {
+    const normalized = normalizeKey(header);
+    const score = scoreHeader(normalized, synonyms);
+    if (score > best.score) best = { field: header, score };
+  }
+
+  return best.field;
+}
+
+function scoreHeader(normalized, synonyms) {
+  for (const synonym of synonyms) {
+    if (normalized === synonym) return 100;
+  }
+
+  for (const synonym of synonyms) {
+    if (normalized.includes(synonym)) return 50;
+  }
+
+  return 0;
+}
+
+function findExactKey(headers, normalizedKey) {
+  for (const header of headers) {
+    if (normalizeKey(header) === normalizedKey) return header;
+  }
+
+  return null;
+}
+
+function parseFlexibleFloat(value) {
+  if (value === null || value === undefined) return NaN;
+  if (typeof value === "number") return Number.isFinite(value) ? value : NaN;
+
+  const normalized = String(value ?? "")
+    .trim()
+    .replace(/\s+/g, "")
+    .replace(/,/g, ".");
+
+  if (!normalized) return NaN;
+
+  const parsed = Number.parseFloat(normalized);
+  return Number.isFinite(parsed) ? parsed : NaN;
+}
+
+function isValidLat(lat) {
+  return Number.isFinite(lat) && lat >= -90 && lat <= 90;
+}
+
+function isValidLon(lon) {
+  return Number.isFinite(lon) && lon >= -180 && lon <= 180;
+}
+
+function getRowTimelineExtent(row, fields) {
+  const yearFrom = getRangeYear(row, fields.yearFromField, fields.dateFromField);
+  const yearTo = getRangeYear(row, fields.yearToField, fields.dateToField);
+
+  if (yearFrom != null || yearTo != null) {
+    const startYear = yearFrom ?? yearTo;
+    const endYear = yearTo ?? yearFrom;
+    return { startYear, endYear };
+  }
+
+  const year = getRangeYear(row, fields.yearField, fields.dateField);
+  if (year == null) return null;
+
+  return { startYear: year, endYear: year };
+}
+
+function getRangeYear(row, yearField, dateField) {
+  if (!row || typeof row !== "object") return null;
+
+  if (yearField) {
+    const year = parseYearValue(row[yearField]);
+    if (year != null) return year;
+  }
+
+  if (dateField) {
+    const date = parseDateValue(row[dateField]);
+    if (date) return date.getUTCFullYear();
+  }
+
+  return null;
+}
+
+function parseYearValue(value) {
+  if (value == null) return null;
+
+  if (typeof value === "number" && Number.isFinite(value)) {
+    const year = Math.trunc(value);
+    return isReasonableYear(year) ? year : null;
+  }
+
+  const match = String(value).trim().match(/-?\d{1,5}/);
+  if (!match) return null;
+
+  const year = Number.parseInt(match[0], 10);
+  return isReasonableYear(year) ? year : null;
+}
+
+function parseDateValue(value) {
+  if (value == null) return null;
+  if (value instanceof Date && !Number.isNaN(value.getTime())) return value;
+
+  const raw = String(value).trim();
+  if (!raw) return null;
+
+  if (/^-?\d{1,5}$/.test(raw)) {
+    const year = Number.parseInt(raw, 10);
+    if (!isReasonableYear(year)) return null;
+
+    const date = new Date(Date.UTC(year, 0, 1));
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+
+  const date = new Date(raw);
+  if (!Number.isNaN(date.getTime())) return date;
+
+  const match = raw.match(/^(-?\d{1,5})[/-](\d{1,2})[/-](\d{1,2})/);
+  if (!match) return null;
+
+  const year = Number.parseInt(match[1], 10);
+  const month = Number.parseInt(match[2], 10);
+  const day = Number.parseInt(match[3], 10);
+  const parsed = new Date(Date.UTC(year, month - 1, day));
+
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function isReasonableYear(year) {
+  return Number.isFinite(year) && Math.abs(year) <= 10000;
+}
+
+function getCompactFields(row, detectedFields) {
+  const compact = {
+    latField: detectedFields.latField,
+    lonField: detectedFields.lonField,
+  };
+
+  for (const key of COMPACT_FIELD_NAMES) {
+    if (Object.prototype.hasOwnProperty.call(row, key)) {
+      compact[key] = row[key];
+    }
+  }
+
+  return compact;
+}
+
+module.exports = {
+  importCsvFileToSqlite,
+};

--- a/desktop/main.cjs
+++ b/desktop/main.cjs
@@ -1,13 +1,66 @@
 "use strict";
 
-const { app, BrowserWindow, shell } = require("electron");
+const { app, BrowserWindow, dialog, ipcMain, shell } = require("electron");
 const path = require("node:path");
+const { importCsvFileToSqlite } = require("./csvImportService.cjs");
+const { closeSqliteStore, openSqliteStore } = require("./sqliteStore.cjs");
+
+// The prototype DB lives in Electron userData, not inside the repository.
+const SQLITE_DB_FILE_NAME = "csv-map-layer-visualizer.sqlite";
 
 function getDevServerUrl() {
   const devServerArg = process.argv.find((arg) => arg.startsWith("--dev-server="));
   return devServerArg ? devServerArg.slice("--dev-server=".length) : null;
 }
 
+/**
+ * Register the small desktop API used by the renderer.
+ * Keep file paths and database access in the main process.
+ */
+function registerDesktopBridgeHandlers() {
+  ipcMain.handle("desktop:getStatus", () => ({
+    ok: true,
+    runtime: "electron",
+  }));
+
+  // The renderer asks to import, but the main process opens the file picker.
+  ipcMain.handle("desktop:importCsvToSqlite", async () => {
+    const fileResult = await dialog.showOpenDialog({
+      title: "Import CSV to local SQLite",
+      properties: ["openFile"],
+      filters: [
+        { name: "CSV files", extensions: ["csv"] },
+        { name: "All files", extensions: ["*"] },
+      ],
+    });
+
+    if (fileResult.canceled || fileResult.filePaths.length === 0) {
+      return { ok: false, canceled: true };
+    }
+
+    const db = openSqliteStore(getDesktopDatabasePath());
+
+    try {
+      return importCsvFileToSqlite({
+        db,
+        filePath: fileResult.filePaths[0],
+      });
+    } finally {
+      closeSqliteStore(db);
+    }
+  });
+}
+
+/**
+ * Return the per-user database path for the desktop app.
+ */
+function getDesktopDatabasePath() {
+  return path.join(app.getPath("userData"), SQLITE_DB_FILE_NAME);
+}
+
+/**
+ * Create the Electron window that hosts the existing Vite app.
+ */
 function createMainWindow() {
   const mainWindow = new BrowserWindow({
     width: 1280,
@@ -39,6 +92,7 @@ function createMainWindow() {
 }
 
 app.whenReady().then(() => {
+  registerDesktopBridgeHandlers();
   createMainWindow();
 
   app.on("activate", () => {
@@ -53,5 +107,3 @@ app.on("window-all-closed", () => {
     app.quit();
   }
 });
-
-

--- a/desktop/preload.cjs
+++ b/desktop/preload.cjs
@@ -1,3 +1,10 @@
 "use strict";
 
-// Reserved for a future, narrow desktop bridge. No desktop APIs are exposed yet.
+const { contextBridge, ipcRenderer } = require("electron");
+
+// Expose only fixed desktop methods. The renderer cannot choose IPC channel names.
+contextBridge.exposeInMainWorld("csvMapDesktop", {
+  isDesktop: true,
+  getStatus: () => ipcRenderer.invoke("desktop:getStatus"),
+  importCsvToSqlite: () => ipcRenderer.invoke("desktop:importCsvToSqlite"),
+});

--- a/desktop/run-electron.cjs
+++ b/desktop/run-electron.cjs
@@ -4,8 +4,10 @@ const { spawn } = require("node:child_process");
 const electronPath = require("electron");
 
 const env = { ...process.env };
+// Make sure Electron starts as the desktop app, not as plain Node.js.
 delete env.ELECTRON_RUN_AS_NODE;
 
+// Pass CLI args through so desktop:dev can send the Vite dev-server URL.
 const child = spawn(electronPath, process.argv.slice(2), {
   stdio: "inherit",
   env,

--- a/desktop/sqliteStore.cjs
+++ b/desktop/sqliteStore.cjs
@@ -1,0 +1,78 @@
+"use strict";
+
+const Database = require("better-sqlite3");
+
+/**
+ * Open the SQLite database and make sure the prototype schema exists.
+ */
+function openSqliteStore(dbPath) {
+  if (!dbPath || typeof dbPath !== "string") {
+    throw new TypeError("A SQLite database path is required.");
+  }
+
+  const db = new Database(dbPath);
+  initializeSchema(db);
+  return db;
+}
+
+/**
+ * Create the import schema and future query indexes.
+ * Later issues can query these tables without changing the browser CSV flow.
+ */
+function initializeSchema(db) {
+  db.pragma("journal_mode = WAL");
+  db.pragma("foreign_keys = ON");
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS datasets (
+      id TEXT PRIMARY KEY,
+      file_name TEXT NOT NULL,
+      source_path TEXT,
+      row_count INTEGER NOT NULL DEFAULT 0,
+      imported_feature_count INTEGER NOT NULL DEFAULT 0,
+      skipped_row_count INTEGER NOT NULL DEFAULT 0,
+      columns_json TEXT NOT NULL DEFAULT '[]',
+      imported_at TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS features (
+      id TEXT PRIMARY KEY,
+      dataset_id TEXT NOT NULL,
+      source_row_index INTEGER NOT NULL,
+      lat REAL NOT NULL,
+      lon REAL NOT NULL,
+      timeline_start_year INTEGER,
+      timeline_end_year INTEGER,
+      compact_json TEXT NOT NULL DEFAULT '{}',
+      row_json TEXT NOT NULL DEFAULT '{}',
+      FOREIGN KEY (dataset_id) REFERENCES datasets(id) ON DELETE CASCADE
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_features_dataset
+      ON features(dataset_id);
+
+    CREATE INDEX IF NOT EXISTS idx_features_dataset_lat_lon
+      ON features(dataset_id, lat, lon);
+
+    CREATE INDEX IF NOT EXISTS idx_features_dataset_timeline
+      ON features(dataset_id, timeline_start_year, timeline_end_year);
+
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_features_dataset_source_row
+      ON features(dataset_id, source_row_index);
+  `);
+}
+
+/**
+ * Close the database if it is still open.
+ */
+function closeSqliteStore(db) {
+  if (db?.open) {
+    db.close();
+  }
+}
+
+module.exports = {
+  closeSqliteStore,
+  initializeSchema,
+  openSqliteStore,
+};

--- a/docs/desktop-runtime.md
+++ b/docs/desktop-runtime.md
@@ -39,3 +39,7 @@ npm run desktop:dev
 ```
 
 Installer or packaged executable output should be handled by a separate packaging issue.
+
+## Related Desktop Data Work
+
+- [SQLite import prototype](./sqlite-import-prototype.md)

--- a/docs/sqlite-import-prototype.md
+++ b/docs/sqlite-import-prototype.md
@@ -1,0 +1,90 @@
+# SQLite Import Prototype
+
+Issue #81 adds the first desktop-only path for importing local CSV files into a SQLite-backed prototype store.
+
+## Runtime Boundary
+
+SQLite access belongs to the Electron desktop runtime only. The browser and GitHub Pages path should continue to use the existing in-memory CSV flow.
+
+The renderer talks to the desktop runtime through the narrow preload bridge:
+
+- `window.csvMapDesktop.isDesktop`
+- `window.csvMapDesktop.getStatus()`
+- `window.csvMapDesktop.importCsvToSqlite()`
+
+The renderer does not pass arbitrary IPC channel names, local file paths, or database paths. The Electron main process owns the file picker, database path, and SQLite import work.
+
+## Database Location
+
+The prototype database is stored under Electron's app data directory:
+
+```text
+app.getPath("userData") / csv-map-layer-visualizer.sqlite
+```
+
+This keeps imported local data outside the repository and outside the browser build output.
+## Native Module Rebuild
+
+`better-sqlite3` is a native Node module. If Electron shows a `NODE_MODULE_VERSION` mismatch when importing, rebuild the module for the Electron runtime and restart the desktop app:
+
+```bash
+npm rebuild better-sqlite3 --runtime=electron --target=43.1.0 --dist-url=https://electronjs.org/headers
+```
+
+This rebuild is for local development only. It does not change the browser/GitHub Pages path.
+
+## Prototype Schema
+
+The schema is intentionally small and import-focused.
+
+### `datasets`
+
+One row per imported CSV file:
+
+- `id`
+- `file_name`
+- `source_path`
+- `row_count`
+- `imported_feature_count`
+- `skipped_row_count`
+- `columns_json`
+- `imported_at`
+
+### `features`
+
+One row per imported CSV row with valid point coordinates:
+
+- `id`
+- `dataset_id`
+- `source_row_index`
+- `lat`
+- `lon`
+- `timeline_start_year`
+- `timeline_end_year`
+- `compact_json`
+- `row_json`
+
+`row_json` preserves the original row for later detail lookup. `compact_json` stores lightweight fields that later map queries may need without reading the full row.
+
+## Index Direction
+
+The prototype creates indexes for later issues:
+
+- `features(dataset_id)` for dataset-scoped reads
+- `features(dataset_id, lat, lon)` for future viewport queries
+- `features(dataset_id, timeline_start_year, timeline_end_year)` for future timeline filtering
+- unique `features(dataset_id, source_row_index)` for stable row/detail lookup
+
+These indexes are not yet used for Leaflet rendering. They document and prove the storage direction needed by follow-up query work.
+
+## Non-Goals
+
+This prototype does not:
+
+- render SQLite-backed markers in Leaflet
+- implement viewport queries
+- add grouped or representative markers
+- add marker detail UI
+- add paged group rows
+- replace the browser/GitHub Pages CSV flow
+- support DuckDB, remote data sources, or unlimited CSV sizes

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "app",
       "version": "0.0.0",
       "dependencies": {
+        "better-sqlite3": "^12.11.1",
         "leaflet": "^1.9.4",
         "leaflet-polylinedecorator": "^1.6.0",
         "leaflet.markercluster": "^1.5.3",
@@ -1513,7 +1514,6 @@
       "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1677,6 +1677,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.7",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.7.tgz",
@@ -1685,6 +1705,40 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/better-sqlite3": {
+      "version": "12.11.1",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.11.1.tgz",
+      "integrity": "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/brace-expansion": {
@@ -1731,6 +1785,30 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -1794,6 +1872,12 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
     },
     "node_modules/cliui": {
       "version": "9.0.1",
@@ -1948,6 +2032,30 @@
         }
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -1963,6 +2071,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/dunder-proto": {
@@ -2012,6 +2129,15 @@
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
     },
     "node_modules/env-paths": {
       "version": "3.0.0",
@@ -2325,6 +2451,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2376,6 +2511,12 @@
       "engines": {
         "node": ">=16.0.0"
       }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
     },
     "node_modules/find-up": {
       "version": "5.0.0",
@@ -2452,6 +2593,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -2549,6 +2696,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",
@@ -2679,6 +2832,26 @@
         "node": ">= 6"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2715,6 +2888,18 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -2960,6 +3145,18 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -2977,11 +3174,16 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -3009,6 +3211,12 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -3016,12 +3224,45 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-abi": {
+      "version": "3.94.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.94.0.tgz",
+      "integrity": "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-abi/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -3162,6 +3403,33 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -3192,6 +3460,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3200,6 +3478,30 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/react": {
@@ -3266,6 +3568,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -3328,6 +3644,26 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -3380,6 +3716,51 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3388,6 +3769,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-width": {
@@ -3463,6 +3853,34 @@
         "node": ">=8"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
+      "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -3496,6 +3914,18 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD"
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -3568,6 +3998,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "7.3.0",
@@ -3721,6 +4157,12 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "better-sqlite3": "^12.11.1",
     "leaflet": "^1.9.4",
     "leaflet-polylinedecorator": "^1.6.0",
     "leaflet.markercluster": "^1.5.3",

--- a/src/App.css
+++ b/src/App.css
@@ -150,6 +150,39 @@ button.csvBtnPrimary.csvImportButton {
   width: 100%;
 }
 
+.csvDesktopImportBlock {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+button.csvBtnPrimary.csvDesktopImportButton {
+  height: 32px;
+  flex: 0 0 auto;
+  width: 100%;
+}
+
+.csvDesktopImportStatus {
+  border-radius: 8px;
+  border: 1px solid rgba(34, 197, 94, 0.35);
+  background: rgba(34, 197, 94, 0.10);
+  color: #dcfce7;
+  font-size: 12px;
+  line-height: 1.35;
+  padding: 8px;
+}
+
+.csvDesktopImportStatusError {
+  border-color: rgba(248, 113, 113, 0.35);
+  background: rgba(248, 113, 113, 0.10);
+  color: #fee2e2;
+}
+
+.csvDesktopImportTitle {
+  font-weight: 700;
+  margin-bottom: 3px;
+  overflow-wrap: anywhere;
+}
 .csvFilesList {
   display: flex;
   flex-direction: column;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import "./App.css";
 import GeoMap from "./components/GeoMap";
 import CsvPanel from "./components/CsvPanel";
@@ -67,6 +67,65 @@ export default function App() {
   useExampleCsvFilesFromUrl({
     importExampleFile,
   });
+  // Electron exposes this object in desktop mode only. Browser builds will not have it.
+  const desktopApi = useMemo(() => globalThis.csvMapDesktop ?? null, []);
+  const desktopImportAvailable =
+    !!desktopApi?.isDesktop && typeof desktopApi.importCsvToSqlite === "function";
+  const [desktopImportState, setDesktopImportState] = useState({
+    status: "idle",
+    summary: null,
+    error: null,
+  });
+
+  /**
+   * Start the desktop-only SQLite import flow.
+   * The imported rows are stored in SQLite, but they are not rendered on the map yet.
+   */
+  const importCsvToSqlite = useCallback(async () => {
+    if (!desktopImportAvailable) return;
+
+    setDesktopImportState({ status: "importing", summary: null, error: null });
+
+    try {
+      const result = await desktopApi.importCsvToSqlite();
+
+      if (result?.canceled) {
+        setDesktopImportState({ status: "canceled", summary: null, error: null });
+        return;
+      }
+
+      if (result?.ok) {
+        setDesktopImportState({ status: "imported", summary: result, error: null });
+        return;
+      }
+
+      setDesktopImportState({
+        status: "error",
+        summary: null,
+        error: "Import failed.",
+      });
+    } catch (error) {
+      setDesktopImportState({
+        status: "error",
+        summary: null,
+        error: error?.message ? String(error.message) : "Import failed.",
+      });
+    }
+  }, [desktopApi, desktopImportAvailable]);
+
+  const desktopImport = useMemo(() => ({
+    isAvailable: desktopImportAvailable,
+    status: desktopImportState.status,
+    summary: desktopImportState.summary,
+    error: desktopImportState.error,
+    onImport: importCsvToSqlite,
+  }), [
+    desktopImportAvailable,
+    desktopImportState.error,
+    desktopImportState.status,
+    desktopImportState.summary,
+    importCsvToSqlite,
+  ]);
 
   const selectedHeaders = selected?.headers;
   const selectedRows = selected?.rows;
@@ -204,6 +263,7 @@ export default function App() {
             selectedId={selectedId}
             onSelect={setSelectedId}
             onImportFiles={importFiles}
+            desktopImport={desktopImport}
             onUnloadSelected={unloadSelected}
             onUnloadFile={unloadFile}
             onToggleEnabled={updateFileEnabled}

--- a/src/components/CsvPanel.jsx
+++ b/src/components/CsvPanel.jsx
@@ -25,6 +25,7 @@ export default function CsvPanel({
   selectedId,       // ID of the currently selected CSV file
   onSelect,         // Callback to change selected CSV
   onImportFiles,    // Callback to import new CSV files
+  desktopImport,
   onUnloadFile,     // Callback to unload a CSV by ID
   onToggleEnabled,  // Callback to toggle file visibility
   onUpdateMapping,  // Callback when user changes latitude/longitude fields
@@ -148,6 +149,7 @@ export default function CsvPanel({
             selectedId={selectedId}
             onSelect={onSelect}
             onImportFiles={onImportFiles}
+            desktopImport={desktopImport}
             onUnloadFile={onUnloadFile}
             onToggleEnabled={onToggleEnabled}
           />

--- a/src/components/csv-panel/CsvFileControls.jsx
+++ b/src/components/csv-panel/CsvFileControls.jsx
@@ -5,6 +5,7 @@ export default function CsvFileControls({
   selectedId,
   onSelect,
   onImportFiles,
+  desktopImport,
   onUnloadFile,
   onToggleEnabled,
 }) {
@@ -13,6 +14,8 @@ export default function CsvFileControls({
    * We trigger this programmatically when user clicks "Import..."
    */
   const fileInputRef = useRef(null);
+  const isDesktopImporting = desktopImport?.status === "importing";
+  const desktopSummary = desktopImport?.summary ?? null;
 
   /**
    * Trigger the hidden file input.
@@ -47,6 +50,45 @@ export default function CsvFileControls({
       >
         Import...
       </button>
+
+      {/* Desktop-only SQLite import. This is separate from the normal map import above. */}
+      {desktopImport?.isAvailable && (
+        <div className="csvDesktopImportBlock">
+          <button
+            type="button"
+            className="csvBtnPrimary csvDesktopImportButton"
+            onClick={desktopImport.onImport}
+            disabled={isDesktopImporting}
+          >
+            {isDesktopImporting ? "Importing to SQLite..." : "Import to local SQLite"}
+          </button>
+
+          {desktopImport.status === "imported" && desktopSummary && (
+            <div className="csvDesktopImportStatus" role="status">
+              <div className="csvDesktopImportTitle">{desktopSummary.fileName}</div>
+              <div>
+                Stored {desktopSummary.importedFeatureCount} of {desktopSummary.rowCount} rows
+                {desktopSummary.skippedRowCount ? `, skipped ${desktopSummary.skippedRowCount}` : ""}.
+              </div>
+              <div>
+                Fields: {formatFieldList(desktopSummary.detectedFields)}
+              </div>
+            </div>
+          )}
+
+          {desktopImport.status === "canceled" && (
+            <div className="csvDesktopImportStatus" role="status">
+              Import canceled.
+            </div>
+          )}
+
+          {desktopImport.status === "error" && (
+            <div className="csvDesktopImportStatus csvDesktopImportStatusError" role="alert">
+              {desktopImport.error ?? "Import failed."}
+            </div>
+          )}
+        </div>
+      )}
 
       {/* Hidden file input */}
       <input
@@ -109,4 +151,20 @@ export default function CsvFileControls({
       </div>
     </>
   );
+}
+
+/**
+ * Show the detected import fields in one short status line.
+ */
+function formatFieldList(fields) {
+  if (!fields) return "none";
+
+  return [
+    fields.latField,
+    fields.lonField,
+    fields.yearField,
+    fields.dateField,
+  ]
+    .filter(Boolean)
+    .join(" / ") || "none";
 }


### PR DESCRIPTION
## Summary

- Add a desktop-only SQLite import path for local CSV files
- Store dataset metadata, coordinates, timeline values, compact fields, and full row JSON
- Add the Electron preload/IPC bridge and desktop-only “Import to local SQLite” control
- Document the prototype schema, index direction, non-goals, and Electron native-module rebuild note

## Verification

- Manual desktop smoke test: imported `books.csv` with `2681` rows
- Confirmed SQLite DB at `C:\Users\erik\AppData\Roaming\app\csv-map-layer-visualizer.sqlite`
- Confirmed `1` dataset row and `2681` feature rows
- Confirmed timeline year and `row_json` are stored
- `npm run lint`
- `npm audit --audit-level=low`
- `npm run build`
- `npm run build:desktop`

Closes #81
