### PR TITLE
Prototype temporary SQLite WASM worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ This launches the current app in the Electron desktop shell. It does not create 
 
 For more details, see [Desktop runtime decision](docs/desktop-runtime.md).
 
+For the isolated GitHub Pages experiment, see
+[Temporary SQLite WASM prototype](docs/sqlite-wasm-prototype.md).
+
 ## Author
 
 Developed and maintained by **philip0000000**.

--- a/docs/sqlite-wasm-prototype.md
+++ b/docs/sqlite-wasm-prototype.md
@@ -1,0 +1,123 @@
+# Temporary SQLite WASM Prototype
+
+Issue #102 tests whether a temporary, in-memory SQLite database can run in a dedicated Web Worker in the normal GitHub Pages build. It does not replace the browser CSV flow or the Electron SQLite implementation.
+
+## Prototype URL
+
+The production build emits a separate page at:
+
+```text
+/csv-map-layer-visualizer/sqlite-wasm-prototype.html
+```
+
+After a deployment from `main`, its expected public URL is:
+
+```text
+https://philip0000000.github.io/csv-map-layer-visualizer/sqlite-wasm-prototype.html
+```
+
+The page is intentionally not linked from the normal application UI.
+
+For local development, run `npm run dev` and open `/sqlite-wasm-prototype.html`. To exercise the GitHub Pages base path locally, run `npm run build`, then `npm run preview`, and open the production path shown above.
+
+## Package Decision
+
+The prototype uses the exact dependency `sql.js@1.14.1` and imports its browser-specific WASM pair:
+
+- `sql.js/dist/sql-wasm-browser.js`
+- `sql.js/dist/sql-wasm-browser.wasm`
+
+`sql.js` was selected because this prototype needs an in-memory database in a dedicated worker without server-controlled cross-origin isolation headers. The official `@sqlite.org/sqlite-wasm` worker configuration requires cross-origin isolation headers that GitHub Pages does not provide. `wa-sqlite` was also considered, but `sql.js` provides the smallest direct compatibility proof for the current scope.
+
+The dependency is pinned in `package.json` and `package-lock.json`. During the prototype review, the npm registry metadata, repository, maintainers, license, package integrity, lifecycle scripts, and runtime dependencies were checked. The downloaded tarball matched the lockfile integrity, the package has no runtime dependencies or install scripts, and a local Microsoft Defender scan reported no threats. These checks reduce supply-chain risk but cannot prove that any third-party package is completely risk-free.
+
+## Isolation and Worker Protocol
+
+The prototype is isolated under `src/prototypes/sqliteWasm/`. The normal React entry point does not import it.
+
+The main thread sends named operations instead of arbitrary SQL:
+
+- `initialize`
+- `seed-sample-data`
+- `get-summary`
+- `query-viewport`
+- `get-feature-detail`
+- `close`
+
+Every request has an ID and a 30-second timeout. The worker returns structured success or error messages. The database exists only in worker memory and is closed when the worker is terminated.
+
+## Representative Schema and Workflow
+
+The temporary database mirrors the existing desktop prototype's `datasets` and `features` shape, including dataset, coordinate, timeline, and stable source-row indexes.
+
+The compatibility page:
+
+1. Starts a dedicated module worker.
+2. Creates a fresh in-memory database and schema.
+3. Generates 30,000 deterministic point rows across three geographic regions.
+4. Inserts all rows in one transaction.
+5. Runs named summary, viewport, and detail queries.
+6. Terminates the first worker.
+7. Starts a second worker and verifies that both tables are empty.
+
+The fixture is generated at runtime and is never committed or persisted.
+
+## Local Validation Results
+
+The final production-build check was run in headless Chrome on Windows on 2026-07-24. Timings are environment-specific and are intended as prototype evidence, not performance guarantees.
+
+| Scenario | Observed result |
+| --- | --- |
+| SQLite version | 3.49.1 |
+| Transactional insert | 30,000 rows in 312.3 ms |
+| Dataset/feature summary | 1 dataset and 30,000 features |
+| Stockholm viewport | 10,000 matches; 25 returned in 12.7 ms |
+| Exact detail lookup | Expected source row returned in 0.2 ms |
+| Worker restart | 0 datasets and 0 features |
+| Cross-origin isolation | Not enabled or required |
+| `SharedArrayBuffer` | Not required |
+
+The production build emitted:
+
+- a 47.35 kB worker bundle
+- a 659.73 kB WASM asset (323.01 kB gzip)
+- the standalone prototype HTML and main-thread module
+
+The normal application entry continued to return HTTP 200 during the same production-preview validation.
+
+## GitHub Pages Build
+
+`vite.config.js` includes both `index.html` and `sqlite-wasm-prototype.html` as Rollup inputs and emits workers as ES modules. The existing Pages workflow runs `npm run build` and uploads the complete `dist` directory, so no workflow change is required.
+
+The build output uses the repository base path for the page, worker, JavaScript, and WASM URLs. The browser-specific `sql.js` artifacts also avoid the `node:fs` and `node:crypto` externalization warnings produced by the general distribution.
+
+## Required Follow-Up Cleanup
+
+This is temporary experimental code and must not remain indefinitely as a parallel implementation.
+
+If SQLite WASM is adopted, move the required database and worker logic into production modules, add production-focused automated tests, and then remove the standalone experiment:
+
+- `sqlite-wasm-prototype.html`
+- `src/prototypes/sqliteWasm/`
+- the `sqliteWasmPrototype` Vite page input
+- the prototype link in `README.md`
+
+Keep the `sql.js` dependency and ES-module worker configuration only when the production implementation still uses them. Replace or revise this document so it describes the production design or preserves only the useful decision record.
+
+If SQLite WASM is rejected, remove all items above, remove `sql.js` from `package.json` and `package-lock.json`, and remove the worker configuration when nothing else requires it. This document may remain as a historical decision record after its instructions and links are updated.
+
+The adopting or rejecting follow-up must include this cleanup in its acceptance criteria. The prototype should not be treated as the production integration merely because it is present in the GitHub Pages build.
+
+## Limitations and Non-Goals
+
+This prototype:
+
+- has only been runtime-validated in Chrome
+- uses generated data rather than imported user CSV files
+- does not persist data across workers, reloads, or browser sessions
+- does not expose a general SQL API
+- is not connected to React state, the map, or the normal CSV workflow
+- does not change or replace the Electron `better-sqlite3` path
+- has not been verified on the public GitHub Pages deployment yet
+
+Committing, pushing, deploying, integrating the worker with the application, and deciding whether browser SQLite should become a supported feature are separate follow-up decisions.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-leaflet": "^5.0.0",
-        "react-leaflet-cluster": "^4.0.0"
+        "react-leaflet-cluster": "^4.0.0",
+        "sql.js": "1.14.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
@@ -3770,6 +3771,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/sql.js": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/sql.js/-/sql.js-1.14.1.tgz",
+      "integrity": "sha512-gcj8zBWU5cFsi9WUP+4bFNXAyF1iRpA3LLyS/DP5xlrNzGmPIizUeBggKa8DbDwdqaKwUcTEnChtd2grWo/x/A==",
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-leaflet": "^5.0.0",
-    "react-leaflet-cluster": "^4.0.0"
+    "react-leaflet-cluster": "^4.0.0",
+    "sql.js": "1.14.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/sqlite-wasm-prototype.html
+++ b/sqlite-wasm-prototype.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SQLite WASM compatibility prototype</title>
+  </head>
+  <body>
+    <main>
+      <h1>SQLite WASM compatibility prototype</h1>
+      <p>
+        This isolated smoke page does not connect SQLite to the normal CSV
+        application workflow.
+      </p>
+      <pre id="sqlite-wasm-result">Starting worker check...</pre>
+    </main>
+    <script
+      type="module"
+      src="/src/prototypes/sqliteWasm/compatibilityMain.js"
+    ></script>
+  </body>
+</html>

