### PR TITLE
Show marker details in a resizable side panel

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -112,6 +112,109 @@
   background: rgba(255, 255, 255, 0.12);
 }
 
+/* Marker details overlay, positioned directly after the visible CSV panel. */
+.markerDetailsPanel {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  z-index: 1150;
+  width: 360px;
+  box-sizing: border-box;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  background: #0f172a;
+  color: #e2e8f0;
+  border-right: 1px solid rgba(255, 255, 255, 0.10);
+  box-shadow: 8px 0 30px rgba(0, 0, 0, 0.35);
+}
+
+.markerDetailsPanelHeader {
+  min-height: 48px;
+  padding: 8px 10px;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.markerDetailsPanelTitle {
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: 0.2px;
+}
+
+.markerDetailsPanelHeaderActions {
+  display: flex;
+  gap: 6px;
+}
+
+.markerDetailsPanelCollapse,
+.markerDetailsPanelClose {
+  width: 32px;
+  height: 32px;
+  flex: 0 0 auto;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(15, 23, 42, 0.8);
+  color: #e2e8f0;
+  cursor: pointer;
+  font-size: 20px;
+  line-height: 1;
+}
+
+.markerDetailsPanelCollapse:hover,
+.markerDetailsPanelClose:hover {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.markerDetailsPanelExpand {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  transform: translateY(-50%);
+  width: 34px;
+  height: 64px;
+  padding: 0;
+  border-radius: 0 12px 12px 0;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(15, 23, 42, 0.95);
+  color: #e2e8f0;
+  cursor: pointer;
+  font-size: 18px;
+  font-weight: 800;
+}
+
+.markerDetailsPanelExpand:hover {
+  background: rgba(15, 23, 42, 1);
+}
+
+.markerDetailsPanelContent {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  padding: 12px;
+}
+
+/* Right-edge drag target for changing the marker panel width. */
+.markerDetailsPanelDivider {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 6px;
+  cursor: col-resize;
+  background: rgba(255, 255, 255, 0.06);
+  user-select: none;
+}
+
+.markerDetailsPanelDivider:hover {
+  background: rgba(255, 255, 255, 0.12);
+}
+
 /* --- CSV panel internals (your existing styles) --- */
 .csvPanel {
   height: 100%;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,6 +17,7 @@ import { useCsvFileDrop } from "./components/useCsvFileDrop";
 import { useExampleCsvFilesFromUrl } from "./components/useExampleCsvFilesFromUrl";
 import { useTimelinePlayback } from "./components/useTimelinePlayback";
 import { createDesktopSqliteDataSource } from "./data/desktopSqliteDataSource";
+import { MarkerDetailsPanel } from "./components/MarkerDetailsPanel";
 
 const LARGE_RAW_MARKER_WARNING_THRESHOLD = 3000;
 const SQLITE_RENDER_BUDGET = 1000;
@@ -79,6 +80,13 @@ export default function App() {
     error: null,
   });
   const [mapViewport, setMapViewport] = useState(null);
+
+  // App owns marker selection so the map and details panel share one lifecycle.
+  const [selectedMarker, setSelectedMarker] = useState(null);
+  const [isMarkerPanelCollapsed, setIsMarkerPanelCollapsed] = useState(false);
+
+  // The details panel uses the CSV panel's visible edge as its left position.
+  const [csvPanelVisibleWidth, setCsvPanelVisibleWidth] = useState(420);
   const [desktopMapViewState, setDesktopMapViewState] = useState({
     status: "idle",
     result: null,
@@ -92,6 +100,22 @@ export default function App() {
     () => createDesktopSqliteDataSource({ desktopApi }),
     [desktopApi],
   );
+
+  const handleMarkerSelect = useCallback((marker) => {
+    // Selecting a marker always reveals its details, even after a collapse.
+    setSelectedMarker(marker);
+    setIsMarkerPanelCollapsed(false);
+  }, []);
+
+  const handleMarkerPanelCollapse = useCallback(() => {
+    setIsMarkerPanelCollapsed((isCollapsed) => !isCollapsed);
+  }, []);
+
+  const handleMarkerPanelClose = useCallback(() => {
+    // Clearing the selection unmounts both the panel and its collapsed control.
+    setSelectedMarker(null);
+    setIsMarkerPanelCollapsed(false);
+  }, []);
 
   /**
    * Start the desktop-only SQLite import flow.
@@ -330,14 +354,14 @@ export default function App() {
           regions={activeMapFeatures.regions.polygons}
           lines={activeMapFeatures.lines.lines}
           getSourceRow={activeMapFeatures.getSourceRow}
-          getFeatureDetails={activeFeatureDetailsLoader}
-          getGroupRows={activeGroupRowsLoader}
           clusterMarkersEnabled={!!mapToolsApi.state.clusterMarkersEnabled}
           clusterRadius={mapToolsApi.state.clusterRadius}
           onViewportChange={setMapViewport}
+          onMarkerSelect={handleMarkerSelect}
+          selectedMarker={selectedMarker}
         />
 
-        <CsvPanelOverlay>
+        <CsvPanelOverlay onVisibleWidthChange={setCsvPanelVisibleWidth}>
           <CsvPanel
             files={files}
             selectedId={selectedId}
@@ -364,6 +388,17 @@ export default function App() {
             onMapToolsPatch={patchMapToolsWithSafeguards}
           />
         </CsvPanelOverlay>
+
+        <MarkerDetailsPanel
+          marker={selectedMarker}
+          leftOffset={csvPanelVisibleWidth}
+          getSourceRow={activeMapFeatures.getSourceRow}
+          getFeatureDetails={activeFeatureDetailsLoader}
+          getGroupRows={activeGroupRowsLoader}
+          isCollapsed={isMarkerPanelCollapsed}
+          onToggleCollapse={handleMarkerPanelCollapse}
+          onClose={handleMarkerPanelClose}
+        />
       </div>
     </div>
   );

--- a/src/components/CsvPanelOverlay.jsx
+++ b/src/components/CsvPanelOverlay.jsx
@@ -13,7 +13,7 @@ const MAX_PANEL_WIDTH_RATIO = 0.85;
  */
 const HANDLE_VISIBLE_PX = 34;
 
-export function CsvPanelOverlay({ children }) {
+export function CsvPanelOverlay({ children, onVisibleWidthChange }) {
   /** True when the CSV panel is hidden */
   const [isCollapsed, setIsCollapsed] = useState(false);
 
@@ -67,6 +67,13 @@ export function CsvPanelOverlay({ children }) {
       window.removeEventListener("mouseup", onUp);
     };
   }, []);
+
+  // Keep adjacent overlays aligned with the panel's actual visible edge.
+  useEffect(() => {
+    onVisibleWidthChange?.(
+      isCollapsed ? HANDLE_VISIBLE_PX : panelWidth,
+    );
+  }, [isCollapsed, onVisibleWidthChange, panelWidth]);
 
   /**
    * Starts the resize action.

--- a/src/components/GeoMap.jsx
+++ b/src/components/GeoMap.jsx
@@ -1,5 +1,4 @@
 import { useEffect, useRef } from "react";
-import { useCallback, useState } from 'react';
 // Import core components from react-leaflet.
 // MapContainer is the main map wrapper.
 // TileLayer is used to load map tiles (images).
@@ -12,6 +11,7 @@ import {
   LayerGroup,
   Marker,
   ImageOverlay,
+  CircleMarker,
   Polygon,
   Polyline,
   Popup,
@@ -26,310 +26,10 @@ import L from "leaflet";
 import "leaflet-polylinedecorator";
 
 import { getClusterMarkerIcon, getMarkerIcon } from "./markerIcons";
+import { buildMarkerDetailFields } from "./markerDetailFields";
 
-import { DEFAULT_GROUP_ROWS_LIMIT } from '../data/dataSource';
-
-/**
- * Build a list of fields to show in the popup.
- *
- * - row: one CSV row (object with key/value pairs)
- * - latField / lonField: column names used for coordinates
- * - limit: max number of fields to show
- *
- * Latitude and longitude fields are skipped,
- * because they are already shown at the top.
- */
-function buildPopupFields(row, latField, lonField, limit = 30) {
-  if (!row || typeof row !== "object") return [];
-
-  // Get all column names except lat/lon
-  const keys = Object.keys(row).filter((k) => k !== latField && k !== lonField);
-
-  // Keep only the first few fields to keep popup readable
-  return keys.slice(0, limit).map(
-    (k) => [k, row[k]]
-  );
-}
-
-/**
- * Build the popup content for one point.
- * Kept in a helper so the Marker and Clustered Marker render paths stay identical.
- */
 function getFeaturePopupRow(feature, getSourceRow) {
   return feature?.row ?? getSourceRow?.(feature?.sourceFileId, feature?.sourceRowIndex) ?? null;
-}
-
-function PointPopup({
-  point: p,
-  latField,
-  lonField,
-  getSourceRow,
-  getFeatureDetails,
-}) {
-  const requestVersionRef = useRef(0);
-  const [detailState, setDetailState] = useState({
-    status: 'idle',
-    details: null,
-  });
-  const shouldLoadDetails =
-    typeof getFeatureDetails === 'function' && !!p?.sourceRef;
-  const synchronousRow = getFeaturePopupRow(p, getSourceRow);
-  const row = shouldLoadDetails
-    ? detailState.details?.row ?? null
-    : synchronousRow;
-  const resolvedLatField = detailState.details?.latField ?? latField;
-  const resolvedLonField = detailState.details?.lonField ?? lonField;
-
-  const handlePopupOpen = useCallback(() => {
-    if (!shouldLoadDetails) return;
-
-    const requestVersion = requestVersionRef.current + 1;
-    requestVersionRef.current = requestVersion;
-    setDetailState({ status: 'loading', details: null });
-
-    Promise.resolve(getFeatureDetails({
-      featureId: p.id,
-      sourceRef: p.sourceRef,
-    })).then((details) => {
-      if (requestVersionRef.current !== requestVersion) return;
-
-      setDetailState({
-        status: details?.row ? 'loaded' : 'empty',
-        details: details?.row ? details : null,
-      });
-    }).catch(() => {
-      if (requestVersionRef.current !== requestVersion) return;
-      setDetailState({ status: 'error', details: null });
-    });
-  }, [getFeatureDetails, p.id, p.sourceRef, shouldLoadDetails]);
-
-  const handlePopupClose = useCallback(() => {
-    // Ignore a late reply if this popup closes before its request finishes.
-    requestVersionRef.current += 1;
-  }, []);
-
-  useEffect(() => () => {
-    requestVersionRef.current += 1;
-  }, []);
-
-  return (
-    <Popup
-      eventHandlers={{
-        add: handlePopupOpen,
-        remove: handlePopupClose,
-      }}
-    >
-      <div style={{ minWidth: 220 }}>
-        <div style={{ fontWeight: 700, marginBottom: 6 }}>Point</div>
-
-        {/* Always show coordinates */}
-        <div>
-          <b>lat:</b> {p.lat}
-        </div>
-        <div>
-          <b>lon:</b> {p.lon}
-        </div>
-
-        <hr style={{ opacity: 0.25 }} />
-
-        {shouldLoadDetails && (
-          detailState.status === 'idle' || detailState.status === 'loading'
-        ) && (
-          <div>Loading details...</div>
-        )}
-        {shouldLoadDetails && detailState.status === 'empty' && (
-          <div>No details found.</div>
-        )}
-        {shouldLoadDetails && detailState.status === 'error' && (
-          <div>Could not load details.</div>
-        )}
-
-        {(!shouldLoadDetails || detailState.status === 'loaded') &&
-        buildPopupFields(row, resolvedLatField, resolvedLonField).map(([k, v]) => (
-          <div key={k} style={{ marginBottom: 4 }}>
-            <b>{k}:</b> {String(v ?? "")}
-          </div>
-        ))}
-      </div>
-    </Popup>
-  );
-}
-
-/**
- * Load backing SQLite rows only after a grouped marker popup opens.
- */
-function GroupedPointPopup({ point: p, getGroupRows }) {
-  const requestVersionRef = useRef(0);
-  const [pagingState, setPagingState] = useState({
-    status: 'idle',
-    rows: [],
-    totalRows: null,
-    error: null,
-  });
-  const canLoadGroupRows =
-    typeof getGroupRows === 'function' && !!p?.groupRef;
-
-  const loadPage = useCallback((offset, replaceRows) => {
-    if (!canLoadGroupRows) return;
-
-    // groupRef keeps every page tied to the group created by the original query.
-    const requestVersion = requestVersionRef.current + 1;
-    requestVersionRef.current = requestVersion;
-    setPagingState((previous) => ({
-      ...previous,
-      status: offset === 0 ? 'loading' : 'loading-more',
-      rows: replaceRows ? [] : previous.rows,
-      totalRows: replaceRows ? null : previous.totalRows,
-      error: null,
-    }));
-
-    Promise.resolve(getGroupRows({
-      groupRef: p.groupRef,
-      offset,
-      limit: DEFAULT_GROUP_ROWS_LIMIT,
-    })).then((result) => {
-      if (requestVersionRef.current !== requestVersion) return;
-
-      const pageRows = Array.isArray(result?.rows) ? result.rows : [];
-      setPagingState((previous) => {
-        // Opening starts a fresh list; "Show more" appends the next stable page.
-        const rows = replaceRows
-          ? pageRows
-          : [...previous.rows, ...pageRows];
-
-        return {
-          status: 'loaded',
-          rows,
-          totalRows: result?.totalRows ?? rows.length,
-          error: null,
-        };
-      });
-    }).catch(() => {
-      if (requestVersionRef.current !== requestVersion) return;
-
-      setPagingState((previous) => ({
-        ...previous,
-        status: previous.rows.length > 0 ? 'loaded' : 'error',
-        error: 'Could not load group rows.',
-      }));
-    });
-  }, [canLoadGroupRows, getGroupRows, p.groupRef]);
-
-  const handlePopupOpen = useCallback(() => {
-    loadPage(0, true);
-  }, [loadPage]);
-
-  const handlePopupClose = useCallback(() => {
-    requestVersionRef.current += 1;
-  }, []);
-
-  const handleShowMore = useCallback((event) => {
-    event.stopPropagation();
-    loadPage(pagingState.rows.length, false);
-  }, [loadPage, pagingState.rows.length]);
-
-  useEffect(() => () => {
-    requestVersionRef.current += 1;
-  }, []);
-
-  const canShowMore =
-    canLoadGroupRows &&
-    pagingState.totalRows != null &&
-    pagingState.rows.length < pagingState.totalRows;
-  const title = p.renderType === "representative"
-    ? "Representative marker"
-    : "Grouped markers";
-
-  return (
-    <Popup
-      maxWidth={460}
-      eventHandlers={{
-        add: handlePopupOpen,
-        remove: handlePopupClose,
-      }}
-    >
-      <div style={{ minWidth: 280, maxWidth: 420 }}>
-        <div style={{ fontWeight: 700, marginBottom: 6 }}>{title}</div>
-        <div>
-          <b>count:</b> {p.count ?? 1}
-        </div>
-        <div>
-          <b>lat:</b> {p.lat}
-        </div>
-        <div>
-          <b>lon:</b> {p.lon}
-        </div>
-
-        {canLoadGroupRows && (
-          <div
-            style={{
-              borderTop: '1px solid rgba(0, 0, 0, 0.15)',
-              marginTop: 8,
-              paddingTop: 8,
-            }}
-          >
-            {(pagingState.status === 'idle' ||
-              pagingState.status === 'loading') && (
-              <div>Loading rows...</div>
-            )}
-            {pagingState.status === 'error' && (
-              <div>{pagingState.error}</div>
-            )}
-            {pagingState.status === 'loaded' &&
-              pagingState.rows.length === 0 && (
-                <div>No represented rows found.</div>
-              )}
-            {pagingState.rows.length > 0 && (
-              <>
-                <div style={{ marginBottom: 6 }}>
-                  Loaded {pagingState.rows.length} of{' '}
-                  {pagingState.totalRows ?? pagingState.rows.length} rows
-                </div>
-                <div
-                  style={{
-                    maxHeight: 260,
-                    overflowY: 'auto',
-                    paddingRight: 4,
-                  }}
-                >
-                  {pagingState.rows.map((row, index) => (
-                    <details
-                      key={[p.id, index].join(':')}
-                      style={{ marginBottom: 6 }}
-                    >
-                      <summary>Row {index + 1}</summary>
-                      <div style={{ padding: '4px 0 2px 10px' }}>
-                        {buildPopupFields(row, null, null).map(([key, value]) => (
-                          <div key={key} style={{ marginBottom: 3 }}>
-                            <b>{key}:</b> {String(value ?? '')}
-                          </div>
-                        ))}
-                      </div>
-                    </details>
-                  ))}
-                </div>
-              </>
-            )}
-            {pagingState.rows.length > 0 && pagingState.error && (
-              <div style={{ marginTop: 6 }}>{pagingState.error}</div>
-            )}
-            {canShowMore && (
-              <button
-                type='button'
-                onClick={handleShowMore}
-                disabled={pagingState.status === 'loading-more'}
-                style={{ marginTop: 8 }}
-              >
-                {pagingState.status === 'loading-more'
-                  ? 'Loading...'
-                  : 'Show 30 more'}
-              </button>
-            )}
-          </div>
-        )}
-      </div>
-    </Popup>
-  );
 }
 
 function isGroupedPointFeature(point) {
@@ -387,7 +87,7 @@ function renderRegionPopup(region, latField, lonField, getSourceRow) {
       <div style={{ minWidth: 220 }}>
         <div style={{ fontWeight: 700, marginBottom: 6 }}>{title}</div>
 
-        {buildPopupFields(row, latField, lonField).map(([k, v]) => (
+        {buildMarkerDetailFields(row, latField, lonField).map(([k, v]) => (
           <div key={k} style={{ marginBottom: 4 }}>
             <b>{k}:</b> {String(v ?? "")}
           </div>
@@ -407,7 +107,7 @@ function renderLinePopup(line, latField, lonField, getSourceRow) {
       <div style={{ minWidth: 220 }}>
         <div style={{ fontWeight: 700, marginBottom: 6 }}>{title}</div>
 
-        {buildPopupFields(row, latField, lonField).map(([k, v]) => (
+        {buildMarkerDetailFields(row, latField, lonField).map(([k, v]) => (
           <div key={k} style={{ marginBottom: 4 }}>
             <b>{k}:</b> {String(v ?? "")}
           </div>
@@ -567,11 +267,11 @@ export default function GeoMap({
   // When true, nearby markers are grouped into clusters (visual-only feature).
   // When false, markers are rendered normally (current behavior).
   getSourceRow,
-  getFeatureDetails,
-  getGroupRows,
   clusterMarkersEnabled = false,
   clusterRadius = 80,   // default strength
   onViewportChange,
+  onMarkerSelect,
+  selectedMarker,
 }) {
   const { BaseLayer, Overlay } = LayersControl;
   const markerClusterGroupRef = useRef(null);
@@ -670,6 +370,21 @@ export default function GeoMap({
         </Overlay>
       </LayersControl>
 
+      {/* A map-native ring highlights selection without modifying marker icons. */}
+      {selectedMarker && (
+        <CircleMarker
+          center={[selectedMarker.lat, selectedMarker.lon]}
+          radius={18}
+          pathOptions={{
+            color: "#facc15",
+            weight: 4,
+            opacity: 1,
+            fill: false,
+          }}
+          interactive={false}
+        />
+      )}
+
       {/*
         Render markers for each point derived from enabled CSV files.
 
@@ -699,15 +414,8 @@ export default function GeoMap({
                 ref={(marker) => setCsvMarkerValue(marker, p.marker)}
                 position={[p.lat, p.lon]}
                 {...(icon ? { icon } : {})}
-              >
-                <PointPopup
-                  point={p}
-                  latField={p.latField}
-                  lonField={p.lonField}
-                  getSourceRow={getSourceRow}
-                  getFeatureDetails={getFeatureDetails}
-                />
-              </Marker>
+                eventHandlers={{ click: () => onMarkerSelect?.(p) }}
+              />
             );
           })}
         </MarkerClusterGroup>
@@ -720,15 +428,8 @@ export default function GeoMap({
               key={p.id}
               position={[p.lat, p.lon]}
               {...(icon ? { icon } : {})}
-            >
-              <PointPopup
-                point={p}
-                latField={p.latField}
-                lonField={p.lonField}
-                getSourceRow={getSourceRow}
-                getFeatureDetails={getFeatureDetails}
-              />
-            </Marker>
+              eventHandlers={{ click: () => onMarkerSelect?.(p) }}
+            />
           );
         })
       )}
@@ -742,9 +443,8 @@ export default function GeoMap({
             key={p.id}
             position={[p.lat, p.lon]}
             {...(icon ? { icon } : {})}
-          >
-            <GroupedPointPopup point={p} getGroupRows={getGroupRows} />
-          </Marker>
+            eventHandlers={{ click: () => onMarkerSelect?.(p) }}
+          />
         );
       })}
 
@@ -754,15 +454,8 @@ export default function GeoMap({
           url={p.image}
           bounds={buildPointImageBounds(p)}
           interactive
-        >
-          <PointPopup
-            point={p}
-            latField={p.latField}
-            lonField={p.lonField}
-            getSourceRow={getSourceRow}
-            getFeatureDetails={getFeatureDetails}
-          />
-        </ImageOverlay>
+          eventHandlers={{ click: () => onMarkerSelect?.(p) }}
+        />
       ))}
 
       {regions.map((region) => (

--- a/src/components/MarkerDetails.jsx
+++ b/src/components/MarkerDetails.jsx
@@ -1,0 +1,288 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { DEFAULT_GROUP_ROWS_LIMIT } from '../data/dataSource';
+import { buildMarkerDetailFields } from './markerDetailFields';
+
+export function PointMarkerDetails({
+  point,
+  latField,
+  lonField,
+  getSourceRow,
+  getFeatureDetails,
+  isActive,
+}) {
+  const requestVersionRef = useRef(0);
+  const [detailState, setDetailState] = useState({
+    status: 'idle',
+    details: null,
+  });
+  const shouldLoadDetails =
+    typeof getFeatureDetails === 'function' && !!point?.sourceRef;
+  const synchronousRow = getFeatureDetailRow(point, getSourceRow);
+  const row = shouldLoadDetails
+    ? detailState.details?.row ?? null
+    : synchronousRow;
+  const resolvedLatField = detailState.details?.latField ?? latField;
+  const resolvedLonField = detailState.details?.lonField ?? lonField;
+
+  useEffect(() => {
+    // Browser rows are synchronous; desktop sourceRef rows load on activation.
+    if (!isActive || !shouldLoadDetails) {
+      requestVersionRef.current += 1;
+      return undefined;
+    }
+
+    const requestVersion = requestVersionRef.current + 1;
+    requestVersionRef.current = requestVersion;
+
+    // Deferring the request lets the loading state follow the activation render.
+    queueMicrotask(() => {
+      if (requestVersionRef.current !== requestVersion) return;
+      setDetailState({ status: 'loading', details: null });
+
+      Promise.resolve(getFeatureDetails({
+        featureId: point.id,
+        sourceRef: point.sourceRef,
+      })).then((details) => {
+        if (requestVersionRef.current !== requestVersion) return;
+
+        setDetailState({
+          status: details?.row ? 'loaded' : 'empty',
+          details: details?.row ? details : null,
+        });
+      }).catch(() => {
+        if (requestVersionRef.current !== requestVersion) return;
+        setDetailState({ status: 'error', details: null });
+      });
+    });
+
+    return () => {
+      if (requestVersionRef.current === requestVersion) {
+        requestVersionRef.current += 1;
+      }
+    };
+  }, [
+    getFeatureDetails,
+    isActive,
+    point.id,
+    point.sourceRef,
+    shouldLoadDetails,
+  ]);
+
+  return (
+    <div style={{ minWidth: 220 }}>
+      <div style={{ fontWeight: 700, marginBottom: 6 }}>Point</div>
+
+      <div>
+        <b>lat:</b> {point.lat}
+      </div>
+      <div>
+        <b>lon:</b> {point.lon}
+      </div>
+
+      <hr style={{ opacity: 0.25 }} />
+
+      {shouldLoadDetails && (
+        detailState.status === 'idle' || detailState.status === 'loading'
+      ) && (
+        <div>Loading details...</div>
+      )}
+      {shouldLoadDetails && detailState.status === 'empty' && (
+        <div>No details found.</div>
+      )}
+      {shouldLoadDetails && detailState.status === 'error' && (
+        <div>Could not load details.</div>
+      )}
+
+      {(!shouldLoadDetails || detailState.status === 'loaded') &&
+        buildMarkerDetailFields(
+          row,
+          resolvedLatField,
+          resolvedLonField,
+        ).map(([key, value]) => (
+          <div key={key} style={{ marginBottom: 4 }}>
+            <b>{key}:</b> {String(value ?? '')}
+          </div>
+        ))}
+    </div>
+  );
+}
+
+export function GroupedMarkerDetails({ point, getGroupRows, isActive }) {
+  const requestVersionRef = useRef(0);
+  const [pagingState, setPagingState] = useState({
+    status: 'idle',
+    rows: [],
+    totalRows: null,
+    error: null,
+  });
+  const canLoadGroupRows =
+    typeof getGroupRows === 'function' && !!point?.groupRef;
+
+  const loadPage = useCallback((offset, replaceRows) => {
+    if (!canLoadGroupRows) return;
+
+    // groupRef keeps every page tied to the marker's original map query.
+    const requestVersion = requestVersionRef.current + 1;
+    requestVersionRef.current = requestVersion;
+    setPagingState((previous) => ({
+      ...previous,
+      status: offset === 0 ? 'loading' : 'loading-more',
+      rows: replaceRows ? [] : previous.rows,
+      totalRows: replaceRows ? null : previous.totalRows,
+      error: null,
+    }));
+
+    Promise.resolve(getGroupRows({
+      groupRef: point.groupRef,
+      offset,
+      limit: DEFAULT_GROUP_ROWS_LIMIT,
+    })).then((result) => {
+      if (requestVersionRef.current !== requestVersion) return;
+
+      const pageRows = Array.isArray(result?.rows) ? result.rows : [];
+      setPagingState((previous) => {
+        const rows = replaceRows
+          ? pageRows
+          : [...previous.rows, ...pageRows];
+
+        return {
+          status: 'loaded',
+          rows,
+          totalRows: result?.totalRows ?? rows.length,
+          error: null,
+        };
+      });
+    }).catch(() => {
+      if (requestVersionRef.current !== requestVersion) return;
+
+      setPagingState((previous) => ({
+        ...previous,
+        status: previous.rows.length > 0 ? 'loaded' : 'error',
+        error: 'Could not load group rows.',
+      }));
+    });
+  }, [canLoadGroupRows, getGroupRows, point.groupRef]);
+
+  useEffect(() => {
+    if (!isActive) {
+      requestVersionRef.current += 1;
+      return undefined;
+    }
+
+    // A newly selected group always starts again from its first page.
+    const activationVersion = requestVersionRef.current + 1;
+    requestVersionRef.current = activationVersion;
+    queueMicrotask(() => {
+      if (requestVersionRef.current !== activationVersion) return;
+      loadPage(0, true);
+    });
+
+    return () => {
+      requestVersionRef.current += 1;
+    };
+  }, [isActive, loadPage]);
+
+  const handleShowMore = useCallback((event) => {
+    event.stopPropagation();
+    loadPage(pagingState.rows.length, false);
+  }, [loadPage, pagingState.rows.length]);
+
+  const canShowMore =
+    canLoadGroupRows &&
+    pagingState.totalRows != null &&
+    pagingState.rows.length < pagingState.totalRows;
+  const title = point.renderType === 'representative'
+    ? 'Representative marker'
+    : 'Grouped markers';
+
+  return (
+    <div style={{ minWidth: 280, maxWidth: 420 }}>
+      <div style={{ fontWeight: 700, marginBottom: 6 }}>{title}</div>
+      <div>
+        <b>count:</b> {point.count ?? 1}
+      </div>
+      <div>
+        <b>lat:</b> {point.lat}
+      </div>
+      <div>
+        <b>lon:</b> {point.lon}
+      </div>
+
+      {canLoadGroupRows && (
+        <div
+          style={{
+            borderTop: '1px solid rgba(0, 0, 0, 0.15)',
+            marginTop: 8,
+            paddingTop: 8,
+          }}
+        >
+          {(pagingState.status === 'idle' ||
+            pagingState.status === 'loading') && (
+              <div>Loading rows...</div>
+            )}
+          {pagingState.status === 'error' && (
+            <div>{pagingState.error}</div>
+          )}
+          {pagingState.status === 'loaded' && pagingState.rows.length === 0 && (
+            <div>No represented rows found.</div>
+          )}
+          {pagingState.rows.length > 0 && (
+            <>
+              <div style={{ marginBottom: 6 }}>
+                Loaded {pagingState.rows.length} of{' '}
+                {pagingState.totalRows ?? pagingState.rows.length} rows
+              </div>
+              <div
+                style={{
+                  maxHeight: 260,
+                  overflowY: 'auto',
+                  paddingRight: 4,
+                }}
+              >
+                {pagingState.rows.map((row, index) => (
+                  <details
+                    key={[point.id, index].join(':')}
+                    style={{ marginBottom: 6 }}
+                  >
+                    <summary>Row {index + 1}</summary>
+                    <div style={{ padding: '4px 0 2px 10px' }}>
+                      {buildMarkerDetailFields(row, null, null).map(
+                        ([key, value]) => (
+                          <div key={key} style={{ marginBottom: 3 }}>
+                            <b>{key}:</b> {String(value ?? '')}
+                          </div>
+                        ),
+                      )}
+                    </div>
+                  </details>
+                ))}
+              </div>
+            </>
+          )}
+          {pagingState.rows.length > 0 && pagingState.error && (
+            <div style={{ marginTop: 6 }}>{pagingState.error}</div>
+          )}
+          {canShowMore && (
+            <button
+              type='button'
+              onClick={handleShowMore}
+              disabled={pagingState.status === 'loading-more'}
+              style={{ marginTop: 8 }}
+            >
+              {pagingState.status === 'loading-more'
+                ? 'Loading...'
+                : 'Show 30 more'}
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function getFeatureDetailRow(feature, getSourceRow) {
+  return feature?.row ??
+    getSourceRow?.(feature?.sourceFileId, feature?.sourceRowIndex) ??
+    null;
+}

--- a/src/components/MarkerDetailsPanel.jsx
+++ b/src/components/MarkerDetailsPanel.jsx
@@ -1,0 +1,163 @@
+import { useEffect, useRef, useState } from 'react';
+
+import {
+  GroupedMarkerDetails,
+  PointMarkerDetails,
+} from './MarkerDetails';
+
+const DEFAULT_PANEL_WIDTH = 360;
+const MIN_PANEL_WIDTH = 280;
+const COLLAPSED_PANEL_WIDTH = 34;
+
+export function MarkerDetailsPanel({
+  marker,
+  leftOffset,
+  getSourceRow,
+  getFeatureDetails,
+  getGroupRows,
+  isCollapsed,
+  onToggleCollapse,
+  onClose,
+}) {
+  const [panelWidth, setPanelWidth] = useState(DEFAULT_PANEL_WIDTH);
+  const panelRef = useRef(null);
+
+  // Drag values live outside render so window-level mouse events stay stable.
+  const dragRef = useRef({
+    dragging: false,
+    startX: 0,
+    startWidth: DEFAULT_PANEL_WIDTH,
+  });
+
+  useEffect(() => {
+    const dragState = dragRef.current;
+
+    function handleMouseMove(event) {
+      if (!dragState.dragging) return;
+
+      // The panel may use only the viewport space remaining after the CSV panel.
+      const maxWidth = Math.max(0, window.innerWidth - leftOffset);
+      const minWidth = Math.min(MIN_PANEL_WIDTH, maxWidth);
+      const deltaX = event.clientX - dragState.startX;
+
+      setPanelWidth(clamp(
+        dragState.startWidth + deltaX,
+        minWidth,
+        maxWidth,
+      ));
+    }
+
+    function handleMouseUp() {
+      dragState.dragging = false;
+    }
+
+    window.addEventListener('mousemove', handleMouseMove);
+    window.addEventListener('mouseup', handleMouseUp);
+
+    return () => {
+      dragState.dragging = false;
+      window.removeEventListener('mousemove', handleMouseMove);
+      window.removeEventListener('mouseup', handleMouseUp);
+    };
+  }, [leftOffset]);
+
+  if (!marker) return null;
+
+  const grouped = isGroupedMarker(marker);
+  // Remount details when selection changes so old loading/paging state cannot leak.
+  const detailKey = `${marker.renderType ?? 'exact'}:${marker.id}`;
+
+  return (
+    <aside
+      ref={panelRef}
+      className='markerDetailsPanel'
+      style={{
+        left: leftOffset,
+        width: isCollapsed ? COLLAPSED_PANEL_WIDTH : panelWidth,
+        maxWidth: `calc(100vw - ${leftOffset}px)`,
+      }}
+      aria-label='Marker details'
+    >
+      <button
+        type='button'
+        className='markerDetailsPanelExpand'
+        onClick={onToggleCollapse}
+        aria-label='Expand marker details'
+        title='Expand'
+        hidden={!isCollapsed}
+      >
+        &gt;
+      </button>
+
+      <div className='markerDetailsPanelHeader' hidden={isCollapsed}>
+        <div className='markerDetailsPanelTitle'>Marker details</div>
+        <div className='markerDetailsPanelHeaderActions'>
+          <button
+            type='button'
+            className='markerDetailsPanelCollapse'
+            onClick={onToggleCollapse}
+            aria-label='Collapse marker details'
+            title='Collapse'
+          >
+            &lt;
+          </button>
+          <button
+            type='button'
+            className='markerDetailsPanelClose'
+            onClick={onClose}
+            aria-label='Close marker details'
+            title='Close'
+          >
+            ×
+          </button>
+        </div>
+      </div>
+
+      {/* hidden keeps detail state mounted while the panel is collapsed. */}
+      <div className='markerDetailsPanelContent' hidden={isCollapsed}>
+        {grouped ? (
+          <GroupedMarkerDetails
+            key={detailKey}
+            point={marker}
+            getGroupRows={getGroupRows}
+            isActive
+          />
+        ) : (
+          <PointMarkerDetails
+            key={detailKey}
+            point={marker}
+            latField={marker.latField}
+            lonField={marker.lonField}
+            getSourceRow={getSourceRow}
+            getFeatureDetails={getFeatureDetails}
+            isActive
+          />
+        )}
+      </div>
+
+      <div
+        className='markerDetailsPanelDivider'
+        role='separator'
+        aria-orientation='vertical'
+        aria-label='Resize marker details panel'
+        hidden={isCollapsed}
+        onMouseDown={(event) => {
+          event.preventDefault();
+          dragRef.current.dragging = true;
+          dragRef.current.startX = event.clientX;
+          dragRef.current.startWidth =
+            panelRef.current?.getBoundingClientRect().width ?? panelWidth;
+        }}
+      />
+    </aside>
+  );
+}
+
+function isGroupedMarker(marker) {
+  return marker?.renderType === 'grouped' ||
+    marker?.renderType === 'representative';
+}
+
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value));
+}

--- a/src/components/markerDetailFields.js
+++ b/src/components/markerDetailFields.js
@@ -1,0 +1,15 @@
+export function buildMarkerDetailFields(
+  row,
+  latField,
+  lonField,
+  limit = 30,
+) {
+  if (!row || typeof row !== 'object') return [];
+
+  // Coordinates are rendered separately at the top of marker details.
+  const keys = Object.keys(row).filter(
+    (key) => key !== latField && key !== lonField,
+  );
+
+  return keys.slice(0, limit).map((key) => [key, row[key]]);
+}


### PR DESCRIPTION
## Summary

- Replace point-marker Leaflet popups with a marker-details side panel.
- Position the panel beside the existing CSV panel.
- Support resizing, collapsing, expanding, closing, and switching markers.
- Preserve exact-marker loading and grouped-marker paging.
- Highlight the currently selected marker.
- Keep region and line popups unchanged.

## Testing

- `npm run lint`
- `npm run build`
- `npm run build:desktop`
- `npm run smoke:sqlite-detail`
- `npm run smoke:sqlite-viewport`
- Manually tested browser and desktop marker-detail behavior.

Closes #4
