### PR TITLE
Add SQLite viewport query for desktop map rendering

### DIFF
--- a/desktop/main.cjs
+++ b/desktop/main.cjs
@@ -4,6 +4,7 @@ const { app, BrowserWindow, dialog, ipcMain, shell } = require("electron");
 const path = require("node:path");
 const { importCsvFileToSqlite } = require("./csvImportService.cjs");
 const { closeSqliteStore, openSqliteStore } = require("./sqliteStore.cjs");
+const { querySqliteMapView } = require("./sqliteViewportQuery.cjs");
 
 // The prototype DB lives in Electron userData, not inside the repository.
 const SQLITE_DB_FILE_NAME = "csv-map-layer-visualizer.sqlite";
@@ -44,6 +45,20 @@ function registerDesktopBridgeHandlers() {
       return importCsvFileToSqlite({
         db,
         filePath: fileResult.filePaths[0],
+      });
+    } finally {
+      closeSqliteStore(db);
+    }
+  });
+  ipcMain.handle("desktop:queryMapView", async (_event, query = {}) => {
+    const db = openSqliteStore(getDesktopDatabasePath());
+
+    try {
+      return querySqliteMapView({
+        db,
+        bounds: query?.bounds,
+        timeline: query?.timeline,
+        renderBudget: query?.renderBudget,
       });
     } finally {
       closeSqliteStore(db);

--- a/desktop/preload.cjs
+++ b/desktop/preload.cjs
@@ -7,4 +7,5 @@ contextBridge.exposeInMainWorld("csvMapDesktop", {
   isDesktop: true,
   getStatus: () => ipcRenderer.invoke("desktop:getStatus"),
   importCsvToSqlite: () => ipcRenderer.invoke("desktop:importCsvToSqlite"),
+  queryMapView: (query) => ipcRenderer.invoke("desktop:queryMapView", query),
 });

--- a/desktop/sqliteViewportQuery.cjs
+++ b/desktop/sqliteViewportQuery.cjs
@@ -1,0 +1,292 @@
+"use strict";
+
+const DEFAULT_RENDER_BUDGET = 1000;
+const MAX_RENDER_BUDGET = 10000;
+const DEFAULT_IMAGE_SIZE_METERS = 100;
+const MIN_IMAGE_SIZE_METERS = 1;
+const MAX_IMAGE_SIZE_METERS = 100000;
+
+/**
+ * Query compact point render data from the desktop SQLite store.
+ * This intentionally avoids row_json; full detail lookup belongs to a later issue.
+ */
+function querySqliteMapView({ db, bounds, timeline = null, renderBudget = DEFAULT_RENDER_BUDGET }) {
+  if (!db?.open) {
+    throw new TypeError("An open SQLite database is required.");
+  }
+
+  const normalizedBounds = normalizeBounds(bounds);
+  const budget = normalizeRenderBudget(renderBudget);
+
+  if (!normalizedBounds) {
+    return createEmptyMapViewResult({
+      limitedToRenderBudget: null,
+      totalMatchingCount: 0,
+      skippedPointsByTimeline: 0,
+    });
+  }
+
+  const filter = buildWhereClause({ bounds: normalizedBounds, timeline });
+  // Count first so the UI can explain how many matching datapoints are hidden by the render budget.
+  const totalMatchingCount = countMatchingFeatures(db, filter);
+  const boundsOnlyCount = filter.usesTimeline ? countMatchingFeatures(db, filter.boundsOnly) : totalMatchingCount;
+  const rows = selectMatchingFeatures(db, filter, budget);
+  const returnedCount = rows.length;
+  const hiddenByRenderBudget = Math.max(0, totalMatchingCount - returnedCount);
+  const skippedPointsByTimeline = Math.max(0, boundsOnlyCount - totalMatchingCount);
+
+  return {
+    points: rows.map(rowToPointFeature),
+    lines: [],
+    regions: [],
+    stats: {
+      skippedPoints: 0,
+      skippedLines: 0,
+      skippedRegions: 0,
+      skippedPointsByTimeline,
+      skippedLinesByTimeline: 0,
+      skippedRegionsByTimeline: 0,
+      skippedByTimeline: skippedPointsByTimeline,
+      limitedToRenderBudget: hiddenByRenderBudget > 0 ? budget : null,
+      totalMatchingCount,
+      returnedCount,
+      hiddenByRenderBudget,
+      overBudget: hiddenByRenderBudget > 0,
+    },
+    timelineIndex: {
+      entries: [],
+    },
+  };
+}
+
+function countMatchingFeatures(db, filter) {
+  const row = db.prepare(`SELECT COUNT(*) AS count FROM features ${filter.sql}`).get(filter.params);
+  return normalizeCount(row?.count);
+}
+
+function selectMatchingFeatures(db, filter, renderBudget) {
+  return db.prepare(`
+    SELECT
+      id,
+      dataset_id,
+      source_row_index,
+      lat,
+      lon,
+      timeline_start_year,
+      timeline_end_year,
+      compact_json
+    FROM features
+    ${filter.sql}
+    -- Keep the query order stable when the render budget hides part of the result set.
+    ORDER BY dataset_id, source_row_index
+    LIMIT @limit
+  `).all({
+    ...filter.params,
+    limit: renderBudget,
+  });
+}
+
+function buildWhereClause({ bounds, timeline }) {
+  const boundsFilter = buildBoundsFilter(bounds);
+  const timelineFilter = buildTimelineFilter(timeline);
+  const clauses = [...boundsFilter.clauses, ...timelineFilter.clauses];
+  const params = {
+    ...boundsFilter.params,
+    ...timelineFilter.params,
+  };
+
+  return {
+    sql: clauses.length > 0 ? `WHERE ${clauses.join(" AND ")}` : "",
+    params,
+    usesTimeline: timelineFilter.usesTimeline,
+    // Build the bounds-only filter once so skipped-by-timeline can stay cheap and consistent.
+    boundsOnly: {
+      sql: boundsFilter.clauses.length > 0 ? `WHERE ${boundsFilter.clauses.join(" AND ")}` : "",
+      params: boundsFilter.params,
+    },
+  };
+}
+
+function buildBoundsFilter(bounds) {
+  const clauses = ["lat BETWEEN @south AND @north"];
+  const params = {
+    north: bounds.north,
+    south: bounds.south,
+    east: bounds.east,
+    west: bounds.west,
+  };
+
+  // Leaflet can report wrapped viewports where west is greater than east.
+  if (bounds.crossesAntimeridian) {
+    clauses.push("(lon >= @west OR lon <= @east)");
+  } else {
+    clauses.push("lon BETWEEN @west AND @east");
+  }
+
+  return { clauses, params };
+}
+
+function buildTimelineFilter(timeline) {
+  if (!timeline?.timelineEnabled) {
+    return { clauses: [], params: {}, usesTimeline: false };
+  }
+
+  const startYear = normalizeYear(timeline.startYear);
+  const endYear = normalizeYear(timeline.endYear);
+
+  if (startYear == null || endYear == null) {
+    return { clauses: [], params: {}, usesTimeline: false };
+  }
+
+  return {
+    // Range overlap keeps multi-year rows visible when any part intersects the selected timeline.
+    clauses: [
+      "timeline_start_year IS NOT NULL",
+      "timeline_end_year IS NOT NULL",
+      "timeline_start_year <= @timelineEndYear",
+      "timeline_end_year >= @timelineStartYear",
+    ],
+    params: {
+      timelineStartYear: Math.min(startYear, endYear),
+      timelineEndYear: Math.max(startYear, endYear),
+    },
+    usesTimeline: true,
+  };
+}
+
+function rowToPointFeature(row) {
+  const compactFields = parseCompactFields(row.compact_json);
+
+  return {
+    id: String(row.id),
+    lat: Number(row.lat),
+    lon: Number(row.lon),
+    sourceRef: {
+      datasetId: String(row.dataset_id),
+      rowIndex: normalizeCount(row.source_row_index),
+    },
+    // Keep legacy refs available while the map popup code is still being migrated.
+    sourceFileId: String(row.dataset_id),
+    sourceRowIndex: normalizeCount(row.source_row_index),
+    marker: getNullableString(compactFields.marker),
+    image: getNullableString(compactFields.image),
+    imageWidthMeters: normalizeImageSizeMeters(compactFields.imageWidthMeters),
+    imageHeightMeters: normalizeImageSizeMeters(compactFields.imageHeightMeters),
+    latField: getNullableString(compactFields.latField),
+    lonField: getNullableString(compactFields.lonField),
+    compactFields,
+  };
+}
+
+function parseCompactFields(value) {
+  if (!value || typeof value !== "string") return {};
+
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function normalizeBounds(bounds) {
+  if (!bounds || typeof bounds !== "object") return null;
+
+  const north = normalizeLatitude(bounds.north);
+  const south = normalizeLatitude(bounds.south);
+  const east = normalizeLongitude(bounds.east);
+  const west = normalizeLongitude(bounds.west);
+
+  if (north == null || south == null || east == null || west == null) {
+    return null;
+  }
+
+  return {
+    north: Math.max(north, south),
+    south: Math.min(north, south),
+    east,
+    west,
+    crossesAntimeridian: west > east,
+  };
+}
+
+function normalizeLatitude(value) {
+  const number = Number(value);
+  if (!Number.isFinite(number)) return null;
+  return Math.max(-90, Math.min(90, number));
+}
+
+function normalizeLongitude(value) {
+  const number = Number(value);
+  if (!Number.isFinite(number)) return null;
+
+  if (number >= -180 && number <= 180) return number;
+
+  return ((((number + 180) % 360) + 360) % 360) - 180;
+}
+
+function normalizeImageSizeMeters(value) {
+  const number = Number(value);
+  if (!Number.isFinite(number)) return DEFAULT_IMAGE_SIZE_METERS;
+  return Math.min(MAX_IMAGE_SIZE_METERS, Math.max(MIN_IMAGE_SIZE_METERS, number));
+}
+function normalizeRenderBudget(value) {
+  const number = Number.parseInt(value, 10);
+  if (!Number.isFinite(number) || number <= 0) return DEFAULT_RENDER_BUDGET;
+  return Math.min(number, MAX_RENDER_BUDGET);
+}
+
+function normalizeYear(value) {
+  if (value === null || value === undefined || value === "") return null;
+
+  const number = Number(value);
+  if (!Number.isFinite(number)) return null;
+
+  return Math.trunc(number);
+}
+
+function normalizeCount(value) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : 0;
+}
+
+function getNullableString(value) {
+  if (value === null || value === undefined) return null;
+
+  const stringValue = String(value);
+  return stringValue.trim() ? stringValue : null;
+}
+
+function createEmptyMapViewResult({
+  limitedToRenderBudget,
+  totalMatchingCount,
+  skippedPointsByTimeline,
+}) {
+  return {
+    points: [],
+    lines: [],
+    regions: [],
+    stats: {
+      skippedPoints: 0,
+      skippedLines: 0,
+      skippedRegions: 0,
+      skippedPointsByTimeline,
+      skippedLinesByTimeline: 0,
+      skippedRegionsByTimeline: 0,
+      skippedByTimeline: skippedPointsByTimeline,
+      limitedToRenderBudget,
+      totalMatchingCount,
+      returnedCount: 0,
+      hiddenByRenderBudget: 0,
+      overBudget: false,
+    },
+    timelineIndex: {
+      entries: [],
+    },
+  };
+}
+
+module.exports = {
+  DEFAULT_RENDER_BUDGET,
+  querySqliteMapView,
+};

--- a/docs/sqlite-import-prototype.md
+++ b/docs/sqlite-import-prototype.md
@@ -1,6 +1,6 @@
 # SQLite Import Prototype
 
-Issue #81 adds the first desktop-only path for importing local CSV files into a SQLite-backed prototype store.
+Issue #81 adds the first desktop-only path for importing local CSV files into a SQLite-backed prototype store. Issue #82 adds the first SQLite-backed viewport query for rendering compact desktop map results.
 
 ## Runtime Boundary
 
@@ -11,8 +11,9 @@ The renderer talks to the desktop runtime through the narrow preload bridge:
 - `window.csvMapDesktop.isDesktop`
 - `window.csvMapDesktop.getStatus()`
 - `window.csvMapDesktop.importCsvToSqlite()`
+- `window.csvMapDesktop.queryMapView(query)`
 
-The renderer does not pass arbitrary IPC channel names, local file paths, or database paths. The Electron main process owns the file picker, database path, and SQLite import work.
+The renderer does not pass arbitrary IPC channel names, local file paths, SQL, or database paths. The Electron main process owns the file picker, database path, SQLite import work, and viewport query execution.
 
 ## Database Location
 
@@ -23,6 +24,7 @@ app.getPath("userData") / csv-map-layer-visualizer.sqlite
 ```
 
 This keeps imported local data outside the repository and outside the browser build output.
+
 ## Native Module Rebuild
 
 `better-sqlite3` is a native Node module. If Electron shows a `NODE_MODULE_VERSION` mismatch when importing, rebuild the module for the Electron runtime and restart the desktop app:
@@ -75,16 +77,37 @@ The prototype creates indexes for later issues:
 - `features(dataset_id, timeline_start_year, timeline_end_year)` for future timeline filtering
 - unique `features(dataset_id, source_row_index)` for stable row/detail lookup
 
-These indexes are not yet used for Leaflet rendering. They document and prove the storage direction needed by follow-up query work.
+These indexes support the desktop viewport query path.
+
+## Viewport Query
+
+Issue #82 adds a desktop-only SQLite viewport query that runs through the fixed Electron preload bridge. The browser and GitHub Pages path still use the in-memory CSV flow.
+
+The query uses the current map bounds, zoom, timeline state, and a render budget. It queries all imported SQLite datasets for now. Dataset selection, enable/disable controls, and delete/manage UI are future work.
+
+The first render budget is `1000`. If more datapoints match the current viewport/filter, the query returns the first `1000` compact point records and reports how many matching datapoints are hidden. The panel displays that as a status message, for example:
+
+```text
+9,500 datapoints are not being displayed
+```
+
+Viewport query results include compact marker/render data only:
+
+- stable id
+- latitude
+- longitude
+- source reference
+- marker/image fields when present in `compact_json`
+- coordinate field names when present in `compact_json`
+
+The viewport query does not read or return `row_json`. Full row details remain a separate lookup concern for later work.
 
 ## Non-Goals
 
 This prototype does not:
 
-- render SQLite-backed markers in Leaflet
-- implement viewport queries
 - add grouped or representative markers
-- add marker detail UI
+- add full marker detail lookup UI
 - add paged group rows
 - replace the browser/GitHub Pages CSV flow
 - support DuckDB, remote data sources, or unlimited CSV sizes

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,8 +16,10 @@ import { CsvPanelOverlay } from "./components/CsvPanelOverlay";
 import { useCsvFileDrop } from "./components/useCsvFileDrop";
 import { useExampleCsvFilesFromUrl } from "./components/useExampleCsvFilesFromUrl";
 import { useTimelinePlayback } from "./components/useTimelinePlayback";
+import { createDesktopSqliteDataSource } from "./data/desktopSqliteDataSource";
 
 const LARGE_RAW_MARKER_WARNING_THRESHOLD = 3000;
+const SQLITE_RENDER_BUDGET = 1000;
 
 export default function App() {
   /**
@@ -76,6 +78,20 @@ export default function App() {
     summary: null,
     error: null,
   });
+  const [mapViewport, setMapViewport] = useState(null);
+  const [desktopMapViewState, setDesktopMapViewState] = useState({
+    status: "idle",
+    result: null,
+    error: null,
+  });
+  const desktopSqliteMapAvailable =
+    desktopImportAvailable && typeof desktopApi?.queryMapView === "function";
+  const desktopSqliteMapActive =
+    desktopSqliteMapAvailable && desktopImportState.status === "imported";
+  const desktopSqliteDataSource = useMemo(
+    () => createDesktopSqliteDataSource({ desktopApi }),
+    [desktopApi],
+  );
 
   /**
    * Start the desktop-only SQLite import flow.
@@ -127,11 +143,57 @@ export default function App() {
     importCsvToSqlite,
   ]);
 
+  useEffect(() => {
+    if (!desktopSqliteMapActive || !mapViewport?.bounds) {
+      return undefined;
+    }
+
+    let canceled = false;
+
+    desktopSqliteDataSource.queryMapView({
+      bounds: mapViewport.bounds,
+      zoom: mapViewport.zoom ?? null,
+      timeline: timelineState,
+      renderBudget: SQLITE_RENDER_BUDGET,
+    }).then((result) => {
+      if (!canceled) {
+        setDesktopMapViewState({ status: "loaded", result, error: null });
+      }
+    }).catch((error) => {
+      if (!canceled) {
+        setDesktopMapViewState({
+          status: "error",
+          result: null,
+          error: error?.message ? String(error.message) : "Map query failed.",
+        });
+      }
+    });
+
+    return () => {
+      canceled = true;
+    };
+  }, [
+    desktopSqliteDataSource,
+    desktopSqliteMapActive,
+    mapViewport,
+    timelineState,
+  ]);
+
+  const desktopMapFeatures = useMemo(
+    () => toLegacyMapFeatures(desktopMapViewState.result),
+    [desktopMapViewState.result],
+  );
+  const activeMapFeatures = desktopSqliteMapActive && desktopMapViewState.result
+    ? desktopMapFeatures
+    : derivedMapFeatures;
+  const viewportQueryStats = desktopSqliteMapActive
+    ? desktopMapViewState.result?.stats ?? null
+    : null;
   const selectedHeaders = selected?.headers;
   const selectedRows = selected?.rows;
   const visibleMarkerPointCount = useMemo(
-    () => derivedMapFeatures.points.points.filter((point) => !point.image).length,
-    [derivedMapFeatures.points.points],
+    () => activeMapFeatures.points.points.filter((point) => !point.image).length,
+    [activeMapFeatures.points.points],
   );
 
   // Warn before disabling clustering when raw marker rendering is likely to be expensive.
@@ -249,12 +311,13 @@ export default function App() {
       )}
       <div className="rightPane">
         <GeoMap
-          points={derivedMapFeatures.points.points}
-          regions={derivedMapFeatures.regions.polygons}
-          lines={derivedMapFeatures.lines.lines}
-          getSourceRow={derivedMapFeatures.getSourceRow}
+          points={activeMapFeatures.points.points}
+          regions={activeMapFeatures.regions.polygons}
+          lines={activeMapFeatures.lines.lines}
+          getSourceRow={activeMapFeatures.getSourceRow}
           clusterMarkersEnabled={!!mapToolsApi.state.clusterMarkersEnabled}
           clusterRadius={mapToolsApi.state.clusterRadius}
+          onViewportChange={setMapViewport}
         />
 
         <CsvPanelOverlay>
@@ -264,6 +327,7 @@ export default function App() {
             onSelect={setSelectedId}
             onImportFiles={importFiles}
             desktopImport={desktopImport}
+            viewportQueryStats={viewportQueryStats}
             onUnloadSelected={unloadSelected}
             onUnloadFile={unloadFile}
             onToggleEnabled={updateFileEnabled}
@@ -275,9 +339,9 @@ export default function App() {
             onTimelinePlaybackStop={timelinePlaybackApi.stopPlayback}
             timelineStats={{
               skippedByTimeline:
-                (derivedMapFeatures.points.skippedByTimeline ?? 0) +
-                (derivedMapFeatures.regions.skippedByTimeline ?? 0) +
-                (derivedMapFeatures.lines.skippedByTimeline ?? 0),
+                (activeMapFeatures.points.skippedByTimeline ?? 0) +
+                (activeMapFeatures.regions.skippedByTimeline ?? 0) +
+                (activeMapFeatures.lines.skippedByTimeline ?? 0),
             }}
             mapToolsState={mapToolsApi.state}
             onMapToolsPatch={patchMapToolsWithSafeguards}
@@ -288,6 +352,28 @@ export default function App() {
   );
 }
 
+function toLegacyMapFeatures(mapView) {
+  return {
+    points: {
+      points: mapView?.points ?? [],
+      skipped: mapView?.stats?.skippedPoints ?? 0,
+      skippedByTimeline: mapView?.stats?.skippedPointsByTimeline ?? 0,
+    },
+    lines: {
+      lines: mapView?.lines ?? [],
+      skipped: mapView?.stats?.skippedLines ?? 0,
+      skippedByTimeline: mapView?.stats?.skippedLinesByTimeline ?? 0,
+    },
+    regions: {
+      polygons: mapView?.regions ?? [],
+      skipped: mapView?.stats?.skippedRegions ?? 0,
+      skippedByTimeline: mapView?.stats?.skippedRegionsByTimeline ?? 0,
+    },
+    getSourceRow: () => null,
+    timelineIndex: mapView?.timelineIndex ?? { entries: [] },
+    stats: mapView?.stats ?? null,
+  };
+}
 /**
  * Compute the year extent of a CSV row for timeline domain detection.
  *

--- a/src/components/CsvPanel.jsx
+++ b/src/components/CsvPanel.jsx
@@ -26,6 +26,7 @@ export default function CsvPanel({
   onSelect,         // Callback to change selected CSV
   onImportFiles,    // Callback to import new CSV files
   desktopImport,
+  viewportQueryStats,
   onUnloadFile,     // Callback to unload a CSV by ID
   onToggleEnabled,  // Callback to toggle file visibility
   onUpdateMapping,  // Callback when user changes latitude/longitude fields
@@ -150,6 +151,7 @@ export default function CsvPanel({
             onSelect={onSelect}
             onImportFiles={onImportFiles}
             desktopImport={desktopImport}
+            viewportQueryStats={viewportQueryStats}
             onUnloadFile={onUnloadFile}
             onToggleEnabled={onToggleEnabled}
           />

--- a/src/components/GeoMap.jsx
+++ b/src/components/GeoMap.jsx
@@ -239,7 +239,37 @@ function LineArrowDecorator({ line }) {
 
   return null;
 }
+function ViewportChangeReporter({ onViewportChange }) {
+  const map = useMap();
 
+  useEffect(() => {
+    if (typeof onViewportChange !== "function") return undefined;
+
+    const reportViewport = () => {
+      const bounds = map.getBounds();
+
+      onViewportChange({
+        bounds: {
+          north: bounds.getNorth(),
+          south: bounds.getSouth(),
+          east: bounds.getEast(),
+          west: bounds.getWest(),
+        },
+        zoom: map.getZoom(),
+      });
+    };
+
+    reportViewport();
+
+    map.on("moveend zoomend", reportViewport);
+
+    return () => {
+      map.off("moveend zoomend", reportViewport);
+    };
+  }, [map, onViewportChange]);
+
+  return null;
+}
 /**
  * Map tile providers.
  * We expose:
@@ -287,6 +317,7 @@ export default function GeoMap({
   getSourceRow,
   clusterMarkersEnabled = false,
   clusterRadius = 80,   // default strength
+  onViewportChange,
 }) {
   const { BaseLayer, Overlay } = LayersControl;
   const markerClusterGroupRef = useRef(null);
@@ -333,6 +364,8 @@ export default function GeoMap({
       }}
       zoomControl={false}
     >
+      <ViewportChangeReporter onViewportChange={onViewportChange} />
+
       {/* Zoom controls moved away from the CSV overlay */}
       <ZoomControl position="bottomright" />
 

--- a/src/components/csv-panel/CsvFileControls.jsx
+++ b/src/components/csv-panel/CsvFileControls.jsx
@@ -6,6 +6,7 @@ export default function CsvFileControls({
   onSelect,
   onImportFiles,
   desktopImport,
+  viewportQueryStats,
   onUnloadFile,
   onToggleEnabled,
 }) {
@@ -16,6 +17,7 @@ export default function CsvFileControls({
   const fileInputRef = useRef(null);
   const isDesktopImporting = desktopImport?.status === "importing";
   const desktopSummary = desktopImport?.summary ?? null;
+  const hiddenByRenderBudget = normalizeCount(viewportQueryStats?.hiddenByRenderBudget);
 
   /**
    * Trigger the hidden file input.
@@ -82,6 +84,12 @@ export default function CsvFileControls({
             </div>
           )}
 
+
+          {hiddenByRenderBudget > 0 && (
+            <div className="csvDesktopImportStatus" role="status">
+              {hiddenByRenderBudget.toLocaleString()} datapoints are not being displayed
+            </div>
+          )}
           {desktopImport.status === "error" && (
             <div className="csvDesktopImportStatus csvDesktopImportStatusError" role="alert">
               {desktopImport.error ?? "Import failed."}
@@ -167,4 +175,10 @@ function formatFieldList(fields) {
   ]
     .filter(Boolean)
     .join(" / ") || "none";
+}
+
+function normalizeCount(value) {
+  const number = Number(value);
+  if (!Number.isFinite(number)) return 0;
+  return Math.max(0, Math.trunc(number));
 }

--- a/src/data/desktopSqliteDataSource.js
+++ b/src/data/desktopSqliteDataSource.js
@@ -1,0 +1,153 @@
+const DEFAULT_SQLITE_RENDER_BUDGET = 1000;
+
+/**
+ * Renderer-side DataSource adapter for the Electron SQLite bridge.
+ * It keeps IPC details out of React components and preserves the app-facing contract.
+ */
+export function createDesktopSqliteDataSource({ desktopApi }) {
+  return {
+    async queryMapView(query = {}) {
+      if (typeof desktopApi?.queryMapView !== "function") {
+        return createEmptyMapViewResult();
+      }
+
+      const result = await desktopApi.queryMapView({
+        bounds: query.bounds ?? null,
+        zoom: query.zoom ?? null,
+        timeline: query.timeline ?? null,
+        renderBudget: query.renderBudget ?? DEFAULT_SQLITE_RENDER_BUDGET,
+      });
+
+      return normalizeMapViewResult(result);
+    },
+
+    getFeatureDetails(query = {}) {
+      return {
+        featureId: query.featureId ?? null,
+        row: null,
+        latField: null,
+        lonField: null,
+      };
+    },
+
+    getGroupRows(query = {}) {
+      const offset = normalizeNonNegativeInteger(query.offset, 0);
+      const limit = normalizeNonNegativeInteger(query.limit, 0);
+
+      return {
+        rows: [],
+        offset,
+        limit,
+        totalRows: null,
+      };
+    },
+
+    getDatasetSummary() {
+      return {
+        datasets: [],
+        timeline: null,
+      };
+    },
+  };
+}
+
+function normalizeMapViewResult(result) {
+  if (!result || typeof result !== "object") {
+    return createEmptyMapViewResult();
+  }
+
+  const points = Array.isArray(result.points) ? result.points : [];
+  const lines = Array.isArray(result.lines) ? result.lines : [];
+  const regions = Array.isArray(result.regions) ? result.regions : [];
+  const stats = normalizeStats(result.stats, points.length);
+  const timelineIndex = result.timelineIndex && typeof result.timelineIndex === "object"
+    ? result.timelineIndex
+    : { entries: [] };
+
+  return {
+    points,
+    lines,
+    regions,
+    stats,
+    timelineIndex: {
+      entries: Array.isArray(timelineIndex.entries) ? timelineIndex.entries : [],
+    },
+  };
+}
+
+function normalizeStats(stats, returnedCount) {
+  const normalizedStats = stats && typeof stats === "object" ? stats : {};
+  const totalMatchingCount = normalizeNonNegativeInteger(
+    normalizedStats.totalMatchingCount,
+    returnedCount,
+  );
+  const normalizedReturnedCount = normalizeNonNegativeInteger(
+    normalizedStats.returnedCount,
+    returnedCount,
+  );
+  const hiddenByRenderBudget = normalizeNonNegativeInteger(
+    normalizedStats.hiddenByRenderBudget,
+    Math.max(0, totalMatchingCount - normalizedReturnedCount),
+  );
+  const skippedPointsByTimeline = normalizeNonNegativeInteger(
+    normalizedStats.skippedPointsByTimeline,
+    0,
+  );
+  const skippedLinesByTimeline = normalizeNonNegativeInteger(
+    normalizedStats.skippedLinesByTimeline,
+    0,
+  );
+  const skippedRegionsByTimeline = normalizeNonNegativeInteger(
+    normalizedStats.skippedRegionsByTimeline,
+    0,
+  );
+
+  return {
+    skippedPoints: normalizeNonNegativeInteger(normalizedStats.skippedPoints, 0),
+    skippedLines: normalizeNonNegativeInteger(normalizedStats.skippedLines, 0),
+    skippedRegions: normalizeNonNegativeInteger(normalizedStats.skippedRegions, 0),
+    skippedPointsByTimeline,
+    skippedLinesByTimeline,
+    skippedRegionsByTimeline,
+    skippedByTimeline: normalizeNonNegativeInteger(
+      normalizedStats.skippedByTimeline,
+      skippedPointsByTimeline + skippedLinesByTimeline + skippedRegionsByTimeline,
+    ),
+    limitedToRenderBudget: normalizedStats.limitedToRenderBudget ?? null,
+    totalMatchingCount,
+    returnedCount: normalizedReturnedCount,
+    hiddenByRenderBudget,
+    overBudget: Boolean(normalizedStats.overBudget ?? hiddenByRenderBudget > 0),
+  };
+}
+
+function createEmptyMapViewResult() {
+  return {
+    points: [],
+    lines: [],
+    regions: [],
+    stats: {
+      skippedPoints: 0,
+      skippedLines: 0,
+      skippedRegions: 0,
+      skippedPointsByTimeline: 0,
+      skippedLinesByTimeline: 0,
+      skippedRegionsByTimeline: 0,
+      skippedByTimeline: 0,
+      limitedToRenderBudget: null,
+      totalMatchingCount: 0,
+      returnedCount: 0,
+      hiddenByRenderBudget: 0,
+      overBudget: false,
+    },
+    timelineIndex: {
+      entries: [],
+    },
+  };
+}
+
+function normalizeNonNegativeInteger(value, fallback) {
+  const number = Number(value);
+  if (!Number.isFinite(number)) return fallback;
+  return Math.max(0, Math.trunc(number));
+}


### PR DESCRIPTION
## Summary

This PR adds the first desktop-only SQLite viewport query path for issue #82.

It lets the Electron desktop app query compact map render data from the local SQLite store using the current map bounds, zoom, timeline filter, and a render budget. After a successful SQLite import, the map can render SQLite-backed points and update results when the viewport changes.

## Changes

- Add SQLite viewport query helper for compact point results
- Expose `queryMapView` through the fixed Electron preload bridge
- Add renderer-side SQLite DataSource adapter
- Track Leaflet map bounds and zoom
- Switch desktop SQLite mode to viewport query results after import
- Show hidden datapoint count when results exceed the `1000` render budget
- Update SQLite prototype docs

## Notes

- The query currently reads all imported SQLite datasets.
- Full row details are not returned by this query.
- Grouped/representative markers, paged rows, and dataset management remain future work.

## Verification

- [x] `git diff --check`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run build:desktop`
- [x] Manual desktop smoke test

Closes #82