--- a/src/prototypes/sqliteWasm/compatibilityMain.js
+++ b/src/prototypes/sqliteWasm/compatibilityMain.js
@@ -1,0 +1,240 @@
+const resultElement = document.querySelector("#sqlite-wasm-result");
+const OPERATION_TIMEOUT_MS = 30_000;
+const SAMPLE_ROW_COUNT = 30_000;
+const STOCKHOLM_BOUNDS = {
+  north: 59.42,
+  south: 59.28,
+  east: 18.12,
+  west: 17.98,
+};
+
+/**
+ * Run a representative, isolated SQLite WASM workflow through named worker operations.
+ * The normal CSV and map application never imports or calls this prototype.
+ */
+export async function runSqliteWasmCompatibilityCheck() {
+  const firstWorker = createWorkerClient(showProgress);
+  let firstWorkerClosed = false;
+
+  try {
+    const initialization = await firstWorker.request("initialize");
+    const emptyBeforeSeed = await firstWorker.request("get-summary");
+    assertCount(emptyBeforeSeed.featureCount, 0, "A new worker database was not empty.");
+
+    const seed = await firstWorker.request("seed-sample-data", {
+      rowCount: SAMPLE_ROW_COUNT,
+    });
+    assertCount(
+      seed.insertedFeatureCount,
+      SAMPLE_ROW_COUNT,
+      "The transactional sample insert returned an unexpected count.",
+    );
+
+    const populatedSummary = await firstWorker.request("get-summary");
+    assertCount(populatedSummary.datasetCount, 1, "Expected one prototype dataset.");
+    assertCount(
+      populatedSummary.featureCount,
+      SAMPLE_ROW_COUNT,
+      "The populated database returned an unexpected feature count.",
+    );
+
+    const viewport = await firstWorker.request("query-viewport", {
+      bounds: STOCKHOLM_BOUNDS,
+      limit: 25,
+    });
+    assertCount(
+      viewport.totalMatchingCount,
+      10_000,
+      "The Stockholm viewport query returned an unexpected match count.",
+    );
+    assertCount(viewport.returnedCount, 25, "The viewport limit was not applied.");
+
+    const detail = await firstWorker.request("get-feature-detail", {
+      datasetId: seed.datasetId,
+      sourceRowIndex: 0,
+    });
+    if (!detail.found || detail.feature?.fields?.name !== "Prototype point 0") {
+      throw new Error("The named detail query returned an unexpected feature.");
+    }
+
+    await firstWorker.request("close");
+    firstWorkerClosed = true;
+    firstWorker.terminate();
+
+    const restart = await verifyFreshWorkerDatabase();
+
+    return {
+      sqliteVersion: initialization.sqliteVersion,
+      databaseStorage: initialization.databaseStorage,
+      workerType: initialization.workerType,
+      crossOriginIsolated: initialization.crossOriginIsolated,
+      sharedArrayBufferRequired: initialization.sharedArrayBufferRequired,
+      namedOperations: [
+        "initialize",
+        "seed-sample-data",
+        "get-summary",
+        "query-viewport",
+        "get-feature-detail",
+        "close",
+      ],
+      sampleData: {
+        datasetCount: populatedSummary.datasetCount,
+        featureCount: populatedSummary.featureCount,
+        transactionUsed: seed.transactionUsed,
+      },
+      viewport,
+      detail,
+      restart,
+      timingsMs: {
+        initialize: initialization.durationMs,
+        insertTransaction: seed.durationMs,
+        populatedSummary: populatedSummary.durationMs,
+        viewportQuery: viewport.durationMs,
+        detailQuery: detail.durationMs,
+        restartInitialize: restart.initializeDurationMs,
+        restartSummary: restart.summaryDurationMs,
+      },
+    };
+  } finally {
+    if (!firstWorkerClosed) {
+      firstWorker.terminate();
+    }
+  }
+}
+
+async function verifyFreshWorkerDatabase() {
+  const restartedWorker = createWorkerClient(showProgress);
+
+  try {
+    const initialization = await restartedWorker.request("initialize");
+    const summary = await restartedWorker.request("get-summary");
+    assertCount(
+      summary.featureCount,
+      0,
+      "A restarted worker unexpectedly retained feature rows.",
+    );
+    assertCount(
+      summary.datasetCount,
+      0,
+      "A restarted worker unexpectedly retained dataset rows.",
+    );
+    await restartedWorker.request("close");
+
+    return {
+      verifiedEmpty: true,
+      datasetCount: summary.datasetCount,
+      featureCount: summary.featureCount,
+      initializeDurationMs: initialization.durationMs,
+      summaryDurationMs: summary.durationMs,
+    };
+  } finally {
+    restartedWorker.terminate();
+  }
+}
+
+function createWorkerClient(onProgress) {
+  const worker = new Worker(
+    new URL("./compatibilityWorker.js", import.meta.url),
+    { type: "module" },
+  );
+  const pendingRequests = new Map();
+  let nextRequestId = 1;
+  let terminated = false;
+
+  worker.addEventListener("message", (event) => {
+    const message = event.data;
+
+    if (message?.type === "progress") {
+      onProgress(message.stage ?? "unknown-stage");
+      return;
+    }
+
+    if (message?.type !== "response") return;
+    const pending = pendingRequests.get(message.requestId);
+    if (!pending) return;
+
+    globalThis.clearTimeout(pending.timeoutId);
+    pendingRequests.delete(message.requestId);
+
+    if (message.ok === true) {
+      pending.resolve(message.result);
+      return;
+    }
+
+    pending.reject(new Error(
+      message.error?.message ?? "SQLite WASM worker operation failed.",
+    ));
+  });
+
+  worker.addEventListener("error", (event) => {
+    rejectAllPending(
+      new Error(event.message || "SQLite WASM worker failed to load."),
+    );
+  });
+
+  function request(operation, payload = {}) {
+    if (terminated) {
+      return Promise.reject(new Error("The SQLite WASM worker is terminated."));
+    }
+
+    const requestId = nextRequestId;
+    nextRequestId += 1;
+
+    return new Promise((resolve, reject) => {
+      const timeoutId = globalThis.setTimeout(() => {
+        pendingRequests.delete(requestId);
+        reject(new Error(
+          `SQLite WASM operation "${operation}" timed out after ${OPERATION_TIMEOUT_MS} ms.`,
+        ));
+      }, OPERATION_TIMEOUT_MS);
+
+      pendingRequests.set(requestId, { resolve, reject, timeoutId });
+      worker.postMessage({ requestId, operation, payload });
+    });
+  }
+
+  function rejectAllPending(error) {
+    pendingRequests.forEach((pending) => {
+      globalThis.clearTimeout(pending.timeoutId);
+      pending.reject(error);
+    });
+    pendingRequests.clear();
+  }
+
+  return {
+    request,
+    terminate() {
+      if (terminated) return;
+      terminated = true;
+      worker.terminate();
+      rejectAllPending(new Error("The SQLite WASM worker was terminated."));
+    },
+  };
+}
+
+function assertCount(actual, expected, message) {
+  if (actual !== expected) {
+    throw new Error(`${message} Expected ${expected}, received ${actual}.`);
+  }
+}
+
+function showProgress(stage) {
+  resultElement.textContent = `Worker stage: ${stage}`;
+}
+
+runSqliteWasmCompatibilityCheck()
+  .then((result) => {
+    resultElement.textContent = JSON.stringify(
+      { status: "passed", ...result },
+      null,
+      2,
+    );
+    document.title = "PASS - SQLite WASM compatibility prototype";
+  })
+  .catch((error) => {
+    resultElement.textContent = JSON.stringify({
+      status: "failed",
+      message: error?.message ? String(error.message) : String(error),
+    }, null, 2);
+    document.title = "FAIL - SQLite WASM compatibility prototype";
+  });

