### PR TITLE
Persist and reconnect the desktop SQLite database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+.local-data/
 
 # Editor directories and files
 .vscode/*

--- a/desktop/main.cjs
+++ b/desktop/main.cjs
@@ -1,6 +1,7 @@
 "use strict";
 
 const { app, BrowserWindow, dialog, ipcMain, shell } = require("electron");
+const fs = require("node:fs");
 const path = require("node:path");
 const { importCsvFileToSqlite } = require("./csvImportService.cjs");
 const { closeSqliteStore, openSqliteStore } = require("./sqliteStore.cjs");
@@ -11,7 +12,7 @@ const {
   getSqliteGroupRows,
 } = require('./sqliteDetailQuery.cjs');
 
-// The prototype DB lives in Electron userData, not inside the repository.
+const LOCAL_DATA_DIR_NAME = ".local-data";
 const SQLITE_DB_FILE_NAME = "csv-map-layer-visualizer.sqlite";
 
 function getDevServerUrl() {
@@ -27,6 +28,7 @@ function registerDesktopBridgeHandlers() {
   ipcMain.handle("desktop:getStatus", () => ({
     ok: true,
     runtime: "electron",
+    ...getDesktopDatabaseStatus(),
   }));
 
   // The renderer asks to import, but the main process opens the file picker.
@@ -44,7 +46,7 @@ function registerDesktopBridgeHandlers() {
       return { ok: false, canceled: true };
     }
 
-    const db = openSqliteStore(getDesktopDatabasePath());
+    const db = openDesktopSqliteStore();
 
     try {
       return importCsvFileToSqlite({
@@ -56,7 +58,7 @@ function registerDesktopBridgeHandlers() {
     }
   });
   ipcMain.handle("desktop:queryMapView", async (_event, query = {}) => {
-    const db = openSqliteStore(getDesktopDatabasePath());
+    const db = openDesktopSqliteStore();
 
     try {
       return querySqliteMapView({
@@ -71,7 +73,7 @@ function registerDesktopBridgeHandlers() {
   });
   ipcMain.handle('desktop:getFeatureDetails', async (_event, query = {}) => {
     // Keep SQLite access in the main process and return full rows only on demand.
-    const db = openSqliteStore(getDesktopDatabasePath());
+    const db = openDesktopSqliteStore();
 
     try {
       return getSqliteFeatureDetails({
@@ -83,7 +85,7 @@ function registerDesktopBridgeHandlers() {
     }
   });
   ipcMain.handle('desktop:getGroupRows', async (_event, query = {}) => {
-    const db = openSqliteStore(getDesktopDatabasePath());
+    const db = openDesktopSqliteStore();
 
     try {
       return getSqliteGroupRows({
@@ -99,10 +101,46 @@ function registerDesktopBridgeHandlers() {
 }
 
 /**
- * Return the per-user database path for the desktop app.
+ * Return the project-local database path for the desktop app.
  */
 function getDesktopDatabasePath() {
-  return path.join(app.getPath("userData"), SQLITE_DB_FILE_NAME);
+  return path.join(__dirname, "..", LOCAL_DATA_DIR_NAME, SQLITE_DB_FILE_NAME);
+}
+
+/**
+ * Detect persisted imports without creating a database on first startup.
+ */
+function getDesktopDatabaseStatus() {
+  const dbPath = getDesktopDatabasePath();
+
+  if (!fs.existsSync(dbPath)) {
+    return {
+      databaseExists: false,
+      hasImportedData: false,
+    };
+  }
+
+  const db = openDesktopSqliteStore();
+
+  try {
+    const row = db.prepare("SELECT EXISTS(SELECT 1 FROM datasets) AS has_imported_data").get();
+
+    return {
+      databaseExists: true,
+      hasImportedData: row?.has_imported_data === 1,
+    };
+  } finally {
+    closeSqliteStore(db);
+  }
+}
+
+/**
+ * Create the local data folder only when SQLite is first needed.
+ */
+function openDesktopSqliteStore() {
+  const dbPath = getDesktopDatabasePath();
+  fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+  return openSqliteStore(dbPath);
 }
 
 /**

--- a/docs/sqlite-import-prototype.md
+++ b/docs/sqlite-import-prototype.md
@@ -19,13 +19,15 @@ The renderer does not pass arbitrary IPC channel names, local file paths, SQL, o
 
 ## Database Location
 
-The prototype database is stored under Electron's app data directory:
+The desktop database is stored in the project-local data directory:
 
 ```text
-app.getPath("userData") / csv-map-layer-visualizer.sqlite
+<project root>/.local-data/csv-map-layer-visualizer.sqlite
 ```
 
-This keeps imported local data outside the repository and outside the browser build output.
+The `.local-data/` directory and database are created only when desktop SQLite is first needed. If the database already contains imported datasets, desktop startup detects it and activates the existing SQLite query path automatically. If no database exists, the app starts normally without creating one.
+
+The entire `.local-data/` directory is ignored by Git, including SQLite WAL and SHM files. The browser build does not use this directory or the desktop database.
 
 ## Native Module Rebuild
 
@@ -121,7 +123,7 @@ npm run smoke:sqlite-viewport
 npm run smoke:sqlite-detail
 ```
 
-The smoke scripts create isolated in-memory SQLite databases. The viewport suite calls `querySqliteMapView(...)`, while the detail suite calls the exact and grouped lookup functions directly. Neither suite opens the Electron UI or reads from or modifies the app database under `userData`.
+The smoke scripts create isolated in-memory SQLite databases. The viewport suite calls `querySqliteMapView(...)`, while the detail suite calls the exact and grouped lookup functions directly. Neither suite opens the Electron UI or reads from or modifies the project-local app database.
 
 The current scenarios cover:
 
@@ -188,7 +190,7 @@ The dense, exact, and timeline results were stable across repeated queries. Grou
 
 ### Manual Electron Results
 
-The generated fixture was imported through the visible Electron UI using an isolated temporary `userData` directory:
+These historical results were recorded before issue #97, when the generated fixture was imported through the visible Electron UI using an isolated temporary `userData` directory:
 
 - the UI reported `Stored 30000 of 30000 rows`
 - pan and zoom remained responsive

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -81,6 +81,31 @@ export default function App() {
   });
   const [mapViewport, setMapViewport] = useState(null);
 
+  // Reconnect the desktop map to persisted SQLite data without affecting browser startup.
+  useEffect(() => {
+    if (!desktopImportAvailable || typeof desktopApi?.getStatus !== "function") {
+      return undefined;
+    }
+
+    let canceled = false;
+
+    desktopApi.getStatus().then((status) => {
+      if (canceled || !status?.hasImportedData) return;
+
+      setDesktopImportState((current) => (
+        current.status === "idle"
+          ? { status: "imported", summary: null, error: null }
+          : current
+      ));
+    }, () => {
+      // Keep the normal import flow available if persisted-data detection fails.
+    });
+
+    return () => {
+      canceled = true;
+    };
+  }, [desktopApi, desktopImportAvailable]);
+
   // App owns marker selection so the map and details panel share one lifecycle.
   const [selectedMarker, setSelectedMarker] = useState(null);
   const [isMarkerPanelCollapsed, setIsMarkerPanelCollapsed] = useState(false);


### PR DESCRIPTION
## Summary

Persist the Electron desktop SQLite database in the project-local `.local-data/` folder and reconnect to existing imported data when the app restarts.

## Changes

- Store the desktop database at `.local-data/csv-map-layer-visualizer.sqlite`.
- Create `.local-data/` only when SQLite is first needed.
- Detect existing imported datasets during desktop startup.
- Automatically reactivate the existing SQLite query path after restarting.
- Ignore `.local-data/`, including SQLite WAL and SHM files.
- Update the desktop SQLite documentation.
- Keep the browser/GitHub Pages path unchanged.

## Verification

- `npm run lint`
- `npm run build`
- `npm run build:desktop`
- `npm run smoke:sqlite-viewport`
- `npm run smoke:sqlite-detail`
- Verified first startup does not create a database.
- Manually verified import, shutdown, restart, and automatic reconnection.
- Verified `.local-data/` and SQLite companion files are ignored by Git.

Closes #97
