### PR TITLE
Add marker details and paged group row lookup

### DIFF
--- a/desktop/main.cjs
+++ b/desktop/main.cjs
@@ -6,6 +6,11 @@ const { importCsvFileToSqlite } = require("./csvImportService.cjs");
 const { closeSqliteStore, openSqliteStore } = require("./sqliteStore.cjs");
 const { querySqliteMapView } = require("./sqliteViewportQuery.cjs");
 
+const {
+  getSqliteFeatureDetails,
+  getSqliteGroupRows,
+} = require('./sqliteDetailQuery.cjs');
+
 // The prototype DB lives in Electron userData, not inside the repository.
 const SQLITE_DB_FILE_NAME = "csv-map-layer-visualizer.sqlite";
 
@@ -59,6 +64,33 @@ function registerDesktopBridgeHandlers() {
         bounds: query?.bounds,
         timeline: query?.timeline,
         renderBudget: query?.renderBudget,
+      });
+    } finally {
+      closeSqliteStore(db);
+    }
+  });
+  ipcMain.handle('desktop:getFeatureDetails', async (_event, query = {}) => {
+    // Keep SQLite access in the main process and return full rows only on demand.
+    const db = openSqliteStore(getDesktopDatabasePath());
+
+    try {
+      return getSqliteFeatureDetails({
+        db,
+        sourceRef: query?.sourceRef,
+      });
+    } finally {
+      closeSqliteStore(db);
+    }
+  });
+  ipcMain.handle('desktop:getGroupRows', async (_event, query = {}) => {
+    const db = openSqliteStore(getDesktopDatabasePath());
+
+    try {
+      return getSqliteGroupRows({
+        db,
+        groupRef: query?.groupRef,
+        offset: query?.offset,
+        limit: query?.limit,
       });
     } finally {
       closeSqliteStore(db);

--- a/desktop/preload.cjs
+++ b/desktop/preload.cjs
@@ -8,4 +8,7 @@ contextBridge.exposeInMainWorld("csvMapDesktop", {
   getStatus: () => ipcRenderer.invoke("desktop:getStatus"),
   importCsvToSqlite: () => ipcRenderer.invoke("desktop:importCsvToSqlite"),
   queryMapView: (query) => ipcRenderer.invoke("desktop:queryMapView", query),
+  // Expose structured lookup requests without exposing SQLite or raw SQL.
+  getFeatureDetails: (query) => ipcRenderer.invoke('desktop:getFeatureDetails', query),
+  getGroupRows: (query) => ipcRenderer.invoke('desktop:getGroupRows', query),
 });

--- a/desktop/sqliteDetailQuery.cjs
+++ b/desktop/sqliteDetailQuery.cjs
@@ -1,0 +1,320 @@
+'use strict';
+
+const DEFAULT_GROUP_ROWS_LIMIT = 30;
+const MAX_GROUP_ROWS_LIMIT = 100;
+const GROUP_ROWS_SORT_ORDER = 'dataset-source-row';
+
+/**
+ * Fetch the stored CSV row for one exact SQLite-backed marker.
+ */
+function getSqliteFeatureDetails({ db, sourceRef } = {}) {
+  assertOpenDatabase(db);
+
+  // Use the stored dataset and row position instead of a temporary map render ID.
+  const normalizedSourceRef = normalizeSourceRef(sourceRef);
+  if (!normalizedSourceRef) {
+    return createEmptyFeatureDetailsResult();
+  }
+
+  const storedFeature = db.prepare([
+    'SELECT id, compact_json, row_json',
+    'FROM features',
+    'WHERE dataset_id = @datasetId',
+    '  AND source_row_index = @rowIndex',
+    'LIMIT 1',
+  ].join('\n')).get(normalizedSourceRef);
+
+  if (!storedFeature) {
+    return createEmptyFeatureDetailsResult();
+  }
+
+  // Read the full CSV row only after the user asks to see marker details.
+  const compactFields = parseJsonObject(storedFeature.compact_json, {});
+
+  return {
+    featureId: String(storedFeature.id),
+    row: parseJsonObject(storedFeature.row_json, null),
+    latField: getNullableString(compactFields.latField),
+    lonField: getNullableString(compactFields.lonField),
+  };
+}
+
+/**
+ * Fetch one deterministic page of rows represented by a grouped marker.
+ */
+function getSqliteGroupRows({
+  db,
+  groupRef,
+  offset = 0,
+  limit = DEFAULT_GROUP_ROWS_LIMIT,
+} = {}) {
+  assertOpenDatabase(db);
+
+  const normalizedOffset = normalizeOffset(offset);
+  const normalizedLimit = normalizeLimit(limit);
+  const normalizedGroupRef = normalizeGroupRef(groupRef);
+
+  if (!normalizedGroupRef) {
+    return createEmptyGroupRowsResult(normalizedOffset, normalizedLimit);
+  }
+
+  // The count and page must use the same filter so the paging total stays correct.
+  const filter = buildGroupWhereClause(normalizedGroupRef);
+  const countRow = db.prepare([
+    'SELECT COUNT(*) AS count',
+    'FROM features',
+    filter.sql,
+  ].join('\n')).get(filter.params);
+  const totalRows = normalizeNonNegativeInteger(countRow?.count, 0);
+  const storedRows = db.prepare([
+    'SELECT row_json',
+    'FROM features',
+    filter.sql,
+    // A stable order prevents rows from moving between pages.
+    'ORDER BY dataset_id, source_row_index',
+    'LIMIT @limit',
+    'OFFSET @offset',
+  ].join('\n')).all({
+    ...filter.params,
+    limit: normalizedLimit,
+    offset: normalizedOffset,
+  });
+
+  return {
+    rows: storedRows.map((storedRow) => parseJsonObject(storedRow.row_json, {})),
+    offset: normalizedOffset,
+    limit: normalizedLimit,
+    totalRows,
+  };
+}
+
+function buildGroupWhereClause(groupRef) {
+  const { bounds, grid, timeline } = groupRef;
+  // Rebuild the original group from its viewport, grid cell, and timeline.
+  const clauses = [
+    'lat BETWEEN @south AND @north',
+    bounds.west > bounds.east
+      ? '(lon >= @west OR lon <= @east)'
+      : 'lon BETWEEN @west AND @east',
+    'CAST((lat + 90.0) / @cellHeight AS INTEGER) = @cellLat',
+    'CAST((lon + 180.0) / @cellWidth AS INTEGER) = @cellLon',
+  ];
+  const params = {
+    north: bounds.north,
+    south: bounds.south,
+    east: bounds.east,
+    west: bounds.west,
+    cellLat: grid.cellLat,
+    cellLon: grid.cellLon,
+    cellHeight: grid.cellHeight,
+    cellWidth: grid.cellWidth,
+  };
+
+  if (timeline) {
+    clauses.push(
+      'timeline_start_year IS NOT NULL',
+      'timeline_end_year IS NOT NULL',
+      'timeline_start_year <= @timelineEndYear',
+      'timeline_end_year >= @timelineStartYear',
+    );
+    params.timelineStartYear = timeline.startYear;
+    params.timelineEndYear = timeline.endYear;
+  }
+
+  return {
+    sql: 'WHERE ' + clauses.join(' AND '),
+    params,
+  };
+}
+
+function normalizeGroupRef(groupRef) {
+  if (!groupRef || typeof groupRef !== 'object') return null;
+
+  const bounds = normalizeBounds(groupRef.bounds);
+  const grid = normalizeGridRef(groupRef.grid);
+  const timeline = normalizeTimeline(groupRef.timeline);
+
+  if (!bounds || !grid || timeline === undefined) return null;
+  if (groupRef.sortOrder !== GROUP_ROWS_SORT_ORDER) return null;
+
+  // Reject mismatched IDs instead of accidentally running a wider query.
+  const expectedGroupId = ['grid', grid.cellLat, grid.cellLon].join(':');
+  if (groupRef.groupId !== expectedGroupId) return null;
+
+  return {
+    groupId: expectedGroupId,
+    bounds,
+    grid,
+    timeline,
+    sortOrder: GROUP_ROWS_SORT_ORDER,
+  };
+}
+
+function normalizeSourceRef(sourceRef) {
+  if (!sourceRef || typeof sourceRef !== 'object') return null;
+
+  const datasetId = getNullableString(sourceRef.datasetId);
+  const rowIndex = normalizeNonNegativeInteger(sourceRef.rowIndex, null);
+
+  if (!datasetId || rowIndex == null) return null;
+  return { datasetId, rowIndex };
+}
+
+function normalizeBounds(bounds) {
+  if (!bounds || typeof bounds !== 'object') return null;
+
+  const north = normalizeLatitude(bounds.north);
+  const south = normalizeLatitude(bounds.south);
+  const east = normalizeLongitude(bounds.east);
+  const west = normalizeLongitude(bounds.west);
+
+  if (north == null || south == null || east == null || west == null) {
+    return null;
+  }
+
+  return {
+    north: Math.max(north, south),
+    south: Math.min(north, south),
+    east,
+    west,
+  };
+}
+
+function normalizeGridRef(grid) {
+  if (!grid || typeof grid !== 'object') return null;
+
+  const cellLat = normalizeInteger(grid.cellLat);
+  const cellLon = normalizeInteger(grid.cellLon);
+  const cellHeight = normalizePositiveNumber(grid.cellHeight);
+  const cellWidth = normalizePositiveNumber(grid.cellWidth);
+
+  if (
+    cellLat == null ||
+    cellLon == null ||
+    cellHeight == null ||
+    cellWidth == null
+  ) {
+    return null;
+  }
+
+  return { cellLat, cellLon, cellHeight, cellWidth };
+}
+
+function normalizeTimeline(timeline) {
+  if (!timeline?.timelineEnabled) return null;
+
+  const startYear = normalizeInteger(timeline.startYear);
+  const endYear = normalizeInteger(timeline.endYear);
+  if (startYear == null || endYear == null) return undefined;
+
+  return {
+    timelineEnabled: true,
+    startYear: Math.min(startYear, endYear),
+    endYear: Math.max(startYear, endYear),
+  };
+}
+
+function normalizeLatitude(value) {
+  if (isBlankValue(value)) return null;
+
+  const number = Number(value);
+  if (!Number.isFinite(number)) return null;
+  return Math.max(-90, Math.min(90, number));
+}
+
+function normalizeLongitude(value) {
+  if (isBlankValue(value)) return null;
+
+  const number = Number(value);
+  if (!Number.isFinite(number)) return null;
+  if (number >= -180 && number <= 180) return number;
+  return ((((number + 180) % 360) + 360) % 360) - 180;
+}
+
+function normalizeInteger(value) {
+  if (isBlankValue(value)) return null;
+
+  const number = Number(value);
+  if (!Number.isFinite(number)) return null;
+  return Math.trunc(number);
+}
+
+function normalizePositiveNumber(value) {
+  const number = Number(value);
+  if (!Number.isFinite(number) || number <= 0) return null;
+  return number;
+}
+
+function normalizeOffset(value) {
+  return normalizeNonNegativeInteger(value, 0);
+}
+
+function normalizeLimit(value) {
+  const normalized = normalizeNonNegativeInteger(value, DEFAULT_GROUP_ROWS_LIMIT);
+  if (normalized <= 0) return DEFAULT_GROUP_ROWS_LIMIT;
+  return Math.min(normalized, MAX_GROUP_ROWS_LIMIT);
+}
+
+function normalizeNonNegativeInteger(value, fallback) {
+  if (isBlankValue(value)) return fallback;
+
+  const number = Number(value);
+  if (!Number.isFinite(number) || number < 0) return fallback;
+  return Math.trunc(number);
+}
+
+function isBlankValue(value) {
+  return value === null || value === undefined || value === '';
+}
+
+function parseJsonObject(value, fallback) {
+  if (!value || typeof value !== 'string') return fallback;
+
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? parsed
+      : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function getNullableString(value) {
+  if (value === null || value === undefined) return null;
+
+  const stringValue = String(value);
+  return stringValue.trim() ? stringValue : null;
+}
+
+function assertOpenDatabase(db) {
+  if (!db?.open) {
+    throw new TypeError('An open SQLite database is required.');
+  }
+}
+
+function createEmptyFeatureDetailsResult() {
+  return {
+    featureId: null,
+    row: null,
+    latField: null,
+    lonField: null,
+  };
+}
+
+function createEmptyGroupRowsResult(offset, limit) {
+  return {
+    rows: [],
+    offset,
+    limit,
+    totalRows: 0,
+  };
+}
+
+module.exports = {
+  DEFAULT_GROUP_ROWS_LIMIT,
+  GROUP_ROWS_SORT_ORDER,
+  MAX_GROUP_ROWS_LIMIT,
+  getSqliteFeatureDetails,
+  getSqliteGroupRows,
+};

--- a/desktop/sqliteDetailQuery.smoke.cjs
+++ b/desktop/sqliteDetailQuery.smoke.cjs
@@ -1,0 +1,303 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+
+const ELECTRON_SMOKE_CHILD = 'CSV_MAP_SQLITE_DETAIL_SMOKE_CHILD';
+const DATASET_A = 'detail-smoke-a';
+const DATASET_B = 'detail-smoke-b';
+
+function runSmokeCheck() {
+  const { closeSqliteStore } = require('./sqliteStore.cjs');
+  // Keep this smoke check isolated while using the same schema as the app.
+  const db = createSmokeDatabase();
+
+  try {
+    runExactDetailSmoke(db);
+    runGroupedPagingSmoke(db);
+    console.log('SQLite detail smoke: exact details and grouped paging passed.');
+  } finally {
+    closeSqliteStore(db);
+  }
+}
+
+function runExactDetailSmoke(db) {
+  const { getSqliteFeatureDetails } = require('./sqliteDetailQuery.cjs');
+  // The stable source reference should find the row across dataset boundaries.
+  const result = getSqliteFeatureDetails({
+    db,
+    sourceRef: {
+      datasetId: DATASET_B,
+      rowIndex: 0,
+    },
+  });
+
+  assert.deepEqual(result, {
+    featureId: 'detail-b-0',
+    row: {
+      name: 'match-three',
+      latitude: '1',
+      longitude: '1',
+    },
+    latField: 'latitude',
+    lonField: 'longitude',
+  });
+  assert.deepEqual(
+    getSqliteFeatureDetails({
+      db,
+      sourceRef: {
+        datasetId: DATASET_B,
+        rowIndex: 999,
+      },
+    }),
+    {
+      featureId: null,
+      row: null,
+      latField: null,
+      lonField: null,
+    },
+  );
+  assert.deepEqual(
+    getSqliteFeatureDetails({
+      db,
+      sourceRef: {
+        datasetId: DATASET_B,
+      },
+    }),
+    {
+      featureId: null,
+      row: null,
+      latField: null,
+      lonField: null,
+    },
+  );
+
+  console.log('SQLite detail smoke: stable exact lookup passed.');
+}
+
+function runGroupedPagingSmoke(db) {
+  const {
+    DEFAULT_GROUP_ROWS_LIMIT,
+    getSqliteGroupRows,
+  } = require('./sqliteDetailQuery.cjs');
+  // The fixture includes other dates and cells to prove the saved group filter.
+  const groupRef = {
+    groupId: 'grid:18:36',
+    bounds: {
+      north: 10,
+      south: 0,
+      east: 10,
+      west: 0,
+    },
+    timeline: {
+      timelineEnabled: true,
+      startYear: 2000,
+      endYear: 2005,
+    },
+    grid: {
+      cellLat: 18,
+      cellLon: 36,
+      cellHeight: 5,
+      cellWidth: 5,
+    },
+    sortOrder: 'dataset-source-row',
+  };
+  // Two pages also verify the fixed dataset and source-row ordering.
+  const firstPage = getSqliteGroupRows({
+    db,
+    groupRef,
+    offset: 0,
+    limit: 2,
+  });
+  const secondPage = getSqliteGroupRows({
+    db,
+    groupRef,
+    offset: 2,
+    limit: 2,
+  });
+
+  assert.deepEqual(firstPage, {
+    rows: [
+      {
+        name: 'match-one',
+        latitude: '1',
+        longitude: '1',
+      },
+      {
+        name: 'match-two',
+        latitude: '1',
+        longitude: '1',
+      },
+    ],
+    offset: 0,
+    limit: 2,
+    totalRows: 3,
+  });
+  assert.deepEqual(secondPage, {
+    rows: [
+      {
+        name: 'match-three',
+        latitude: '1',
+        longitude: '1',
+      },
+    ],
+    offset: 2,
+    limit: 2,
+    totalRows: 3,
+  });
+  assert.deepEqual(
+    getSqliteGroupRows({
+      db,
+      groupRef: {
+        ...groupRef,
+        groupId: 'grid:wrong',
+      },
+      offset: -1,
+      limit: 0,
+    }),
+    {
+      rows: [],
+      offset: 0,
+      limit: DEFAULT_GROUP_ROWS_LIMIT,
+      totalRows: 0,
+    },
+  );
+
+  console.log('SQLite detail smoke: deterministic timeline-aware paging passed.');
+}
+
+function createSmokeDatabase() {
+  const Database = require('better-sqlite3');
+  const { closeSqliteStore, initializeSchema } = require('./sqliteStore.cjs');
+  const db = new Database(':memory:');
+  const features = [
+    createFeature(DATASET_A, 0, 'excluded-before', 1, 1, 1980, 1990),
+    createFeature(DATASET_A, 1, 'match-one', 1, 1, 1995, 2001),
+    createFeature(DATASET_A, 2, 'match-two', 1, 1, 2003, 2003),
+    createFeature(DATASET_A, 3, 'other-cell', 6, 1, 2003, 2003),
+    createFeature(DATASET_B, 0, 'match-three', 1, 1, 2005, 2010),
+    createFeature(DATASET_B, 1, 'excluded-after', 1, 1, 2011, 2020),
+  ];
+
+  try {
+    initializeSchema(db);
+    insertDataset(db, DATASET_A, 4);
+    insertDataset(db, DATASET_B, 2);
+
+    const insertFeature = db.prepare([
+      'INSERT INTO features (',
+      '  id, dataset_id, source_row_index, lat, lon,',
+      '  timeline_start_year, timeline_end_year, compact_json, row_json',
+      ') VALUES (',
+      '  @id, @datasetId, @sourceRowIndex, @lat, @lon,',
+      '  @timelineStartYear, @timelineEndYear, @compactJson, @rowJson',
+      ')',
+    ].join('\n'));
+    const insertFeatures = db.transaction((rows) => {
+      rows.forEach((feature) => insertFeature.run(feature));
+    });
+
+    insertFeatures(features);
+    return db;
+  } catch (error) {
+    closeSqliteStore(db);
+    throw error;
+  }
+}
+
+function insertDataset(db, datasetId, rowCount) {
+  db.prepare([
+    'INSERT INTO datasets (',
+    '  id, file_name, source_path, row_count, imported_feature_count,',
+    '  skipped_row_count, columns_json, imported_at',
+    ') VALUES (',
+    '  @id, @fileName, NULL, @rowCount, @rowCount,',
+    '  0, @columnsJson, @importedAt',
+    ')',
+  ].join('\n')).run({
+    id: datasetId,
+    fileName: datasetId + '.csv',
+    rowCount,
+    columnsJson: JSON.stringify(['name', 'latitude', 'longitude']),
+    importedAt: '2026-01-01T00:00:00.000Z',
+  });
+}
+
+function createFeature(
+  datasetId,
+  sourceRowIndex,
+  name,
+  lat,
+  lon,
+  timelineStartYear,
+  timelineEndYear,
+) {
+  return {
+    id: datasetId === DATASET_A
+      ? 'detail-a-' + sourceRowIndex
+      : 'detail-b-' + sourceRowIndex,
+    datasetId,
+    sourceRowIndex,
+    lat,
+    lon,
+    timelineStartYear,
+    timelineEndYear,
+    compactJson: JSON.stringify({
+      latField: 'latitude',
+      lonField: 'longitude',
+    }),
+    rowJson: JSON.stringify({
+      name,
+      latitude: String(lat),
+      longitude: String(lon),
+    }),
+  };
+}
+
+function runInElectronNode() {
+  const electronPath = require('electron');
+  // Run with Electron's Node ABI because better-sqlite3 is built for Electron.
+  const result = spawnSync(electronPath, [__filename], {
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      ELECTRON_RUN_AS_NODE: '1',
+      [ELECTRON_SMOKE_CHILD]: '1',
+    },
+    windowsHide: true,
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (result.signal) {
+    throw new Error(
+      'Electron detail smoke process stopped by signal ' + result.signal + '.',
+    );
+  }
+
+  process.exitCode = result.status ?? 1;
+}
+
+function main() {
+  try {
+    if (process.env[ELECTRON_SMOKE_CHILD] !== '1') {
+      runInElectronNode();
+      return;
+    }
+
+    if (!process.versions.electron) {
+      throw new Error(
+        'SQLite detail smoke check did not start in Electron Node mode.',
+      );
+    }
+
+    runSmokeCheck();
+  } catch (error) {
+    console.error('SQLite detail smoke check failed.', error);
+    process.exitCode = 1;
+  }
+}
+
+main();

--- a/desktop/sqliteViewportQuery.cjs
+++ b/desktop/sqliteViewportQuery.cjs
@@ -8,7 +8,7 @@ const MAX_IMAGE_SIZE_METERS = 100000;
 
 /**
  * Query compact point render data from the desktop SQLite store.
- * This intentionally avoids row_json; full detail lookup belongs to a later issue.
+ * This intentionally avoids row_json; full details use a separate lookup path.
  */
 function querySqliteMapView({ db, bounds, timeline = null, renderBudget = DEFAULT_RENDER_BUDGET }) {
   if (!db?.open) {
@@ -32,11 +32,19 @@ function querySqliteMapView({ db, bounds, timeline = null, renderBudget = DEFAUL
   const boundsOnlyCount = filter.usesTimeline ? countMatchingFeatures(db, filter.boundsOnly) : totalMatchingCount;
   const skippedPointsByTimeline = Math.max(0, boundsOnlyCount - totalMatchingCount);
   const overBudget = totalMatchingCount > budget;
+  // Save the same grid used for rendering so detail paging can reproduce each group.
+  const groupGrid = overBudget ? getGridSpec(normalizedBounds, budget) : null;
   // Under budget stays exact; over budget switches to compact render summaries.
   const rows = overBudget
-    ? selectGroupedFeatures(db, filter, normalizedBounds, budget)
+    ? selectGroupedFeatures(db, filter, groupGrid, budget)
     : selectMatchingFeatures(db, filter, budget);
-  const points = rows.map(overBudget ? rowToGroupedPointFeature : rowToPointFeature);
+  const points = overBudget
+    ? rows.map((row) => rowToGroupedPointFeature(row, {
+      bounds: normalizedBounds,
+      timeline: filter.timeline,
+      grid: groupGrid,
+    }))
+    : rows.map(rowToPointFeature);
   const returnedCount = points.length;
   const representedCount = overBudget
     ? points.reduce((sum, point) => sum + normalizeCount(point.count), 0)
@@ -98,9 +106,7 @@ function selectMatchingFeatures(db, filter, renderBudget) {
  * Return one compact render item per occupied grid cell for dense viewport results.
  * Reuses the already-built bounds/timeline filter so grouping happens after filtering.
  */
-function selectGroupedFeatures(db, filter, bounds, renderBudget) {
-  const grid = getGridSpec(bounds, renderBudget);
-
+function selectGroupedFeatures(db, filter, grid, renderBudget) {
   return db.prepare(`
     WITH matching AS (
       SELECT
@@ -192,6 +198,7 @@ function buildWhereClause({ bounds, timeline }) {
     sql: clauses.length > 0 ? `WHERE ${clauses.join(" AND ")}` : "",
     params,
     usesTimeline: timelineFilter.usesTimeline,
+    timeline: timelineFilter.timeline,
     // Build the bounds-only filter once so skipped-by-timeline can stay cheap and consistent.
     boundsOnly: {
       sql: boundsFilter.clauses.length > 0 ? `WHERE ${boundsFilter.clauses.join(" AND ")}` : "",
@@ -221,14 +228,14 @@ function buildBoundsFilter(bounds) {
 
 function buildTimelineFilter(timeline) {
   if (!timeline?.timelineEnabled) {
-    return { clauses: [], params: {}, usesTimeline: false };
+    return { clauses: [], params: {}, usesTimeline: false, timeline: null };
   }
 
   const startYear = normalizeYear(timeline.startYear);
   const endYear = normalizeYear(timeline.endYear);
 
   if (startYear == null || endYear == null) {
-    return { clauses: [], params: {}, usesTimeline: false };
+    return { clauses: [], params: {}, usesTimeline: false, timeline: null };
   }
 
   return {
@@ -244,6 +251,11 @@ function buildTimelineFilter(timeline) {
       timelineEndYear: Math.max(startYear, endYear),
     },
     usesTimeline: true,
+    timeline: {
+      timelineEnabled: true,
+      startYear: Math.min(startYear, endYear),
+      endYear: Math.max(startYear, endYear),
+    },
   };
 }
 
@@ -276,9 +288,9 @@ function rowToPointFeature(row) {
 
 /**
  * Convert one grouped SQL row into compact map render data only.
- * Full row/details stay out of grouped results until the later detail/group-row work.
+ * Full rows stay out of render results; groupRef supports separate paged lookup.
  */
-function rowToGroupedPointFeature(row) {
+function rowToGroupedPointFeature(row, { bounds, timeline, grid }) {
   const compactFields = parseCompactFields(row.compact_json);
   const count = Math.max(1, normalizeCount(row.group_count));
   const groupId = `grid:${row.cell_lat}:${row.cell_lon}`;
@@ -290,6 +302,24 @@ function rowToGroupedPointFeature(row) {
     lon: Number(row.group_lon),
     count,
     groupId,
+    // Capture the originating query so later paging cannot drift with current UI state.
+    groupRef: {
+      groupId,
+      bounds: {
+        north: bounds.north,
+        south: bounds.south,
+        east: bounds.east,
+        west: bounds.west,
+      },
+      timeline,
+      grid: {
+        cellLat: normalizeCount(row.cell_lat),
+        cellLon: normalizeCount(row.cell_lon),
+        cellHeight: grid.cellHeight,
+        cellWidth: grid.cellWidth,
+      },
+      sortOrder: 'dataset-source-row',
+    },
     sourceRef: null,
     marker: getNullableString(compactFields.marker),
     image: null,

--- a/desktop/sqliteViewportQuery.smoke.cjs
+++ b/desktop/sqliteViewportQuery.smoke.cjs
@@ -95,6 +95,10 @@ function runUnderBudgetExactSmoke() {
     assert.equal(result.stats.overBudget, false);
     assert.equal(result.stats.limitedToRenderBudget, null);
     assert.equal(result.stats.hiddenByRenderBudget, 0);
+    assert.equal(
+      Object.prototype.hasOwnProperty.call(result.points[0], 'groupRef'),
+      false,
+    );
 
     console.log("SQLite viewport smoke: under-budget exact results passed.");
   } finally {
@@ -188,6 +192,52 @@ function runOverBudgetGroupingSmoke() {
     assert.equal(result.stats.overBudget, true);
     assert.equal(result.stats.limitedToRenderBudget, 3);
     assert.equal(result.stats.hiddenByRenderBudget, 0);
+    assert.deepEqual(
+      result.points.map((point) => point.groupRef),
+      [
+        {
+          groupId: 'grid:18:36',
+          bounds: {
+            north: 10,
+            south: 0,
+            east: 10,
+            west: 0,
+          },
+          timeline: null,
+          grid: {
+            cellLat: 18,
+            cellLon: 36,
+            cellHeight: 5,
+            cellWidth: 5,
+          },
+          sortOrder: 'dataset-source-row',
+        },
+        {
+          groupId: 'grid:19:37',
+          bounds: {
+            north: 10,
+            south: 0,
+            east: 10,
+            west: 0,
+          },
+          timeline: null,
+          grid: {
+            cellLat: 19,
+            cellLon: 37,
+            cellHeight: 5,
+            cellWidth: 5,
+          },
+          sortOrder: 'dataset-source-row',
+        },
+      ],
+    );
+    const { getSqliteGroupRows } = require('./sqliteDetailQuery.cjs');
+    assert.deepEqual(
+      result.points.map((point) => (
+        getSqliteGroupRows({ db, groupRef: point.groupRef }).totalRows
+      )),
+      [3, 1],
+    );
     assert.equal(
       result.points.reduce((sum, point) => sum + point.count, 0),
       4,
@@ -290,6 +340,35 @@ function runTimelineBeforeGroupingSmoke() {
     assert.equal(result.stats.overBudget, true);
     assert.equal(result.stats.limitedToRenderBudget, 2);
     assert.equal(result.stats.hiddenByRenderBudget, 0);
+    assert.deepEqual(result.points[0].groupRef, {
+      groupId: 'grid:9:36',
+      bounds: {
+        north: 10,
+        south: 0,
+        east: 10,
+        west: 0,
+      },
+      timeline: {
+        timelineEnabled: true,
+        startYear: 2000,
+        endYear: 2005,
+      },
+      grid: {
+        cellLat: 9,
+        cellLon: 36,
+        cellHeight: 10,
+        cellWidth: 5,
+      },
+      sortOrder: 'dataset-source-row',
+    });
+    const { getSqliteGroupRows } = require('./sqliteDetailQuery.cjs');
+    assert.equal(
+      getSqliteGroupRows({
+        db,
+        groupRef: result.points[0].groupRef,
+      }).totalRows,
+      3,
+    );
 
     console.log("SQLite viewport smoke: timeline filtering before grouping passed.");
   } finally {

--- a/docs/sqlite-import-prototype.md
+++ b/docs/sqlite-import-prototype.md
@@ -1,6 +1,6 @@
 # SQLite Import Prototype
 
-Issue #81 adds the first desktop-only path for importing local CSV files into a SQLite-backed prototype store. Issue #82 adds the first SQLite-backed viewport query for rendering compact desktop map results.
+Issue #81 adds the desktop SQLite import path, issue #82 adds viewport querying, issue #83 adds grouped render results, and issue #84 adds on-demand marker details and paged group rows. Issue #90 provides repeatable viewport smoke coverage.
 
 ## Runtime Boundary
 
@@ -12,6 +12,8 @@ The renderer talks to the desktop runtime through the narrow preload bridge:
 - `window.csvMapDesktop.getStatus()`
 - `window.csvMapDesktop.importCsvToSqlite()`
 - `window.csvMapDesktop.queryMapView(query)`
+- `window.csvMapDesktop.getFeatureDetails(query)`
+- `window.csvMapDesktop.getGroupRows(query)`
 
 The renderer does not pass arbitrary IPC channel names, local file paths, SQL, or database paths. The Electron main process owns the file picker, database path, SQLite import work, and viewport query execution.
 
@@ -85,32 +87,41 @@ Issue #82 adds a desktop-only SQLite viewport query that runs through the fixed 
 
 The query uses the current map bounds, zoom, timeline state, and a render budget. It queries all imported SQLite datasets for now. Dataset selection, enable/disable controls, and delete/manage UI are future work.
 
-The first render budget is `1000`. If more datapoints match the current viewport/filter, the query returns the first `1000` compact point records and reports how many matching datapoints are hidden. The panel displays that as a status message, for example:
-
-```text
-9,500 datapoints are not being displayed
-```
+The render budget is `1000`. Under-budget results return exact compact points. Over-budget results return deterministic grouped or representative points produced after the bounds and timeline filters are applied.
 
 Viewport query results include compact marker/render data only:
 
 - stable id
 - latitude
 - longitude
-- source reference
+- source reference for exact points
+- group id, count, and compact lookup context for grouped results
 - marker/image fields when present in `compact_json`
 - coordinate field names when present in `compact_json`
 
-The viewport query does not read or return `row_json`. Full row details remain a separate lookup concern for later work.
+The viewport query does not read or return `row_json`. Exact details and group rows are fetched separately only after the user opens a marker popup.
 
-## SQLite Viewport Smoke Check
+## On-Demand Marker Details and Group Rows
+
+Issue #84 adds two desktop-only lookup paths:
+
+- `getFeatureDetails(query)` reads one full row by stable dataset id and source row index.
+- `getGroupRows(query)` reads one deterministic page of rows represented by a grouped marker.
+
+Grouped viewport results carry a compact `groupRef` with the originating bounds, normalized timeline filter, grid cell identity and dimensions, and fixed dataset/source-row ordering. Paging reuses this captured context instead of the current map state.
+
+The first group page contains 30 rows. The grouped popup can request another 30 rows with `Show 30 more` until all matching rows are loaded. Full rows remain separate from the marker render result and React only stores details for the popup the user opened.
+
+## SQLite Query Smoke Checks
 
 Issue #90 adds a repeatable check for the SQLite viewport query path:
 
 ```bash
 npm run smoke:sqlite-viewport
+npm run smoke:sqlite-detail
 ```
 
-The smoke script creates isolated in-memory SQLite databases and calls `querySqliteMapView(...)` directly. It does not open the Electron UI or read from or modify the app database under `userData`.
+The smoke scripts create isolated in-memory SQLite databases. The viewport suite calls `querySqliteMapView(...)`, while the detail suite calls the exact and grouped lookup functions directly. Neither suite opens the Electron UI or reads from or modifies the app database under `userData`.
 
 The current scenarios cover:
 
@@ -119,17 +130,29 @@ The current scenarios cover:
 - grouped counts and deterministic representative marker selection
 - timeline filtering before grouped result generation
 - compact render results that do not expose `row_json` or full row/detail fields
+- exact detail lookup by stable source reference
+- missing detail rows
+- deterministic group paging across datasets
+- group paging with the originating timeline filter
+- invalid lookup context and paging input
 
-The npm command starts with the local Node runtime, then the script relaunches itself in Electron's Node mode before loading `better-sqlite3`. This keeps the native module on the same ABI as the desktop app. If the native module has an ABI mismatch, use the Electron rebuild command in [Native Module Rebuild](#native-module-rebuild).
+Each npm command starts with the local Node runtime, then its script relaunches itself in Electron's Node mode before loading `better-sqlite3`. This keeps the native module on the same ABI as the desktop app. If the native module has an ABI mismatch, use the Electron rebuild command in [Native Module Rebuild](#native-module-rebuild).
 
-To extend the smoke coverage, add another isolated fixture and assertion function in `desktop/sqliteViewportQuery.smoke.cjs`. Keep the full-row sentinel assertion for new viewport result shapes so detail data does not enter the render query by accident.
+To extend the smoke coverage, add an isolated fixture and assertion to the relevant viewport or detail smoke file. Keep the full-row sentinel assertion for new viewport result shapes so detail data does not enter the render query by accident.
+
+## Manual Acceptance Check
+
+Use `npm run desktop:start` with one small CSV and one dense CSV containing more than 30 points in a group:
+
+1. Open an exact marker and confirm its original row fields load.
+2. Open a grouped marker and confirm the first page reports up to 30 represented rows.
+3. Expand several rows, select `Show 30 more`, and confirm the next page appends without duplicates.
+4. Enable a timeline range and confirm grouped detail counts and rows use that same range.
+5. Load a CSV through the normal browser flow and confirm its existing marker popup still works.
 
 ## Non-Goals
 
 This prototype does not:
 
-- add grouped or representative markers
-- add full marker detail lookup UI
-- add paged group rows
 - replace the browser/GitHub Pages CSV flow
 - support DuckDB, remote data sources, or unlimited CSV sizes

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "desktop:dev": "concurrently -k \"npm run dev -- --host 127.0.0.1\" \"wait-on http://127.0.0.1:5173 && node desktop/run-electron.cjs . --dev-server=http://127.0.0.1:5173\"",
     "desktop:start": "npm run build:desktop && node desktop/run-electron.cjs .",
     "smoke:sqlite-viewport": "node desktop/sqliteViewportQuery.smoke.cjs",
+    "smoke:sqlite-detail": "node desktop/sqliteDetailQuery.smoke.cjs",
     "lint": "eslint .",
     "preview": "vite preview"
   },

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -189,6 +189,21 @@ export default function App() {
   const viewportQueryStats = desktopSqliteMapActive
     ? desktopMapViewState.result?.stats ?? null
     : null;
+  // Detail loaders are desktop-only, so browser and in-memory maps keep their old path.
+  const getDesktopFeatureDetails = useCallback(
+    (query) => desktopSqliteDataSource.getFeatureDetails(query),
+    [desktopSqliteDataSource],
+  );
+  const activeFeatureDetailsLoader = desktopSqliteMapActive
+    ? getDesktopFeatureDetails
+    : null;
+  const getDesktopGroupRows = useCallback(
+    (query) => desktopSqliteDataSource.getGroupRows(query),
+    [desktopSqliteDataSource],
+  );
+  const activeGroupRowsLoader = desktopSqliteMapActive
+    ? getDesktopGroupRows
+    : null;
   const selectedHeaders = selected?.headers;
   const selectedRows = selected?.rows;
   const visibleMarkerPointCount = useMemo(
@@ -315,6 +330,8 @@ export default function App() {
           regions={activeMapFeatures.regions.polygons}
           lines={activeMapFeatures.lines.lines}
           getSourceRow={activeMapFeatures.getSourceRow}
+          getFeatureDetails={activeFeatureDetailsLoader}
+          getGroupRows={activeGroupRowsLoader}
           clusterMarkersEnabled={!!mapToolsApi.state.clusterMarkersEnabled}
           clusterRadius={mapToolsApi.state.clusterRadius}
           onViewportChange={setMapViewport}

--- a/src/components/GeoMap.jsx
+++ b/src/components/GeoMap.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from "react";
+import { useCallback, useState } from 'react';
 // Import core components from react-leaflet.
 // MapContainer is the main map wrapper.
 // TileLayer is used to load map tiles (images).
@@ -25,6 +26,8 @@ import L from "leaflet";
 import "leaflet-polylinedecorator";
 
 import { getClusterMarkerIcon, getMarkerIcon } from "./markerIcons";
+
+import { DEFAULT_GROUP_ROWS_LIMIT } from '../data/dataSource';
 
 /**
  * Build a list of fields to show in the popup.
@@ -56,11 +59,66 @@ function getFeaturePopupRow(feature, getSourceRow) {
   return feature?.row ?? getSourceRow?.(feature?.sourceFileId, feature?.sourceRowIndex) ?? null;
 }
 
-function renderPointPopup(p, latField, lonField, getSourceRow) {
-  const row = getFeaturePopupRow(p, getSourceRow);
+function PointPopup({
+  point: p,
+  latField,
+  lonField,
+  getSourceRow,
+  getFeatureDetails,
+}) {
+  const requestVersionRef = useRef(0);
+  const [detailState, setDetailState] = useState({
+    status: 'idle',
+    details: null,
+  });
+  const shouldLoadDetails =
+    typeof getFeatureDetails === 'function' && !!p?.sourceRef;
+  const synchronousRow = getFeaturePopupRow(p, getSourceRow);
+  const row = shouldLoadDetails
+    ? detailState.details?.row ?? null
+    : synchronousRow;
+  const resolvedLatField = detailState.details?.latField ?? latField;
+  const resolvedLonField = detailState.details?.lonField ?? lonField;
+
+  const handlePopupOpen = useCallback(() => {
+    if (!shouldLoadDetails) return;
+
+    const requestVersion = requestVersionRef.current + 1;
+    requestVersionRef.current = requestVersion;
+    setDetailState({ status: 'loading', details: null });
+
+    Promise.resolve(getFeatureDetails({
+      featureId: p.id,
+      sourceRef: p.sourceRef,
+    })).then((details) => {
+      if (requestVersionRef.current !== requestVersion) return;
+
+      setDetailState({
+        status: details?.row ? 'loaded' : 'empty',
+        details: details?.row ? details : null,
+      });
+    }).catch(() => {
+      if (requestVersionRef.current !== requestVersion) return;
+      setDetailState({ status: 'error', details: null });
+    });
+  }, [getFeatureDetails, p.id, p.sourceRef, shouldLoadDetails]);
+
+  const handlePopupClose = useCallback(() => {
+    // Ignore a late reply if this popup closes before its request finishes.
+    requestVersionRef.current += 1;
+  }, []);
+
+  useEffect(() => () => {
+    requestVersionRef.current += 1;
+  }, []);
 
   return (
-    <Popup>
+    <Popup
+      eventHandlers={{
+        add: handlePopupOpen,
+        remove: handlePopupClose,
+      }}
+    >
       <div style={{ minWidth: 220 }}>
         <div style={{ fontWeight: 700, marginBottom: 6 }}>Point</div>
 
@@ -74,7 +132,20 @@ function renderPointPopup(p, latField, lonField, getSourceRow) {
 
         <hr style={{ opacity: 0.25 }} />
 
-        {buildPopupFields(row, latField, lonField).map(([k, v]) => (
+        {shouldLoadDetails && (
+          detailState.status === 'idle' || detailState.status === 'loading'
+        ) && (
+          <div>Loading details...</div>
+        )}
+        {shouldLoadDetails && detailState.status === 'empty' && (
+          <div>No details found.</div>
+        )}
+        {shouldLoadDetails && detailState.status === 'error' && (
+          <div>Could not load details.</div>
+        )}
+
+        {(!shouldLoadDetails || detailState.status === 'loaded') &&
+        buildPopupFields(row, resolvedLatField, resolvedLonField).map(([k, v]) => (
           <div key={k} style={{ marginBottom: 4 }}>
             <b>{k}:</b> {String(v ?? "")}
           </div>
@@ -85,16 +156,99 @@ function renderPointPopup(p, latField, lonField, getSourceRow) {
 }
 
 /**
- * Grouped SQLite results are render summaries, so their popup stays summary-only.
+ * Load backing SQLite rows only after a grouped marker popup opens.
  */
-function renderGroupedPointPopup(p) {
+function GroupedPointPopup({ point: p, getGroupRows }) {
+  const requestVersionRef = useRef(0);
+  const [pagingState, setPagingState] = useState({
+    status: 'idle',
+    rows: [],
+    totalRows: null,
+    error: null,
+  });
+  const canLoadGroupRows =
+    typeof getGroupRows === 'function' && !!p?.groupRef;
+
+  const loadPage = useCallback((offset, replaceRows) => {
+    if (!canLoadGroupRows) return;
+
+    // groupRef keeps every page tied to the group created by the original query.
+    const requestVersion = requestVersionRef.current + 1;
+    requestVersionRef.current = requestVersion;
+    setPagingState((previous) => ({
+      ...previous,
+      status: offset === 0 ? 'loading' : 'loading-more',
+      rows: replaceRows ? [] : previous.rows,
+      totalRows: replaceRows ? null : previous.totalRows,
+      error: null,
+    }));
+
+    Promise.resolve(getGroupRows({
+      groupRef: p.groupRef,
+      offset,
+      limit: DEFAULT_GROUP_ROWS_LIMIT,
+    })).then((result) => {
+      if (requestVersionRef.current !== requestVersion) return;
+
+      const pageRows = Array.isArray(result?.rows) ? result.rows : [];
+      setPagingState((previous) => {
+        // Opening starts a fresh list; "Show more" appends the next stable page.
+        const rows = replaceRows
+          ? pageRows
+          : [...previous.rows, ...pageRows];
+
+        return {
+          status: 'loaded',
+          rows,
+          totalRows: result?.totalRows ?? rows.length,
+          error: null,
+        };
+      });
+    }).catch(() => {
+      if (requestVersionRef.current !== requestVersion) return;
+
+      setPagingState((previous) => ({
+        ...previous,
+        status: previous.rows.length > 0 ? 'loaded' : 'error',
+        error: 'Could not load group rows.',
+      }));
+    });
+  }, [canLoadGroupRows, getGroupRows, p.groupRef]);
+
+  const handlePopupOpen = useCallback(() => {
+    loadPage(0, true);
+  }, [loadPage]);
+
+  const handlePopupClose = useCallback(() => {
+    requestVersionRef.current += 1;
+  }, []);
+
+  const handleShowMore = useCallback((event) => {
+    event.stopPropagation();
+    loadPage(pagingState.rows.length, false);
+  }, [loadPage, pagingState.rows.length]);
+
+  useEffect(() => () => {
+    requestVersionRef.current += 1;
+  }, []);
+
+  const canShowMore =
+    canLoadGroupRows &&
+    pagingState.totalRows != null &&
+    pagingState.rows.length < pagingState.totalRows;
   const title = p.renderType === "representative"
     ? "Representative marker"
     : "Grouped markers";
 
   return (
-    <Popup>
-      <div style={{ minWidth: 220 }}>
+    <Popup
+      maxWidth={460}
+      eventHandlers={{
+        add: handlePopupOpen,
+        remove: handlePopupClose,
+      }}
+    >
+      <div style={{ minWidth: 280, maxWidth: 420 }}>
         <div style={{ fontWeight: 700, marginBottom: 6 }}>{title}</div>
         <div>
           <b>count:</b> {p.count ?? 1}
@@ -105,6 +259,74 @@ function renderGroupedPointPopup(p) {
         <div>
           <b>lon:</b> {p.lon}
         </div>
+
+        {canLoadGroupRows && (
+          <div
+            style={{
+              borderTop: '1px solid rgba(0, 0, 0, 0.15)',
+              marginTop: 8,
+              paddingTop: 8,
+            }}
+          >
+            {(pagingState.status === 'idle' ||
+              pagingState.status === 'loading') && (
+              <div>Loading rows...</div>
+            )}
+            {pagingState.status === 'error' && (
+              <div>{pagingState.error}</div>
+            )}
+            {pagingState.status === 'loaded' &&
+              pagingState.rows.length === 0 && (
+                <div>No represented rows found.</div>
+              )}
+            {pagingState.rows.length > 0 && (
+              <>
+                <div style={{ marginBottom: 6 }}>
+                  Loaded {pagingState.rows.length} of{' '}
+                  {pagingState.totalRows ?? pagingState.rows.length} rows
+                </div>
+                <div
+                  style={{
+                    maxHeight: 260,
+                    overflowY: 'auto',
+                    paddingRight: 4,
+                  }}
+                >
+                  {pagingState.rows.map((row, index) => (
+                    <details
+                      key={[p.id, index].join(':')}
+                      style={{ marginBottom: 6 }}
+                    >
+                      <summary>Row {index + 1}</summary>
+                      <div style={{ padding: '4px 0 2px 10px' }}>
+                        {buildPopupFields(row, null, null).map(([key, value]) => (
+                          <div key={key} style={{ marginBottom: 3 }}>
+                            <b>{key}:</b> {String(value ?? '')}
+                          </div>
+                        ))}
+                      </div>
+                    </details>
+                  ))}
+                </div>
+              </>
+            )}
+            {pagingState.rows.length > 0 && pagingState.error && (
+              <div style={{ marginTop: 6 }}>{pagingState.error}</div>
+            )}
+            {canShowMore && (
+              <button
+                type='button'
+                onClick={handleShowMore}
+                disabled={pagingState.status === 'loading-more'}
+                style={{ marginTop: 8 }}
+              >
+                {pagingState.status === 'loading-more'
+                  ? 'Loading...'
+                  : 'Show 30 more'}
+              </button>
+            )}
+          </div>
+        )}
       </div>
     </Popup>
   );
@@ -345,6 +567,8 @@ export default function GeoMap({
   // When true, nearby markers are grouped into clusters (visual-only feature).
   // When false, markers are rendered normally (current behavior).
   getSourceRow,
+  getFeatureDetails,
+  getGroupRows,
   clusterMarkersEnabled = false,
   clusterRadius = 80,   // default strength
   onViewportChange,
@@ -476,7 +700,13 @@ export default function GeoMap({
                 position={[p.lat, p.lon]}
                 {...(icon ? { icon } : {})}
               >
-                {renderPointPopup(p, p.latField, p.lonField, getSourceRow)}
+                <PointPopup
+                  point={p}
+                  latField={p.latField}
+                  lonField={p.lonField}
+                  getSourceRow={getSourceRow}
+                  getFeatureDetails={getFeatureDetails}
+                />
               </Marker>
             );
           })}
@@ -491,7 +721,13 @@ export default function GeoMap({
               position={[p.lat, p.lon]}
               {...(icon ? { icon } : {})}
             >
-              {renderPointPopup(p, p.latField, p.lonField, getSourceRow)}
+              <PointPopup
+                point={p}
+                latField={p.latField}
+                lonField={p.lonField}
+                getSourceRow={getSourceRow}
+                getFeatureDetails={getFeatureDetails}
+              />
             </Marker>
           );
         })
@@ -507,7 +743,7 @@ export default function GeoMap({
             position={[p.lat, p.lon]}
             {...(icon ? { icon } : {})}
           >
-            {renderGroupedPointPopup(p)}
+            <GroupedPointPopup point={p} getGroupRows={getGroupRows} />
           </Marker>
         );
       })}
@@ -519,7 +755,13 @@ export default function GeoMap({
           bounds={buildPointImageBounds(p)}
           interactive
         >
-          {renderPointPopup(p, p.latField, p.lonField, getSourceRow)}
+          <PointPopup
+            point={p}
+            latField={p.latField}
+            lonField={p.lonField}
+            getSourceRow={getSourceRow}
+            getFeatureDetails={getFeatureDetails}
+          />
         </ImageOverlay>
       ))}
 

--- a/src/data/dataSource.js
+++ b/src/data/dataSource.js
@@ -14,6 +14,8 @@ export const DATA_SOURCE_METHODS = Object.freeze({
   getDatasetSummary: "getDatasetSummary",
 });
 
+export const DEFAULT_GROUP_ROWS_LIMIT = 30;
+
 /**
  * @typedef {object} DataSource
  * @property {(query: MapViewQuery) => MapViewResult | Promise<MapViewResult>} queryMapView
@@ -81,6 +83,9 @@ export const DATA_SOURCE_METHODS = Object.freeze({
  *   Number of source rows represented by this render result.
  * @property {string|null} [groupId]
  *   Stable group key for grouped or representative render results.
+ * @property {GroupRef|null} [groupRef]
+ *   Compact lookup context captured when a grouped render result is created.
+ *   It must not contain full source rows or other detail payloads.
  * @property {FeatureSourceRef|null} [sourceRef]
  * @property {string|null} [marker]
  * @property {string|null} [image]
@@ -118,6 +123,31 @@ export const DATA_SOURCE_METHODS = Object.freeze({
  * @typedef {object} FeatureSourceRef
  * @property {string} datasetId
  * @property {number} rowIndex
+ */
+
+/**
+ * @typedef {'dataset-source-row'} GroupRowsSortOrder
+ */
+
+/**
+ * @typedef {object} GroupGridRef
+ * @property {number} cellLat
+ * @property {number} cellLon
+ * @property {number} cellHeight
+ * @property {number} cellWidth
+ */
+
+/**
+ * Immutable context needed to reproduce the rows represented by one group.
+ * The originating bounds matter because edge grid cells can extend beyond the
+ * viewport, while the grid dimensions depend on that viewport's render query.
+ *
+ * @typedef {object} GroupRef
+ * @property {string} groupId
+ * @property {MapBounds} bounds
+ * @property {TimelineFilter|null} timeline
+ * @property {GroupGridRef} grid
+ * @property {GroupRowsSortOrder} sortOrder
  */
 
 /**
@@ -160,10 +190,13 @@ export const DATA_SOURCE_METHODS = Object.freeze({
 
 /**
  * @typedef {object} GroupRowsQuery
+ * @property {GroupRef|null} [groupRef]
+ *   Preferred grouped-marker lookup context. It preserves the original spatial
+ *   and timeline query instead of relying on the UI's current map state.
  * @property {string|null} [datasetId]
- * @property {string|null} [groupId]
+ *   Optional dataset-only lookup used by data sources without grouped markers.
  * @property {number} [offset]
- * @property {number} [limit]
+ * @property {number} [limit=30]
  */
 
 /**

--- a/src/data/desktopSqliteDataSource.js
+++ b/src/data/desktopSqliteDataSource.js
@@ -1,3 +1,5 @@
+import { DEFAULT_GROUP_ROWS_LIMIT } from './dataSource';
+
 const DEFAULT_SQLITE_RENDER_BUDGET = 1000;
 
 /**
@@ -21,25 +23,38 @@ export function createDesktopSqliteDataSource({ desktopApi }) {
       return normalizeMapViewResult(result);
     },
 
-    getFeatureDetails(query = {}) {
-      return {
-        featureId: query.featureId ?? null,
-        row: null,
-        latField: null,
-        lonField: null,
-      };
+    async getFeatureDetails(query = {}) {
+      const sourceRef = normalizeFeatureSourceRef(query.sourceRef);
+      if (
+        typeof desktopApi?.getFeatureDetails !== 'function' ||
+        !sourceRef
+      ) {
+        return createEmptyFeatureDetailsResult();
+      }
+
+      const result = await desktopApi.getFeatureDetails({ sourceRef });
+      return normalizeFeatureDetailsResult(result);
     },
 
-    getGroupRows(query = {}) {
+    async getGroupRows(query = {}) {
       const offset = normalizeNonNegativeInteger(query.offset, 0);
-      const limit = normalizeNonNegativeInteger(query.limit, 0);
+      const limit = normalizePositiveInteger(
+        query.limit ?? DEFAULT_GROUP_ROWS_LIMIT,
+        DEFAULT_GROUP_ROWS_LIMIT,
+      );
+      const groupRef = normalizeGroupRef(query.groupRef);
 
-      return {
-        rows: [],
+      if (typeof desktopApi?.getGroupRows !== 'function' || !groupRef) {
+        return createEmptyGroupRowsResult(offset, limit);
+      }
+
+      const result = await desktopApi.getGroupRows({
+        groupRef,
         offset,
         limit,
-        totalRows: null,
-      };
+      });
+
+      return normalizeGroupRowsResult(result, offset, limit);
     },
 
     getDatasetSummary() {
@@ -86,6 +101,7 @@ function normalizePointFeature(point) {
       renderType: "exact",
       count: 1,
       groupId: null,
+      groupRef: null,
     };
   }
 
@@ -94,6 +110,7 @@ function normalizePointFeature(point) {
     renderType: normalizePointRenderType(point.renderType),
     count: normalizePositiveInteger(point.count, 1),
     groupId: normalizeNullableString(point.groupId),
+    groupRef: normalizeGroupRef(point.groupRef),
   };
 }
 
@@ -103,6 +120,140 @@ function normalizePointRenderType(value) {
   }
 
   return "exact";
+}
+
+function normalizeFeatureDetailsResult(result) {
+  if (!result || typeof result !== 'object') {
+    return createEmptyFeatureDetailsResult();
+  }
+
+  return {
+    featureId: normalizeNullableString(result.featureId),
+    row: normalizeRecord(result.row),
+    latField: normalizeNullableString(result.latField),
+    lonField: normalizeNullableString(result.lonField),
+  };
+}
+
+// Validate detail IPC results before they reach React components.
+function normalizeGroupRowsResult(result, requestedOffset, requestedLimit) {
+  if (!result || typeof result !== 'object') {
+    return createEmptyGroupRowsResult(requestedOffset, requestedLimit);
+  }
+
+  const rows = Array.isArray(result.rows)
+    ? result.rows.map(normalizeRecord).filter(Boolean)
+    : [];
+
+  return {
+    rows,
+    offset: normalizeNonNegativeInteger(
+      result.offset ?? requestedOffset,
+      requestedOffset,
+    ),
+    limit: normalizePositiveInteger(
+      result.limit ?? requestedLimit,
+      requestedLimit,
+    ),
+    totalRows: normalizeNonNegativeInteger(
+      result.totalRows ?? rows.length,
+      rows.length,
+    ),
+  };
+}
+
+function normalizeFeatureSourceRef(sourceRef) {
+  if (!sourceRef || typeof sourceRef !== 'object') return null;
+
+  const datasetId = normalizeNullableString(sourceRef.datasetId);
+  const rowIndex = normalizeOptionalNonNegativeInteger(sourceRef.rowIndex);
+  if (!datasetId || rowIndex == null) return null;
+
+  return { datasetId, rowIndex };
+}
+
+function normalizeGroupRef(groupRef) {
+  if (!groupRef || typeof groupRef !== 'object') return null;
+
+  const groupId = normalizeNullableString(groupRef.groupId);
+  const bounds = normalizeGroupBounds(groupRef.bounds);
+  const timeline = normalizeGroupTimeline(groupRef.timeline);
+  const grid = normalizeGroupGrid(groupRef.grid);
+
+  if (
+    !groupId ||
+    !bounds ||
+    timeline === undefined ||
+    !grid ||
+    groupRef.sortOrder !== 'dataset-source-row'
+  ) {
+    return null;
+  }
+
+  // A mismatched group ID is unsafe because it could broaden the requested rows.
+  if (groupId !== ['grid', grid.cellLat, grid.cellLon].join(':')) {
+    return null;
+  }
+
+  return {
+    groupId,
+    bounds,
+    timeline,
+    grid,
+    sortOrder: 'dataset-source-row',
+  };
+}
+
+function normalizeGroupBounds(bounds) {
+  if (!bounds || typeof bounds !== 'object') return null;
+
+  const north = normalizeFiniteNumber(bounds.north);
+  const south = normalizeFiniteNumber(bounds.south);
+  const east = normalizeFiniteNumber(bounds.east);
+  const west = normalizeFiniteNumber(bounds.west);
+  if (north == null || south == null || east == null || west == null) {
+    return null;
+  }
+
+  return { north, south, east, west };
+}
+
+function normalizeGroupTimeline(timeline) {
+  if (!timeline?.timelineEnabled) return null;
+
+  const startYear = normalizeOptionalInteger(timeline.startYear);
+  const endYear = normalizeOptionalInteger(timeline.endYear);
+  if (startYear == null || endYear == null) return undefined;
+
+  return {
+    timelineEnabled: true,
+    startYear: Math.min(startYear, endYear),
+    endYear: Math.max(startYear, endYear),
+  };
+}
+
+function normalizeGroupGrid(grid) {
+  if (!grid || typeof grid !== 'object') return null;
+
+  const cellLat = normalizeOptionalInteger(grid.cellLat);
+  const cellLon = normalizeOptionalInteger(grid.cellLon);
+  const cellHeight = normalizePositiveNumber(grid.cellHeight);
+  const cellWidth = normalizePositiveNumber(grid.cellWidth);
+  if (
+    cellLat == null ||
+    cellLon == null ||
+    cellHeight == null ||
+    cellWidth == null
+  ) {
+    return null;
+  }
+
+  return { cellLat, cellLon, cellHeight, cellWidth };
+}
+
+function normalizeRecord(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  return value;
 }
 
 function normalizeStats(stats, returnedCount) {
@@ -151,6 +302,24 @@ function normalizeStats(stats, returnedCount) {
   };
 }
 
+function createEmptyFeatureDetailsResult() {
+  return {
+    featureId: null,
+    row: null,
+    latField: null,
+    lonField: null,
+  };
+}
+
+function createEmptyGroupRowsResult(offset, limit) {
+  return {
+    rows: [],
+    offset,
+    limit,
+    totalRows: 0,
+  };
+}
+
 function createEmptyMapViewResult() {
   return {
     points: [],
@@ -176,10 +345,37 @@ function createEmptyMapViewResult() {
   };
 }
 
+function normalizeOptionalNonNegativeInteger(value) {
+  const number = normalizeFiniteNumber(value);
+  if (number == null || number < 0) return null;
+  return Math.trunc(number);
+}
+
+function normalizeOptionalInteger(value) {
+  const number = normalizeFiniteNumber(value);
+  if (number == null) return null;
+  return Math.trunc(number);
+}
+
+function normalizePositiveNumber(value) {
+  const number = normalizeFiniteNumber(value);
+  if (number == null || number <= 0) return null;
+  return number;
+}
+
+function normalizeFiniteNumber(value) {
+  if (value === null || value === undefined || value === '') return null;
+
+  const number = Number(value);
+  return Number.isFinite(number) ? number : null;
+}
+
 function normalizePositiveInteger(value, fallback) {
   const number = Number(value);
   if (!Number.isFinite(number)) return fallback;
-  return Math.max(1, Math.trunc(number));
+
+  const integer = Math.trunc(number);
+  return integer > 0 ? integer : fallback;
 }
 
 function normalizeNonNegativeInteger(value, fallback) {


### PR DESCRIPTION
## Summary

- Add on-demand full row details for exact SQLite-backed markers
- Add paged row loading for grouped markers
- Keep full CSV row data out of compact viewport query results
- Preserve the original viewport and timeline filters when loading grouped rows
- Add smoke coverage and update the SQLite prototype documentation

## Testing

- `npm run lint`
- `npm run smoke:sqlite-viewport`
- `npm run smoke:sqlite-detail`
- `npm run build`
- `npm run build:desktop`
- Manual desktop testing completed

Closes #84