--- a/src/prototypes/sqliteWasm/compatibilityWorker.js
+++ b/src/prototypes/sqliteWasm/compatibilityWorker.js
@@ -1,0 +1,452 @@
+import initSqlJs from "sql.js/dist/sql-wasm-browser.js";
+import sqlWasmUrl from "sql.js/dist/sql-wasm-browser.wasm?url";
+
+const DEFAULT_SAMPLE_ROW_COUNT = 30_000;
+const MAX_SAMPLE_ROW_COUNT = 50_000;
+const DEFAULT_VIEWPORT_LIMIT = 25;
+const MAX_VIEWPORT_LIMIT = 1_000;
+const PROTOTYPE_DATASET_ID = "prototype-dataset";
+
+let SQL = null;
+let database = null;
+
+self.addEventListener("message", (event) => {
+  void handleRequest(event.data);
+});
+
+async function handleRequest(message) {
+  const requestId = message?.requestId;
+  const operation = message?.operation;
+
+  if (!requestId || typeof operation !== "string") {
+    postFailure(requestId, "invalid-request", "A request ID and named operation are required.");
+    return;
+  }
+
+  postProgress(requestId, `${operation}:started`);
+
+  try {
+    let result;
+
+    switch (operation) {
+      case "initialize":
+        result = await initializeDatabase(requestId);
+        break;
+      case "seed-sample-data":
+        result = seedSampleData(message.payload);
+        break;
+      case "get-summary":
+        result = getSummary();
+        break;
+      case "query-viewport":
+        result = queryViewport(message.payload);
+        break;
+      case "get-feature-detail":
+        result = getFeatureDetail(message.payload);
+        break;
+      case "close":
+        result = closeDatabase();
+        break;
+      default:
+        throw new PrototypeError(
+          "unsupported-operation",
+          `Unsupported worker operation: ${operation}`,
+        );
+    }
+
+    self.postMessage({
+      type: "response",
+      requestId,
+      ok: true,
+      result,
+    });
+  } catch (error) {
+    postFailure(
+      requestId,
+      error?.code ?? "prototype-operation-failed",
+      error?.message ? String(error.message) : String(error),
+    );
+  }
+}
+
+async function initializeDatabase(requestId) {
+  if (database) {
+    return getInitializationResult(0, true);
+  }
+
+  const startedAt = performance.now();
+  SQL ??= await initSqlJs({
+    locateFile: () => sqlWasmUrl,
+  });
+  postProgress(requestId, "initialize:sqlite-module-ready");
+
+  // No database bytes are supplied, so every worker starts with a fresh in-memory database.
+  database = new SQL.Database();
+  postProgress(requestId, "initialize:database-created");
+  createSchema(database);
+  postProgress(requestId, "initialize:schema-created");
+
+  return getInitializationResult(elapsedMilliseconds(startedAt), false);
+}
+
+function createSchema(targetDatabase) {
+  targetDatabase.run("PRAGMA foreign_keys = ON");
+  targetDatabase.run(`
+    CREATE TABLE datasets (
+      id TEXT PRIMARY KEY,
+      file_name TEXT NOT NULL,
+      source_path TEXT,
+      row_count INTEGER NOT NULL DEFAULT 0,
+      imported_feature_count INTEGER NOT NULL DEFAULT 0,
+      skipped_row_count INTEGER NOT NULL DEFAULT 0,
+      columns_json TEXT NOT NULL DEFAULT '[]',
+      enabled INTEGER NOT NULL DEFAULT 1 CHECK (enabled IN (0, 1)),
+      imported_at TEXT NOT NULL
+    );
+
+    CREATE TABLE features (
+      id TEXT PRIMARY KEY,
+      dataset_id TEXT NOT NULL,
+      source_row_index INTEGER NOT NULL,
+      lat REAL NOT NULL,
+      lon REAL NOT NULL,
+      timeline_start_year INTEGER,
+      timeline_end_year INTEGER,
+      compact_json TEXT NOT NULL DEFAULT '{}',
+      row_json TEXT NOT NULL DEFAULT '{}',
+      FOREIGN KEY (dataset_id) REFERENCES datasets(id) ON DELETE CASCADE
+    );
+
+    CREATE INDEX idx_features_dataset
+      ON features(dataset_id);
+
+    CREATE INDEX idx_features_dataset_lat_lon
+      ON features(dataset_id, lat, lon);
+
+    CREATE INDEX idx_features_dataset_timeline
+      ON features(dataset_id, timeline_start_year, timeline_end_year);
+
+    CREATE UNIQUE INDEX idx_features_dataset_source_row
+      ON features(dataset_id, source_row_index);
+  `);
+}
+
+function seedSampleData(payload) {
+  ensureDatabase();
+  const rowCount = normalizeInteger(
+    payload?.rowCount,
+    DEFAULT_SAMPLE_ROW_COUNT,
+    1,
+    MAX_SAMPLE_ROW_COUNT,
+  );
+  const currentSummary = getSummary();
+
+  if (currentSummary.featureCount !== 0 || currentSummary.datasetCount !== 0) {
+    throw new PrototypeError(
+      "database-not-empty",
+      "Sample data can only be seeded into an empty prototype database.",
+    );
+  }
+
+  const startedAt = performance.now();
+  database.run("BEGIN TRANSACTION");
+  let insertFeature = null;
+
+  try {
+    database.run(
+      `INSERT INTO datasets (
+        id, file_name, source_path, row_count, imported_feature_count,
+        skipped_row_count, columns_json, enabled, imported_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        PROTOTYPE_DATASET_ID,
+        "prototype-30000.csv",
+        null,
+        rowCount,
+        rowCount,
+        0,
+        JSON.stringify(["name", "latitude", "longitude", "year"]),
+        1,
+        "2026-01-01T00:00:00.000Z",
+      ],
+    );
+
+    insertFeature = database.prepare(`
+      INSERT INTO features (
+        id, dataset_id, source_row_index, lat, lon,
+        timeline_start_year, timeline_end_year, compact_json, row_json
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+
+    for (let rowIndex = 0; rowIndex < rowCount; rowIndex += 1) {
+      const point = createDeterministicPoint(rowIndex);
+      insertFeature.run([
+        `${PROTOTYPE_DATASET_ID}:${rowIndex}`,
+        PROTOTYPE_DATASET_ID,
+        rowIndex,
+        point.lat,
+        point.lon,
+        point.year,
+        point.year,
+        JSON.stringify({
+          marker: point.region,
+          latField: "latitude",
+          lonField: "longitude",
+        }),
+        JSON.stringify({
+          name: `Prototype point ${rowIndex}`,
+          latitude: point.lat.toFixed(6),
+          longitude: point.lon.toFixed(6),
+          year: String(point.year),
+          region: point.region,
+        }),
+      ]);
+    }
+
+    database.run("COMMIT");
+  } catch (error) {
+    database.run("ROLLBACK");
+    throw error;
+  } finally {
+    insertFeature?.free();
+  }
+
+  return {
+    datasetId: PROTOTYPE_DATASET_ID,
+    insertedFeatureCount: rowCount,
+    transactionUsed: true,
+    durationMs: elapsedMilliseconds(startedAt),
+  };
+}
+
+function getSummary() {
+  ensureDatabase();
+  const startedAt = performance.now();
+  const row = getOne(`
+    SELECT
+      (SELECT COUNT(*) FROM datasets) AS dataset_count,
+      (SELECT COUNT(*) FROM features) AS feature_count
+  `);
+
+  return {
+    datasetCount: normalizeCount(row?.dataset_count),
+    featureCount: normalizeCount(row?.feature_count),
+    durationMs: elapsedMilliseconds(startedAt),
+  };
+}
+
+function queryViewport(payload) {
+  ensureDatabase();
+  const bounds = normalizeBounds(payload?.bounds);
+  const limit = normalizeInteger(
+    payload?.limit,
+    DEFAULT_VIEWPORT_LIMIT,
+    1,
+    MAX_VIEWPORT_LIMIT,
+  );
+  const startedAt = performance.now();
+  const parameters = [bounds.south, bounds.north, bounds.west, bounds.east];
+  const countRow = getOne(`
+    SELECT COUNT(*) AS count
+    FROM features
+    WHERE dataset_id IN (SELECT id FROM datasets WHERE enabled = 1)
+      AND lat BETWEEN ? AND ?
+      AND lon BETWEEN ? AND ?
+  `, parameters);
+  const rows = getAll(`
+    SELECT id, dataset_id, source_row_index, lat, lon,
+      timeline_start_year, timeline_end_year, compact_json
+    FROM features
+    WHERE dataset_id IN (SELECT id FROM datasets WHERE enabled = 1)
+      AND lat BETWEEN ? AND ?
+      AND lon BETWEEN ? AND ?
+    ORDER BY dataset_id, source_row_index
+    LIMIT ?
+  `, [...parameters, limit]);
+
+  return {
+    bounds,
+    totalMatchingCount: normalizeCount(countRow?.count),
+    returnedCount: rows.length,
+    sampleRows: rows.slice(0, 3).map((row) => ({
+      id: String(row.id),
+      datasetId: String(row.dataset_id),
+      sourceRowIndex: normalizeCount(row.source_row_index),
+      lat: Number(row.lat),
+      lon: Number(row.lon),
+    })),
+    durationMs: elapsedMilliseconds(startedAt),
+  };
+}
+
+function getFeatureDetail(payload) {
+  ensureDatabase();
+  const datasetId = String(payload?.datasetId ?? "").trim();
+  const sourceRowIndex = normalizeInteger(payload?.sourceRowIndex, -1, 0, Number.MAX_SAFE_INTEGER);
+
+  if (!datasetId || sourceRowIndex < 0) {
+    throw new PrototypeError(
+      "invalid-detail-reference",
+      "A dataset ID and non-negative source row index are required.",
+    );
+  }
+
+  const startedAt = performance.now();
+  const row = getOne(`
+    SELECT id, dataset_id, source_row_index, lat, lon, row_json
+    FROM features
+    WHERE dataset_id = ? AND source_row_index = ?
+  `, [datasetId, sourceRowIndex]);
+
+  return {
+    found: Boolean(row),
+    feature: row ? {
+      id: String(row.id),
+      datasetId: String(row.dataset_id),
+      sourceRowIndex: normalizeCount(row.source_row_index),
+      lat: Number(row.lat),
+      lon: Number(row.lon),
+      fields: parseJsonObject(row.row_json),
+    } : null,
+    durationMs: elapsedMilliseconds(startedAt),
+  };
+}
+
+function closeDatabase() {
+  const wasOpen = Boolean(database);
+  database?.close();
+  database = null;
+
+  return { closed: wasOpen };
+}
+
+function getInitializationResult(durationMs, reused) {
+  return {
+    sqliteVersion: getOne("SELECT sqlite_version() AS version")?.version ?? null,
+    databaseStorage: "memory",
+    workerType: "dedicated-module-worker",
+    crossOriginIsolated: self.crossOriginIsolated === true,
+    sharedArrayBufferRequired: false,
+    reused,
+    durationMs,
+  };
+}
+
+function getOne(sql, parameters = []) {
+  return getAll(sql, parameters, 1)[0] ?? null;
+}
+
+function getAll(sql, parameters = [], maximumRows = Number.POSITIVE_INFINITY) {
+  const statement = database.prepare(sql);
+  const rows = [];
+
+  try {
+    statement.bind(parameters);
+    while (rows.length < maximumRows && statement.step()) {
+      rows.push(statement.getAsObject());
+    }
+  } finally {
+    statement.free();
+  }
+
+  return rows;
+}
+
+function createDeterministicPoint(rowIndex) {
+  const clusterIndex = Math.floor(rowIndex / 10_000) % 3;
+  const position = rowIndex % 10_000;
+  const row = position % 100;
+  const column = Math.floor(position / 100);
+  const regions = [
+    { name: "stockholm", lat: 59.3, lon: 18.0 },
+    { name: "western-europe", lat: 40.0, lon: -10.0 },
+    { name: "sydney", lat: -33.9, lon: 151.15 },
+  ];
+  const region = regions[clusterIndex];
+
+  return {
+    lat: region.lat + row * 0.001,
+    lon: region.lon + column * 0.001,
+    year: 1900 + (rowIndex % 125),
+    region: region.name,
+  };
+}
+
+function normalizeBounds(bounds) {
+  const north = Number(bounds?.north);
+  const south = Number(bounds?.south);
+  const east = Number(bounds?.east);
+  const west = Number(bounds?.west);
+
+  if (![north, south, east, west].every(Number.isFinite)) {
+    throw new PrototypeError("invalid-bounds", "Finite viewport bounds are required.");
+  }
+
+  return {
+    north: Math.max(-90, Math.min(90, Math.max(north, south))),
+    south: Math.max(-90, Math.min(90, Math.min(north, south))),
+    east: Math.max(-180, Math.min(180, east)),
+    west: Math.max(-180, Math.min(180, west)),
+  };
+}
+
+function normalizeInteger(value, fallback, minimum, maximum) {
+  const number = Number.parseInt(value, 10);
+  if (!Number.isFinite(number)) return fallback;
+  return Math.min(maximum, Math.max(minimum, number));
+}
+
+function normalizeCount(value) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : 0;
+}
+
+function parseJsonObject(value) {
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function elapsedMilliseconds(startedAt) {
+  return Number((performance.now() - startedAt).toFixed(2));
+}
+
+function ensureDatabase() {
+  if (!database) {
+    throw new PrototypeError(
+      "database-not-initialized",
+      "Initialize the prototype database before running this operation.",
+    );
+  }
+}
+
+function postProgress(requestId, stage) {
+  self.postMessage({
+    type: "progress",
+    requestId,
+    stage,
+  });
+}
+
+function postFailure(requestId, code, message) {
+  self.postMessage({
+    type: "response",
+    requestId,
+    ok: false,
+    error: {
+      code,
+      message,
+    },
+  });
+}
+
+class PrototypeError extends Error {
+  constructor(code, message) {
+    super(message);
+    this.name = "PrototypeError";
+    this.code = code;
+  }
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -6,4 +6,17 @@ import react from "@vitejs/plugin-react";
 export default defineConfig(({ mode }) => ({
   plugins: [react()],
   base: mode === "desktop" ? "./" : mode === "production" ? "/csv-map-layer-visualizer/" : "/",
+  worker: {
+    format: "es",
+  },
+  build: {
+    rollupOptions: {
+      input: mode === "desktop"
+        ? { app: "index.html" }
+        : {
+            app: "index.html",
+            sqliteWasmPrototype: "sqlite-wasm-prototype.html",
+          },
+    },
+  },
 }));


### PR DESCRIPTION
## Summary

Adds an isolated SQLite WASM prototype to the GitHub Pages build using the pinned `sql.js@1.14.1` browser-specific WASM distribution.

## What changed

- Added a standalone `sqlite-wasm-prototype.html` page
- Runs SQLite in a dedicated module Web Worker
- Uses named worker operations instead of accepting arbitrary SQL
- Mirrors the existing `datasets` and `features` schema
- Generates and transactionally inserts 30,000 deterministic points
- Tests summary, viewport, and detail queries
- Restarts the worker and confirms that the in-memory database is empty
- Added prototype decision, security, validation, limitations, and cleanup documentation
- Keeps the prototype out of desktop builds and isolated from the normal browser application

## Validation

- `npm run lint`
- `npm run build`
- `npm run build:desktop`
- Production-preview validation in Chrome

Observed local results:

- 30,000-row transaction: approximately 312 ms
- 10,000-match viewport query: approximately 13 ms
- Detail lookup: approximately 0.2 ms
- SQLite version: 3.49.1
- No cross-origin isolation or `SharedArrayBuffer` required
- Normal application entry continued to return HTTP 200
- Desktop build emitted no prototype artifacts

## Scope

This does not integrate SQLite WASM with the normal CSV, React, or map workflow. The database is temporary and exists only in worker memory.

The documentation includes required follow-up cleanup for both outcomes:

- If adopted, move the useful logic into production modules and tests, then remove the standalone prototype.
- If rejected, remove the prototype, dependency, and unused Vite configuration.

Closes #102
