### PR TITLE
Add browser SQLite point queries, grouping, and details

### DIFF
--- a/docs/browser-sqlite-point-query-architecture.md
+++ b/docs/browser-sqlite-point-query-architecture.md
@@ -1,0 +1,63 @@
+# Browser SQLite point-query architecture
+
+Issue #105 adds point derivation and query operations to the temporary browser
+SQLite backend. It does not select that backend in the normal browser runtime;
+the existing GitHub Pages data path and desktop SQLite implementation remain
+unchanged.
+
+## Storage boundary
+
+`source_rows` remains the authoritative store for complete normalized CSV rows.
+The `point_features` table contains only the stable source reference,
+coordinates, timeline extent, and compact presentation JSON needed by map
+queries. Its composite foreign key cascades from `source_rows`, so dataset
+removal cannot leave derived records behind.
+
+Import finalization builds point records before committing the file transaction.
+Coordinate remapping updates metadata and rebuilds only the affected dataset in
+one transaction. A failed rebuild therefore preserves both the previous mapping
+and its working derived records.
+
+Rows with invalid point coordinates remain available in `source_rows`. Rows
+explicitly marked for another feature type are not counted as invalid points and
+are reserved for later line and region work.
+
+## Query behavior
+
+Viewport queries resolve the enabled dataset set once, then apply bounds and
+timeline overlap in SQLite before counting or grouping. Wrapped Leaflet bounds
+use the two longitude segments on either side of the antimeridian. Timeline
+filtering uses inclusive year-range overlap; disabled timeline state includes
+undated points, while enabled state excludes them. Day-of-year state remains
+intentionally unapplied, preserving the browser parity decision from issue
+#103.
+
+Results at or below the render budget are exact and ordered by dataset and
+source-row index. Dense results use a deterministic viewport-relative grid and
+choose the first dataset/source row in each occupied cell as the representative.
+Viewport responses never select or return `row_json`.
+
+## Details and group paging
+
+Exact details accept only a stable dataset/source-row reference and join the
+derived point to its original source row and current coordinate mapping.
+
+Every grouped result captures its originating bounds, normalized timeline,
+enabled dataset snapshot, grid cell, and stable sort order. Group paging uses
+that captured context rather than current map or visibility state, defaults to
+30 rows, and is capped at 100 rows per worker response. Removed datasets and
+points invalidated by later remapping naturally disappear because paging joins
+the current derived table back to `source_rows`.
+
+## Worker boundary
+
+The worker protocol exposes only three additional named operations:
+
+- `query-map-view`
+- `get-feature-details`
+- `get-group-rows`
+
+Their payloads are strictly validated and cannot contain SQL, database handles,
+or unrestricted row filters. All operations use the worker's existing serialized
+database queue, and complete rows cross the worker boundary only through an
+explicit detail or bounded paging request.

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "smoke:browser-sqlite-worker-runtime": "node src/data/browserSqlite/browserSqliteWorkerRuntime.smoke.js",
     "smoke:browser-sqlite-worker-client": "node src/data/browserSqlite/browserSqliteWorkerClient.smoke.js",
     "smoke:browser-sqlite-data-source": "node src/data/browserSqlite/browserSqliteDataSource.smoke.js",
+    "smoke:browser-sqlite-points": "node src/data/browserSqlite/browserSqlitePointQueries.smoke.js",
     "validate:browser-sqlite-worker": "node desktop/run-electron.cjs desktop/browserSqliteWorkerValidation.cjs",
     "smoke:csv-compatibility": "node src/data/csvParsingCompatibility.smoke.js",
     "smoke:data-source-normalization": "node src/data/dataSourceNormalization.smoke.js",

--- a/src/data/browserSqlite/browserSqliteDataSource.js
+++ b/src/data/browserSqlite/browserSqliteDataSource.js
@@ -11,6 +11,9 @@ import {
   normalizeImportCancellationResult,
   normalizeImportProgress,
   normalizeInitializationResult,
+  normalizeFeatureDetailsResult,
+  normalizeGroupRowsResult,
+  normalizeMapViewResult,
   normalizeMappingMutationResult,
   normalizePreviewPageResult,
 } from '../dataSourceNormalization.js';
@@ -32,10 +35,10 @@ const CAPABILITIES = normalizeBackendCapabilities({
   datasetRemoval: true,
   datasetMapping: true,
   previewPaging: true,
-  points: false,
+  points: true,
   lines: false,
   regions: false,
-  groupedViewportResults: false,
+  groupedViewportResults: true,
 });
 
 /** Create the unselected browser SQLite data-source adapter. */
@@ -255,19 +258,38 @@ export function createBrowserSqliteDataSource({ client } = {}) {
       }
     },
 
-    queryMapView() {
+    async queryMapView(query = {}) {
       assertActive(DATA_SOURCE_METHODS.queryMapView);
-      throw unsupportedFailure(DATA_SOURCE_METHODS.queryMapView);
+      try {
+        return normalizeMapViewResult(await workerClient.queryMapView(query));
+      } catch (error) {
+        throw workerFailure(DATA_SOURCE_METHODS.queryMapView, error);
+      }
     },
 
-    getFeatureDetails() {
+    async getFeatureDetails(query = {}) {
       assertActive(DATA_SOURCE_METHODS.getFeatureDetails);
-      throw unsupportedFailure(DATA_SOURCE_METHODS.getFeatureDetails);
+      try {
+        return normalizeFeatureDetailsResult(
+          await workerClient.getFeatureDetails(query),
+        );
+      } catch (error) {
+        throw workerFailure(DATA_SOURCE_METHODS.getFeatureDetails, error, {
+          datasetId: query.sourceRef?.datasetId,
+        });
+      }
     },
 
-    getGroupRows() {
+    async getGroupRows(query = {}) {
       assertActive(DATA_SOURCE_METHODS.getGroupRows);
-      throw unsupportedFailure(DATA_SOURCE_METHODS.getGroupRows);
+      try {
+        return normalizeGroupRowsResult(
+          await workerClient.getGroupRows(query),
+          query,
+        );
+      } catch (error) {
+        throw workerFailure(DATA_SOURCE_METHODS.getGroupRows, error);
+      }
     },
 
     dispose() {
@@ -340,15 +362,6 @@ function unsupportedImport(operation) {
     operation,
     category: BACKEND_FAILURE_CATEGORIES.BACKEND_UNAVAILABLE,
     message: 'This import operation is unavailable.',
-  });
-}
-
-function unsupportedFailure(operation) {
-  return normalizeBackendFailure(null, {
-    category: BACKEND_FAILURE_CATEGORIES.BACKEND_UNAVAILABLE,
-    operation,
-    message: 'This browser data operation is unavailable.',
-    recoverable: false,
   });
 }
 

--- a/src/data/browserSqlite/browserSqliteDataSource.smoke.js
+++ b/src/data/browserSqlite/browserSqliteDataSource.smoke.js
@@ -141,6 +141,46 @@ class FakeWorkerClient {
     });
   }
 
+  queryMapView(query) {
+    this.calls.push(['queryMapView', query]);
+    return this.result({
+      points: [{
+        id: 'dataset-1:0',
+        renderType: 'exact',
+        lat: 1,
+        lon: 2,
+        count: 1,
+        sourceRef: { datasetId: 'dataset-1', rowIndex: 0 },
+        marker: 'blue',
+        row: { mustNotEscape: true },
+      }],
+      lines: [],
+      regions: [],
+      stats: { totalMatchingCount: 1, returnedCount: 1 },
+      timelineIndex: { entries: [] },
+    });
+  }
+
+  getFeatureDetails(query) {
+    this.calls.push(['getFeatureDetails', query]);
+    return this.result({
+      featureId: 'dataset-1:0',
+      row: { name: 'One', count: 2 },
+      latField: 'lat',
+      lonField: 'lon',
+    });
+  }
+
+  getGroupRows(query) {
+    this.calls.push(['getGroupRows', query]);
+    return this.result({
+      rows: [{ name: 'One', count: 2 }],
+      offset: query.offset ?? 0,
+      limit: query.limit ?? 30,
+      totalRows: 1,
+    });
+  }
+
   dispose() {
     this.disposeCount += 1;
   }
@@ -164,7 +204,8 @@ assert.equal(initialized.capabilities.browserFileImport, true);
 assert.equal(initialized.capabilities.droppedFileImport, true);
 assert.equal(initialized.capabilities.datasetSelection, true);
 assert.equal(initialized.capabilities.previewPaging, true);
-assert.equal(initialized.capabilities.points, false);
+assert.equal(initialized.capabilities.points, true);
+assert.equal(initialized.capabilities.groupedViewportResults, true);
 assert.deepEqual(dataSource.getCapabilities(), initialized.capabilities);
 
 const observedProgress = [];
@@ -246,12 +287,21 @@ assert.equal(summary.selectedDatasetId, 'dataset-1');
 const missingRemoval = await dataSource.removeDataset('dataset-2');
 assert.equal(missingRemoval.error.category, 'dataset-not-found');
 
-for (const method of ['queryMapView', 'getFeatureDetails', 'getGroupRows']) {
-  assert.throws(() => dataSource[method](), (error) => (
-    error.category === 'backend-unavailable' &&
-    error.operation === DATA_SOURCE_METHODS[method]
-  ));
-}
+const mapView = await dataSource.queryMapView({
+  bounds: { north: 10, south: 0, east: 10, west: 0 },
+});
+assert.equal(mapView.points.length, 1);
+assert.equal(Object.hasOwn(mapView.points[0], 'row'), false);
+assert.deepEqual(client.calls.at(-1), [
+  'queryMapView',
+  { bounds: { north: 10, south: 0, east: 10, west: 0 } },
+]);
+const featureDetails = await dataSource.getFeatureDetails({
+  sourceRef: { datasetId: 'dataset-1', rowIndex: 0 },
+});
+assert.deepEqual(featureDetails.row, { name: 'One', count: '2' });
+const groupRows = await dataSource.getGroupRows({ offset: 0, limit: 1 });
+assert.deepEqual(groupRows.rows, [{ name: 'One', count: '2' }]);
 
 client.failure = { code: 'invalid-mapping', message: 'private detail' };
 const invalidMapping = await dataSource.updateDatasetMapping('dataset-1', {
@@ -276,7 +326,7 @@ client.failure = null;
 dataSource.dispose();
 dataSource.dispose();
 assert.equal(client.disposeCount, 1);
-assert.throws(() => dataSource.queryMapView(), (error) => (
+await assert.rejects(dataSource.queryMapView(), (error) => (
   error.category === 'backend-unavailable'
 ));
 const disposedInitialization = await dataSource.initialize();

--- a/src/data/browserSqlite/browserSqliteDatabase.js
+++ b/src/data/browserSqlite/browserSqliteDatabase.js
@@ -4,7 +4,7 @@
  * The version describes databases created during the current page session. It
  * does not imply that database bytes are persisted or migrated across sessions.
  */
-export const BROWSER_SQLITE_SCHEMA_VERSION = 1;
+export const BROWSER_SQLITE_SCHEMA_VERSION = 2;
 
 const closedDatabases = new WeakSet();
 
@@ -34,7 +34,7 @@ export function createBrowserSqliteDatabase(SQL) {
 }
 
 /**
- * Initialize schema version 1 on a fresh in-memory database.
+ * Initialize the current browser schema on a fresh in-memory database.
  *
  * Foreign keys are enabled before the schema transaction so dataset deletion
  * can safely cascade to original source rows. The composite source-row primary
@@ -67,6 +67,10 @@ export function initializeBrowserSqliteSchema(database) {
           CHECK (stored_row_count >= 0),
         skipped_row_count INTEGER NOT NULL DEFAULT 0
           CHECK (skipped_row_count >= 0),
+        point_feature_count INTEGER NOT NULL DEFAULT 0
+          CHECK (point_feature_count >= 0),
+        skipped_point_count INTEGER NOT NULL DEFAULT 0
+          CHECK (skipped_point_count >= 0),
         enabled INTEGER NOT NULL DEFAULT 1
           CHECK (enabled IN (0, 1)),
         detected_fields_json TEXT NOT NULL DEFAULT '{}'
@@ -101,10 +105,47 @@ export function initializeBrowserSqliteSchema(database) {
           ON DELETE CASCADE
       ) WITHOUT ROWID;
 
+      CREATE TABLE point_features (
+        dataset_id TEXT NOT NULL,
+        source_row_index INTEGER NOT NULL
+          CHECK (source_row_index >= 0),
+        lat REAL NOT NULL
+          CHECK (lat >= -90 AND lat <= 90),
+        lon REAL NOT NULL
+          CHECK (lon >= -180 AND lon <= 180),
+        timeline_start_year INTEGER,
+        timeline_end_year INTEGER,
+        compact_json TEXT NOT NULL DEFAULT '{}'
+          CHECK (json_valid(compact_json)),
+        PRIMARY KEY (dataset_id, source_row_index),
+        FOREIGN KEY (dataset_id, source_row_index)
+          REFERENCES source_rows(dataset_id, source_row_index)
+          ON DELETE CASCADE,
+        CHECK (
+          (timeline_start_year IS NULL AND timeline_end_year IS NULL)
+          OR
+          (
+            timeline_start_year IS NOT NULL
+            AND timeline_end_year IS NOT NULL
+            AND timeline_start_year <= timeline_end_year
+          )
+        )
+      ) WITHOUT ROWID;
+
       CREATE INDEX idx_datasets_imported_order
         ON datasets(imported_at DESC, id);
 
-      PRAGMA user_version = 1;
+      CREATE INDEX idx_point_features_dataset_lat_lon
+        ON point_features(dataset_id, lat, lon);
+
+      CREATE INDEX idx_point_features_dataset_timeline
+        ON point_features(
+          dataset_id,
+          timeline_start_year,
+          timeline_end_year
+        );
+
+      PRAGMA user_version = 2;
     `);
     database.run('COMMIT');
   } catch (error) {

--- a/src/data/browserSqlite/browserSqliteDatabase.smoke.js
+++ b/src/data/browserSqlite/browserSqliteDatabase.smoke.js
@@ -26,7 +26,7 @@ try {
     FROM sqlite_schema
     WHERE type = 'table' AND name NOT LIKE 'sqlite_%'
     ORDER BY name
-  `), ['datasets', 'source_rows']);
+  `), ['datasets', 'point_features', 'source_rows']);
   assert.deepEqual(
     readColumn(database, 'PRAGMA table_info(datasets)', 'name'),
     [
@@ -39,6 +39,8 @@ try {
       'total_parsed_row_count',
       'stored_row_count',
       'skipped_row_count',
+      'point_feature_count',
+      'skipped_point_count',
       'enabled',
       'detected_fields_json',
       'coordinate_mapping_json',
@@ -52,11 +54,24 @@ try {
     ['dataset_id', 'source_row_index', 'row_json'],
   );
   assert.deepEqual(
+    readColumn(database, 'PRAGMA table_info(point_features)', 'name'),
+    [
+      'dataset_id',
+      'source_row_index',
+      'lat',
+      'lon',
+      'timeline_start_year',
+      'timeline_end_year',
+      'compact_json',
+    ],
+  );
+  assert.deepEqual(
     readColumn(database, 'PRAGMA index_list(datasets)', 'name'),
     ['idx_datasets_imported_order', 'sqlite_autoindex_datasets_1'],
   );
   assert.equal(readScalar(database, 'SELECT COUNT(*) FROM datasets'), 0);
   assert.equal(readScalar(database, 'SELECT COUNT(*) FROM source_rows'), 0);
+  assert.equal(readScalar(database, 'SELECT COUNT(*) FROM point_features'), 0);
   assert.equal(persistenceAccessCount, 0);
   assert.equal(closeBrowserSqliteDatabase(database), true);
   assert.equal(closeBrowserSqliteDatabase(database), false);

--- a/src/data/browserSqlite/browserSqliteDatasetMutations.js
+++ b/src/data/browserSqlite/browserSqliteDatasetMutations.js
@@ -1,6 +1,9 @@
 import {
   getBrowserSqliteDatasetSummary,
 } from './browserSqliteDatasetQueries.js';
+import {
+  rebuildBrowserSqlitePointFeatures,
+} from './browserSqlitePointDerivation.js';
 
 /**
  * Enable or disable one completely imported dataset.
@@ -84,11 +87,23 @@ export function updateBrowserSqliteDatasetMapping(
   requireKnownHeader(headers, latField, 'latitude');
   requireKnownHeader(headers, lonField, 'longitude');
 
-  database.run(`
-    UPDATE datasets
-    SET coordinate_mapping_json = ?
-    WHERE id = ? AND import_state = 'complete'
-  `, [JSON.stringify({ latField, lonField }), normalizedId]);
+  database.run('BEGIN TRANSACTION');
+  try {
+    database.run(`
+      UPDATE datasets
+      SET coordinate_mapping_json = ?
+      WHERE id = ? AND import_state = 'complete'
+    `, [JSON.stringify({ latField, lonField }), normalizedId]);
+    rebuildBrowserSqlitePointFeatures(database, normalizedId);
+    database.run('COMMIT');
+  } catch (error) {
+    safeRollback(database);
+    if (error instanceof BrowserSqliteMutationError) throw error;
+    throw new BrowserSqliteMutationError(
+      'operation-failed',
+      'The coordinate mapping could not be rebuilt.',
+    );
+  }
 
   const dataset = getSummaryItem(database, normalizedId);
   return {
@@ -99,6 +114,14 @@ export function updateBrowserSqliteDatasetMapping(
     dataset,
     error: null,
   };
+}
+
+function safeRollback(database) {
+  try {
+    database.run('ROLLBACK');
+  } catch {
+    // Preserve the normalized rebuild failure if SQLite already rolled back.
+  }
 }
 
 function requireCompleteDataset(database, datasetId) {

--- a/src/data/browserSqlite/browserSqliteDatasetQueries.js
+++ b/src/data/browserSqlite/browserSqliteDatasetQueries.js
@@ -22,6 +22,7 @@ export function getBrowserSqliteDatasetSummary(database) {
       total_parsed_row_count,
       stored_row_count,
       skipped_row_count,
+      point_feature_count,
       enabled,
       detected_fields_json,
       coordinate_mapping_json,
@@ -31,6 +32,18 @@ export function getBrowserSqliteDatasetSummary(database) {
     WHERE import_state = 'complete'
     ORDER BY imported_at DESC, id
   `);
+
+  const timelineExtent = readOne(database, `
+    SELECT
+      MIN(point_features.timeline_start_year) AS year_min,
+      MAX(point_features.timeline_end_year) AS year_max
+    FROM point_features
+    INNER JOIN datasets ON datasets.id = point_features.dataset_id
+    WHERE datasets.import_state = 'complete'
+      AND datasets.enabled = 1
+  `);
+  const yearMin = normalizeStoredYear(timelineExtent?.year_min);
+  const yearMax = normalizeStoredYear(timelineExtent?.year_max);
 
   return {
     datasets: rows.map((row) => {
@@ -44,7 +57,7 @@ export function getBrowserSqliteDatasetSummary(database) {
         rowCount: normalizeStoredCount(row.stored_row_count),
         totalRows: normalizeStoredCount(row.total_parsed_row_count),
         sizeBytes: normalizeNullableStoredCount(row.size_bytes),
-        importedFeatureCount: 0,
+        importedFeatureCount: normalizeStoredCount(row.point_feature_count),
         skippedRowCount: normalizeStoredCount(row.skipped_row_count),
         importedAt: normalizeNullableString(row.imported_at),
         latField: normalizeNullableString(mapping.latField),
@@ -54,7 +67,9 @@ export function getBrowserSqliteDatasetSummary(database) {
       };
     }),
     selectedDatasetId: null,
-    timeline: null,
+    timeline: yearMin == null || yearMax == null
+      ? null
+      : { yearMin, yearMax },
   };
 }
 
@@ -194,6 +209,12 @@ function normalizeStoredCount(value) {
 
 function normalizeNullableStoredCount(value) {
   return value == null ? null : normalizeStoredCount(value);
+}
+
+function normalizeStoredYear(value) {
+  if (value == null || value === '') return null;
+  const number = Number(value);
+  return Number.isFinite(number) ? Math.trunc(number) : null;
 }
 
 function normalizeNullableString(value) {

--- a/src/data/browserSqlite/browserSqliteImportTransaction.js
+++ b/src/data/browserSqlite/browserSqliteImportTransaction.js
@@ -1,4 +1,7 @@
 import { MAX_CSV_PARSE_WARNINGS } from '../csvParsingCompatibility.js';
+import {
+  rebuildBrowserSqlitePointFeatures,
+} from './browserSqlitePointDerivation.js';
 
 /** Maximum already-normalized rows accepted by one storage call. */
 export const MAX_BROWSER_SQLITE_IMPORT_BATCH_ROWS = 1_000;
@@ -177,6 +180,12 @@ export function completeBrowserSqliteFileImport(activeImport, metadata) {
       throw new Error('The provisional dataset was unavailable.');
     }
 
+    // Derived points join the file transaction so a failed build cannot leave
+    // committed source rows without their matching query records.
+    const pointResult = rebuildBrowserSqlitePointFeatures(
+      state.database,
+      state.datasetId,
+    );
     state.database.run('COMMIT');
     finishActiveImport(state, 'complete');
 
@@ -185,6 +194,8 @@ export function completeBrowserSqliteFileImport(activeImport, metadata) {
       rowCount: state.nextSourceRowIndex,
       totalParsedRowCount: normalized.totalParsedRowCount,
       skippedRowCount: normalized.skippedRowCount,
+      pointFeatureCount: pointResult.pointFeatureCount,
+      skippedPointCount: pointResult.skippedPointCount,
       importedAt: normalized.importedAt,
     };
   } catch (error) {

--- a/src/data/browserSqlite/browserSqliteImportTransaction.smoke.js
+++ b/src/data/browserSqlite/browserSqliteImportTransaction.smoke.js
@@ -76,6 +76,8 @@ try {
     rowCount: 3,
     totalParsedRowCount: 4,
     skippedRowCount: 1,
+    pointFeatureCount: 2,
+    skippedPointCount: 1,
     importedAt: '2026-07-26T14:00:00.000Z',
   });
   assert.equal(freedInsertStatementCount, 1);

--- a/src/data/browserSqlite/browserSqliteImporter.js
+++ b/src/data/browserSqlite/browserSqliteImporter.js
@@ -244,7 +244,7 @@ function finalizeParsedFile(state) {
     datasetId: committed.datasetId,
     rowCount: committed.rowCount,
     totalParsedRowCount: committed.totalParsedRowCount,
-    importedFeatureCount: 0,
+    importedFeatureCount: committed.pointFeatureCount,
     skippedRowCount: committed.skippedRowCount,
     warnings: [...state.warnings],
     detectedFields,

--- a/src/data/browserSqlite/browserSqliteImporter.smoke.js
+++ b/src/data/browserSqlite/browserSqliteImporter.smoke.js
@@ -72,7 +72,7 @@ try {
   assert.equal(result.totalParsedRowCount, 3);
   assert.equal(result.skippedRowCount, 0);
   assert.equal(result.storedBatchCount, 2);
-  assert.equal(result.importedFeatureCount, 0);
+  assert.equal(result.importedFeatureCount, 2);
   assert.deepEqual(result.detectedFields, {
     latField: 'latitude',
     lonField: 'longitude',

--- a/src/data/browserSqlite/browserSqlitePointDerivation.js
+++ b/src/data/browserSqlite/browserSqlitePointDerivation.js
@@ -1,0 +1,289 @@
+import {
+  isValidLat,
+  isValidLon,
+  parseFlexibleFloat,
+} from '../../components/geoColumns.js';
+import {
+  detectFeatureTypeField,
+  getRowFeatureType,
+} from '../../components/featureTypes.js';
+import {
+  parseDateValue,
+  parseYearValue,
+} from '../../components/timeline.js';
+
+const DEFAULT_IMAGE_SIZE_METERS = 100;
+const MIN_IMAGE_SIZE_METERS = 1;
+const MAX_IMAGE_SIZE_METERS = 100_000;
+const COMPACT_FIELD_NAMES = Object.freeze([
+  'featureType',
+  'featureId',
+  'part',
+  'order',
+  'name',
+  'title',
+  'label',
+  'comment',
+  'marker',
+  'image',
+  'color',
+  'weight',
+]);
+
+/**
+ * Rebuild one dataset's compact point records from its authoritative source rows.
+ *
+ * The caller owns the surrounding transaction. Source rows are stepped one at a
+ * time so remapping does not create a second complete in-memory dataset.
+ *
+ * @param {{ prepare: Function, run: Function }} database sql.js database.
+ * @param {string} datasetId Stable dataset identifier.
+ * @returns {{ pointFeatureCount: number, skippedPointCount: number }}
+ */
+export function rebuildBrowserSqlitePointFeatures(database, datasetId) {
+  requireDatabase(database);
+  const normalizedId = normalizeRequiredId(datasetId);
+  const metadata = readDatasetDerivationMetadata(database, normalizedId);
+  if (!metadata) {
+    throw new BrowserSqlitePointDerivationError(
+      'dataset-not-found',
+      'The requested dataset is unavailable.',
+    );
+  }
+
+  const headers = parseJsonStringList(metadata.columns_json);
+  const mapping = parseJsonObject(metadata.coordinate_mapping_json);
+  const detectedFields = parseJsonObject(metadata.detected_fields_json);
+  const featureTypeField = detectFeatureTypeField(headers);
+  const latField = normalizeNullableString(mapping.latField);
+  const lonField = normalizeNullableString(mapping.lonField);
+  let pointFeatureCount = 0;
+  let skippedPointCount = 0;
+
+  database.run(
+    'DELETE FROM point_features WHERE dataset_id = ?',
+    [normalizedId],
+  );
+
+  if (latField && lonField) {
+    const sourceRows = database.prepare(`
+      SELECT source_row_index, row_json
+      FROM source_rows
+      WHERE dataset_id = ?
+      ORDER BY source_row_index
+    `);
+    let insertPoint = null;
+
+    try {
+      insertPoint = database.prepare(`
+        INSERT INTO point_features (
+          dataset_id,
+          source_row_index,
+          lat,
+          lon,
+          timeline_start_year,
+          timeline_end_year,
+          compact_json
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)
+      `);
+      sourceRows.bind([normalizedId]);
+      while (sourceRows.step()) {
+        const stored = sourceRows.getAsObject();
+        const row = parseJsonObject(stored.row_json);
+        const featureType = getRowFeatureType(row, featureTypeField);
+
+        // Explicit line, region, or unknown feature types are not point failures.
+        if (featureType && featureType !== 'point') continue;
+
+        const lat = parseFlexibleFloat(row[latField]);
+        const lon = parseFlexibleFloat(row[lonField]);
+        if (!isValidLat(lat) || !isValidLon(lon)) {
+          skippedPointCount += 1;
+          continue;
+        }
+
+        const timeline = getTimelineExtent(row, detectedFields);
+        insertPoint.run([
+          normalizedId,
+          normalizeSourceRowIndex(stored.source_row_index),
+          lat,
+          lon,
+          timeline?.startYear ?? null,
+          timeline?.endYear ?? null,
+          JSON.stringify(getCompactFields(row, { latField, lonField })),
+        ]);
+        pointFeatureCount += 1;
+      }
+    } finally {
+      sourceRows.free();
+      insertPoint?.free();
+    }
+  }
+
+  database.run(`
+    UPDATE datasets
+    SET point_feature_count = ?,
+        skipped_point_count = ?
+    WHERE id = ?
+  `, [pointFeatureCount, skippedPointCount, normalizedId]);
+
+  return { pointFeatureCount, skippedPointCount };
+}
+
+function getTimelineExtent(row, fields) {
+  const yearFrom = getRangeYear(
+    row,
+    normalizeNullableString(fields.yearFromField),
+    normalizeNullableString(fields.dateFromField),
+  );
+  const yearTo = getRangeYear(
+    row,
+    normalizeNullableString(fields.yearToField),
+    normalizeNullableString(fields.dateToField),
+  );
+
+  if (yearFrom != null || yearTo != null) {
+    const first = yearFrom ?? yearTo;
+    const last = yearTo ?? yearFrom;
+    return {
+      startYear: Math.min(first, last),
+      endYear: Math.max(first, last),
+    };
+  }
+
+  const year = getRangeYear(
+    row,
+    normalizeNullableString(fields.yearField),
+    normalizeNullableString(fields.dateField),
+  );
+  return year == null ? null : { startYear: year, endYear: year };
+}
+
+function getRangeYear(row, yearField, dateField) {
+  if (yearField) {
+    const year = parseYearValue(row[yearField]);
+    if (year != null) return year;
+  }
+  if (dateField) {
+    const date = parseDateValue(row[dateField]);
+    if (date) return date.getUTCFullYear();
+  }
+  return null;
+}
+
+function getCompactFields(row, mapping) {
+  const compact = {
+    latField: mapping.latField,
+    lonField: mapping.lonField,
+  };
+
+  for (const key of COMPACT_FIELD_NAMES) {
+    if (Object.hasOwn(row, key)) compact[key] = row[key];
+  }
+
+  compact.image = resolvePointImage(row.image);
+  compact.imageWidthMeters = normalizeImageSizeMeters(row.imageWidthMeters);
+  compact.imageHeightMeters = normalizeImageSizeMeters(row.imageHeightMeters);
+  return compact;
+}
+
+function resolvePointImage(value) {
+  if (typeof value !== 'string') return null;
+  const image = value.trim();
+  if (!image) return null;
+  if (image.startsWith('/') || /^https?:\/\//i.test(image)) return image;
+  return `/point-images/${image}`;
+}
+
+function normalizeImageSizeMeters(value) {
+  const number = parseFlexibleFloat(value);
+  if (!Number.isFinite(number)) return DEFAULT_IMAGE_SIZE_METERS;
+  return Math.min(
+    MAX_IMAGE_SIZE_METERS,
+    Math.max(MIN_IMAGE_SIZE_METERS, number),
+  );
+}
+
+function readDatasetDerivationMetadata(database, datasetId) {
+  const statement = database.prepare(`
+    SELECT
+      columns_json,
+      detected_fields_json,
+      coordinate_mapping_json
+    FROM datasets
+    WHERE id = ?
+  `);
+  try {
+    statement.bind([datasetId]);
+    return statement.step() ? statement.getAsObject() : null;
+  } finally {
+    statement.free();
+  }
+}
+
+function parseJsonObject(value) {
+  try {
+    const parsed = JSON.parse(String(value ?? ''));
+    return isRecord(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function parseJsonStringList(value) {
+  try {
+    const parsed = JSON.parse(String(value ?? ''));
+    return Array.isArray(parsed)
+      ? parsed.filter((item) => typeof item === 'string')
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+function normalizeRequiredId(value) {
+  const id = normalizeNullableString(value);
+  if (id) return id;
+  throw new BrowserSqlitePointDerivationError(
+    'invalid-point-rebuild',
+    'A dataset ID is required.',
+  );
+}
+
+function normalizeSourceRowIndex(value) {
+  const number = Number(value);
+  if (Number.isSafeInteger(number) && number >= 0) return number;
+  throw new BrowserSqlitePointDerivationError(
+    'invalid-point-rebuild',
+    'A stored source-row index is invalid.',
+  );
+}
+
+function normalizeNullableString(value) {
+  if (typeof value !== 'string') return null;
+  return value.trim() || null;
+}
+
+function requireDatabase(database) {
+  if (
+    !database ||
+    typeof database.prepare !== 'function' ||
+    typeof database.run !== 'function'
+  ) {
+    throw new TypeError(
+      'A sql.js database with prepare() and run() is required.',
+    );
+  }
+}
+
+function isRecord(value) {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+export class BrowserSqlitePointDerivationError extends Error {
+  constructor(code, message) {
+    super(message);
+    this.name = 'BrowserSqlitePointDerivationError';
+    this.code = code;
+  }
+}

--- a/src/data/browserSqlite/browserSqlitePointDetails.js
+++ b/src/data/browserSqlite/browserSqlitePointDetails.js
@@ -1,0 +1,322 @@
+import { DEFAULT_GROUP_ROWS_LIMIT } from '../dataSource.js';
+
+export const MAX_BROWSER_SQLITE_GROUP_ROWS_LIMIT = 100;
+const GROUP_ROWS_SORT_ORDER = 'dataset-source-row';
+
+/**
+ * Fetch one original source row for an exact point reference.
+ *
+ * Full row JSON is read only for this explicit lookup, never for viewport work.
+ *
+ * @param {{ prepare: Function }} database sql.js database.
+ * @param {{ sourceRef?: object }} [query] Exact detail request.
+ * @returns {object} Normalized detail input or a defined empty result.
+ */
+export function getBrowserSqlitePointDetails(database, query = {}) {
+  requireDatabase(database);
+  const sourceRef = normalizeSourceRef(query.sourceRef);
+  if (!sourceRef) return createEmptyDetailsResult();
+
+  const row = readOne(database, `
+    SELECT
+      source_rows.row_json,
+      datasets.coordinate_mapping_json
+    FROM point_features
+    INNER JOIN source_rows
+      ON source_rows.dataset_id = point_features.dataset_id
+      AND source_rows.source_row_index = point_features.source_row_index
+    INNER JOIN datasets ON datasets.id = point_features.dataset_id
+    WHERE point_features.dataset_id = ?
+      AND point_features.source_row_index = ?
+      AND datasets.import_state = 'complete'
+    LIMIT 1
+  `, [sourceRef.datasetId, sourceRef.rowIndex]);
+  if (!row) return createEmptyDetailsResult();
+
+  const mapping = parseJsonObject(row.coordinate_mapping_json);
+  return {
+    featureId: `${sourceRef.datasetId}:${sourceRef.rowIndex}`,
+    row: parseJsonObject(row.row_json),
+    latField: normalizeNullableString(mapping.latField),
+    lonField: normalizeNullableString(mapping.lonField),
+  };
+}
+
+/**
+ * Return a stable page of source rows represented by one grouped point.
+ *
+ * The captured dataset set, viewport, timeline, and grid cell reproduce the
+ * originating query. Removed or remapped-away points naturally disappear.
+ *
+ * @param {{ prepare: Function }} database sql.js database.
+ * @param {{ groupRef?: object, offset?: number, limit?: number }} [query] Page request.
+ * @returns {object} Bounded deterministic group page.
+ */
+export function getBrowserSqliteGroupRows(database, query = {}) {
+  requireDatabase(database);
+  const offset = normalizeOffset(query.offset);
+  const limit = normalizeLimit(query.limit);
+  const groupRef = normalizeGroupRef(query.groupRef);
+  if (!groupRef) return createEmptyGroupRowsResult(offset, limit);
+
+  const filter = buildGroupFilter(groupRef);
+  const count = readOne(
+    database,
+    `SELECT COUNT(*) AS count FROM point_features ${filter.sql}`,
+    filter.params,
+  );
+  const totalRows = normalizeNonNegativeInteger(count?.count, 0);
+  const storedRows = readAll(database, `
+    SELECT source_rows.row_json
+    FROM point_features
+    INNER JOIN source_rows
+      ON source_rows.dataset_id = point_features.dataset_id
+      AND source_rows.source_row_index = point_features.source_row_index
+    ${filter.sql}
+    ORDER BY point_features.dataset_id, point_features.source_row_index
+    LIMIT $limit OFFSET $offset
+  `, {
+    ...filter.params,
+    $limit: limit,
+    $offset: offset,
+  });
+
+  return {
+    rows: storedRows.map((row) => parseJsonObject(row.row_json)),
+    offset,
+    limit,
+    totalRows,
+    hasMore: offset + storedRows.length < totalRows,
+  };
+}
+
+function buildGroupFilter(groupRef) {
+  const datasetFilter = createDatasetFilter(groupRef.datasetIds);
+  const clauses = [
+    datasetFilter.sql,
+    'point_features.lat BETWEEN $south AND $north',
+    groupRef.bounds.west > groupRef.bounds.east
+      ? '(point_features.lon >= $west OR point_features.lon <= $east)'
+      : 'point_features.lon BETWEEN $west AND $east',
+    `CAST(
+      (point_features.lat + 90.0) / $cellHeight AS INTEGER
+    ) = $cellLat`,
+    `CAST(
+      (point_features.lon + 180.0) / $cellWidth AS INTEGER
+    ) = $cellLon`,
+  ];
+  const params = {
+    ...datasetFilter.params,
+    $north: groupRef.bounds.north,
+    $south: groupRef.bounds.south,
+    $east: groupRef.bounds.east,
+    $west: groupRef.bounds.west,
+    $cellHeight: groupRef.grid.cellHeight,
+    $cellWidth: groupRef.grid.cellWidth,
+    $cellLat: groupRef.grid.cellLat,
+    $cellLon: groupRef.grid.cellLon,
+  };
+
+  if (groupRef.timeline) {
+    clauses.push(
+      'point_features.timeline_start_year IS NOT NULL',
+      'point_features.timeline_end_year IS NOT NULL',
+      'point_features.timeline_start_year <= $timelineEndYear',
+      'point_features.timeline_end_year >= $timelineStartYear',
+    );
+    params.$timelineStartYear = groupRef.timeline.startYear;
+    params.$timelineEndYear = groupRef.timeline.endYear;
+  }
+
+  return {
+    sql: `WHERE ${clauses.join(' AND ')}`,
+    params,
+  };
+}
+
+function normalizeGroupRef(value) {
+  if (!isRecord(value) || value.sortOrder !== GROUP_ROWS_SORT_ORDER) {
+    return null;
+  }
+  const bounds = normalizeBounds(value.bounds);
+  const grid = normalizeGrid(value.grid);
+  const timeline = normalizeTimeline(value.timeline);
+  const datasetIds = normalizeDatasetIds(value.datasetIds);
+  if (!bounds || !grid || timeline === undefined || datasetIds.length === 0) {
+    return null;
+  }
+  const groupId = `grid:${grid.cellLat}:${grid.cellLon}`;
+  if (value.groupId !== groupId) return null;
+  return {
+    groupId,
+    bounds,
+    grid,
+    timeline,
+    datasetIds,
+    sortOrder: GROUP_ROWS_SORT_ORDER,
+  };
+}
+
+function normalizeSourceRef(value) {
+  if (!isRecord(value)) return null;
+  const datasetId = normalizeNullableString(value.datasetId);
+  const rowIndex = normalizeNonNegativeInteger(value.rowIndex, null);
+  return datasetId && rowIndex != null ? { datasetId, rowIndex } : null;
+}
+
+function normalizeDatasetIds(value) {
+  if (!Array.isArray(value)) return [];
+  return [...new Set(value.map(normalizeNullableString).filter(Boolean))].sort();
+}
+
+function createDatasetFilter(datasetIds) {
+  const params = {};
+  const placeholders = datasetIds.map((id, index) => {
+    const key = `$dataset${index}`;
+    params[key] = id;
+    return key;
+  });
+  return {
+    sql: `point_features.dataset_id IN (${placeholders.join(', ')})`,
+    params,
+  };
+}
+
+function normalizeBounds(value) {
+  if (!isRecord(value)) return null;
+  const north = normalizeLatitude(value.north);
+  const south = normalizeLatitude(value.south);
+  const east = normalizeLongitude(value.east);
+  const west = normalizeLongitude(value.west);
+  if (north == null || south == null || east == null || west == null) {
+    return null;
+  }
+  return {
+    north: Math.max(north, south),
+    south: Math.min(north, south),
+    east,
+    west,
+  };
+}
+
+function normalizeGrid(value) {
+  if (!isRecord(value)) return null;
+  const cellLat = normalizeInteger(value.cellLat);
+  const cellLon = normalizeInteger(value.cellLon);
+  const cellHeight = normalizePositiveNumber(value.cellHeight);
+  const cellWidth = normalizePositiveNumber(value.cellWidth);
+  if (
+    cellLat == null ||
+    cellLon == null ||
+    cellHeight == null ||
+    cellWidth == null
+  ) {
+    return null;
+  }
+  return { cellLat, cellLon, cellHeight, cellWidth };
+}
+
+function normalizeTimeline(value) {
+  if (!value?.timelineEnabled) return null;
+  const startYear = normalizeInteger(value.startYear);
+  const endYear = normalizeInteger(value.endYear);
+  if (startYear == null || endYear == null) return undefined;
+  return {
+    timelineEnabled: true,
+    startYear: Math.min(startYear, endYear),
+    endYear: Math.max(startYear, endYear),
+  };
+}
+
+function normalizeOffset(value) {
+  return normalizeNonNegativeInteger(value, 0);
+}
+
+function normalizeLimit(value) {
+  const number = Number(value);
+  if (!Number.isSafeInteger(number) || number <= 0) {
+    return DEFAULT_GROUP_ROWS_LIMIT;
+  }
+  return Math.min(number, MAX_BROWSER_SQLITE_GROUP_ROWS_LIMIT);
+}
+
+function normalizeNonNegativeInteger(value, fallback) {
+  if (value == null || value === '') return fallback;
+  const number = Number(value);
+  return Number.isSafeInteger(number) && number >= 0 ? number : fallback;
+}
+
+function normalizeInteger(value) {
+  if (value == null || value === '') return null;
+  const number = Number(value);
+  return Number.isSafeInteger(number) ? number : null;
+}
+
+function normalizePositiveNumber(value) {
+  const number = Number(value);
+  return Number.isFinite(number) && number > 0 ? number : null;
+}
+
+function normalizeLatitude(value) {
+  const number = Number(value);
+  return Number.isFinite(number) && number >= -90 && number <= 90
+    ? number
+    : null;
+}
+
+function normalizeLongitude(value) {
+  const number = Number(value);
+  return Number.isFinite(number) && number >= -180 && number <= 180
+    ? number
+    : null;
+}
+
+function normalizeNullableString(value) {
+  if (typeof value !== 'string') return null;
+  return value.trim() || null;
+}
+
+function parseJsonObject(value) {
+  try {
+    const parsed = JSON.parse(String(value ?? ''));
+    return isRecord(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function readOne(database, sql, parameters = []) {
+  return readAll(database, sql, parameters, 1)[0] ?? null;
+}
+
+function readAll(database, sql, parameters = [], maximum = Infinity) {
+  const statement = database.prepare(sql);
+  const rows = [];
+  try {
+    statement.bind(parameters);
+    while (rows.length < maximum && statement.step()) {
+      rows.push(statement.getAsObject());
+    }
+    return rows;
+  } finally {
+    statement.free();
+  }
+}
+
+function createEmptyDetailsResult() {
+  return { featureId: null, row: null, latField: null, lonField: null };
+}
+
+function createEmptyGroupRowsResult(offset, limit) {
+  return { rows: [], offset, limit, totalRows: 0, hasMore: false };
+}
+
+function requireDatabase(database) {
+  if (!database || typeof database.prepare !== 'function') {
+    throw new TypeError('A sql.js database with prepare() is required.');
+  }
+}
+
+function isRecord(value) {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}

--- a/src/data/browserSqlite/browserSqlitePointQueries.js
+++ b/src/data/browserSqlite/browserSqlitePointQueries.js
@@ -1,0 +1,454 @@
+export const DEFAULT_BROWSER_SQLITE_RENDER_BUDGET = 1_000;
+export const MAX_BROWSER_SQLITE_RENDER_BUDGET = 10_000;
+
+/**
+ * Query compact browser-SQLite point results for one normalized map viewport.
+ *
+ * Bounds, enabled datasets, and timeline constraints are applied in SQLite
+ * before the render-budget decision. Complete source-row JSON is never read.
+ *
+ * @param {{ prepare: Function }} database sql.js database.
+ * @param {object} [query] Backend-neutral map-view query.
+ * @returns {object} Compact exact or grouped map result.
+ */
+export function queryBrowserSqliteMapView(database, query = {}) {
+  requireDatabase(database);
+  const bounds = normalizeBounds(query.bounds);
+  const renderBudget = normalizeRenderBudget(query.renderBudget);
+  const datasetIds = resolveEnabledDatasetIds(database, query.datasetIds);
+  const skippedPoints = sumSkippedPoints(database, datasetIds);
+
+  if (!bounds || datasetIds.length === 0) {
+    return createEmptyResult({ skippedPoints });
+  }
+
+  const filter = buildPointFilter({ bounds, datasetIds, timeline: query.timeline });
+  const totalMatchingCount = countMatchingPoints(database, filter);
+  const boundsOnlyCount = filter.usesTimeline
+    ? countMatchingPoints(database, filter.boundsOnly)
+    : totalMatchingCount;
+  const skippedPointsByTimeline = Math.max(
+    0,
+    boundsOnlyCount - totalMatchingCount,
+  );
+  const overBudget = totalMatchingCount > renderBudget;
+  const grid = overBudget ? getGridSpec(bounds, renderBudget) : null;
+  const rows = overBudget
+    ? selectGroupedPoints(database, filter, grid, renderBudget)
+    : selectExactPoints(database, filter, renderBudget);
+  const points = overBudget
+    ? rows.map((row) => groupedRowToPoint(row, {
+        bounds,
+        datasetIds,
+        timeline: filter.timeline,
+        grid,
+      }))
+    : rows.map(exactRowToPoint);
+  const representedCount = overBudget
+    ? points.reduce((sum, point) => sum + point.count, 0)
+    : points.length;
+
+  return {
+    points,
+    lines: [],
+    regions: [],
+    stats: {
+      skippedPoints,
+      skippedLines: 0,
+      skippedRegions: 0,
+      skippedPointsByTimeline,
+      skippedLinesByTimeline: 0,
+      skippedRegionsByTimeline: 0,
+      skippedByTimeline: skippedPointsByTimeline,
+      limitedToRenderBudget: overBudget ? renderBudget : null,
+      totalMatchingCount,
+      returnedCount: points.length,
+      hiddenByRenderBudget: Math.max(
+        0,
+        totalMatchingCount - representedCount,
+      ),
+      overBudget,
+    },
+    // Dataset-wide extent is returned by getDatasetSummary; per-row entries
+    // would defeat the compact viewport contract.
+    timelineIndex: { entries: [] },
+  };
+}
+
+function selectExactPoints(database, filter, renderBudget) {
+  return readAll(database, `
+    SELECT
+      dataset_id,
+      source_row_index,
+      lat,
+      lon,
+      compact_json
+    FROM point_features
+    ${filter.sql}
+    ORDER BY dataset_id, source_row_index
+    LIMIT $limit
+  `, { ...filter.params, $limit: renderBudget });
+}
+
+/** Return one deterministic representative for each occupied viewport cell. */
+function selectGroupedPoints(database, filter, grid, renderBudget) {
+  return readAll(database, `
+    WITH matching AS (
+      SELECT
+        dataset_id,
+        source_row_index,
+        lat,
+        lon,
+        compact_json,
+        CAST((lat + 90.0) / $cellHeight AS INTEGER) AS cell_lat,
+        CAST((lon + 180.0) / $cellWidth AS INTEGER) AS cell_lon
+      FROM point_features
+      ${filter.sql}
+    ),
+    ranked AS (
+      SELECT
+        dataset_id,
+        source_row_index,
+        compact_json,
+        cell_lat,
+        cell_lon,
+        COUNT(*) OVER (PARTITION BY cell_lat, cell_lon) AS group_count,
+        AVG(lat) OVER (PARTITION BY cell_lat, cell_lon) AS group_lat,
+        AVG(lon) OVER (PARTITION BY cell_lat, cell_lon) AS group_lon,
+        ROW_NUMBER() OVER (
+          PARTITION BY cell_lat, cell_lon
+          ORDER BY dataset_id, source_row_index
+        ) AS group_rank
+      FROM matching
+    )
+    SELECT
+      dataset_id,
+      source_row_index,
+      compact_json,
+      cell_lat,
+      cell_lon,
+      group_count,
+      group_lat,
+      group_lon
+    FROM ranked
+    WHERE group_rank = 1
+    ORDER BY cell_lat, cell_lon
+    LIMIT $limit
+  `, {
+    ...filter.params,
+    $cellHeight: grid.cellHeight,
+    $cellWidth: grid.cellWidth,
+    $limit: renderBudget,
+  });
+}
+
+function exactRowToPoint(row) {
+  const compact = parseJsonObject(row.compact_json);
+  const datasetId = String(row.dataset_id);
+  const rowIndex = normalizeCount(row.source_row_index);
+  return {
+    id: `${datasetId}:${rowIndex}`,
+    renderType: 'exact',
+    lat: Number(row.lat),
+    lon: Number(row.lon),
+    count: 1,
+    groupId: null,
+    groupRef: null,
+    sourceRef: { datasetId, rowIndex },
+    marker: normalizeNullableString(compact.marker),
+    image: normalizeNullableString(compact.image),
+    imageWidthMeters: normalizePositiveNumber(compact.imageWidthMeters),
+    imageHeightMeters: normalizePositiveNumber(compact.imageHeightMeters),
+    latField: normalizeNullableString(compact.latField),
+    lonField: normalizeNullableString(compact.lonField),
+  };
+}
+
+function groupedRowToPoint(row, context) {
+  const compact = parseJsonObject(row.compact_json);
+  const cellLat = normalizeInteger(row.cell_lat);
+  const cellLon = normalizeInteger(row.cell_lon);
+  const count = Math.max(1, normalizeCount(row.group_count));
+  const groupId = `grid:${cellLat}:${cellLon}`;
+  return {
+    id: groupId,
+    renderType: count > 1 ? 'grouped' : 'representative',
+    lat: Number(row.group_lat),
+    lon: Number(row.group_lon),
+    count,
+    groupId,
+    groupRef: {
+      groupId,
+      bounds: {
+        north: context.bounds.north,
+        south: context.bounds.south,
+        east: context.bounds.east,
+        west: context.bounds.west,
+      },
+      datasetIds: [...context.datasetIds],
+      timeline: context.timeline,
+      grid: {
+        cellLat,
+        cellLon,
+        cellHeight: context.grid.cellHeight,
+        cellWidth: context.grid.cellWidth,
+      },
+      sortOrder: 'dataset-source-row',
+    },
+    sourceRef: null,
+    marker: normalizeNullableString(compact.marker),
+    image: null,
+    imageWidthMeters: null,
+    imageHeightMeters: null,
+    latField: null,
+    lonField: null,
+  };
+}
+
+function buildPointFilter({ bounds, datasetIds, timeline }) {
+  const datasetFilter = createDatasetFilter(datasetIds);
+  const boundsClauses = [
+    datasetFilter.sql,
+    'lat BETWEEN $south AND $north',
+    bounds.crossesAntimeridian
+      ? '(lon >= $west OR lon <= $east)'
+      : 'lon BETWEEN $west AND $east',
+  ];
+  const boundsParams = {
+    ...datasetFilter.params,
+    $south: bounds.south,
+    $north: bounds.north,
+    $west: bounds.west,
+    $east: bounds.east,
+  };
+  const normalizedTimeline = normalizeTimeline(timeline);
+  const clauses = [...boundsClauses];
+  const params = { ...boundsParams };
+
+  if (normalizedTimeline) {
+    clauses.push(
+      'timeline_start_year IS NOT NULL',
+      'timeline_end_year IS NOT NULL',
+      'timeline_start_year <= $timelineEndYear',
+      'timeline_end_year >= $timelineStartYear',
+    );
+    params.$timelineStartYear = normalizedTimeline.startYear;
+    params.$timelineEndYear = normalizedTimeline.endYear;
+  }
+
+  return {
+    sql: `WHERE ${clauses.join(' AND ')}`,
+    params,
+    usesTimeline: normalizedTimeline != null,
+    timeline: normalizedTimeline,
+    boundsOnly: {
+      sql: `WHERE ${boundsClauses.join(' AND ')}`,
+      params: boundsParams,
+    },
+  };
+}
+
+function countMatchingPoints(database, filter) {
+  const row = readOne(
+    database,
+    `SELECT COUNT(*) AS count FROM point_features ${filter.sql}`,
+    filter.params,
+  );
+  return normalizeCount(row?.count);
+}
+
+function resolveEnabledDatasetIds(database, requestedIds) {
+  const enabled = readAll(database, `
+    SELECT id
+    FROM datasets
+    WHERE import_state = 'complete' AND enabled = 1
+    ORDER BY id
+  `).map((row) => String(row.id));
+  if (requestedIds == null) return enabled;
+  if (!Array.isArray(requestedIds)) return [];
+  const requested = new Set(
+    requestedIds
+      .map(normalizeNullableString)
+      .filter(Boolean),
+  );
+  return enabled.filter((id) => requested.has(id));
+}
+
+function sumSkippedPoints(database, datasetIds) {
+  if (datasetIds.length === 0) return 0;
+  const filter = createDatasetFilter(datasetIds, 'id');
+  const row = readOne(database, `
+    SELECT COALESCE(SUM(skipped_point_count), 0) AS count
+    FROM datasets
+    WHERE ${filter.sql}
+  `, filter.params);
+  return normalizeCount(row?.count);
+}
+
+function createDatasetFilter(datasetIds, column = 'dataset_id') {
+  const params = {};
+  const placeholders = datasetIds.map((id, index) => {
+    const key = `$dataset${index}`;
+    params[key] = id;
+    return key;
+  });
+  return {
+    sql: `${column} IN (${placeholders.join(', ')})`,
+    params,
+  };
+}
+
+/** Choose a viewport-relative grid whose occupied results fit the render budget. */
+function getGridSpec(bounds, renderBudget) {
+  const latSpan = Math.max(bounds.north - bounds.south, 0.000001);
+  const lonSpan = Math.max(
+    bounds.crossesAntimeridian
+      ? 360 - bounds.west + bounds.east
+      : bounds.east - bounds.west,
+    0.000001,
+  );
+  const ratio = Math.max(lonSpan / latSpan, 0.000001);
+  const columns = Math.max(1, Math.ceil(Math.sqrt(renderBudget * ratio)));
+  const rows = Math.max(1, Math.ceil(renderBudget / columns));
+  return {
+    cellHeight: Math.max(latSpan / rows, 0.000001),
+    cellWidth: Math.max(lonSpan / columns, 0.000001),
+  };
+}
+
+function normalizeBounds(value) {
+  if (!isRecord(value)) return null;
+  const north = normalizeLatitude(value.north);
+  const south = normalizeLatitude(value.south);
+  const east = normalizeLongitude(value.east);
+  const west = normalizeLongitude(value.west);
+  if (north == null || south == null || east == null || west == null) {
+    return null;
+  }
+  return {
+    north: Math.max(north, south),
+    south: Math.min(north, south),
+    east,
+    west,
+    crossesAntimeridian: west > east,
+  };
+}
+
+function normalizeTimeline(value) {
+  if (!value?.timelineEnabled) return null;
+  const startYear = normalizeOptionalInteger(value.startYear ?? value.yearMin);
+  const endYear = normalizeOptionalInteger(value.endYear ?? value.yearMax);
+  if (startYear == null || endYear == null) return null;
+  return {
+    timelineEnabled: true,
+    startYear: Math.min(startYear, endYear),
+    endYear: Math.max(startYear, endYear),
+  };
+}
+
+function normalizeRenderBudget(value) {
+  const number = Number(value);
+  if (!Number.isFinite(number) || number <= 0) {
+    return DEFAULT_BROWSER_SQLITE_RENDER_BUDGET;
+  }
+  return Math.min(Math.trunc(number), MAX_BROWSER_SQLITE_RENDER_BUDGET);
+}
+
+function normalizeLatitude(value) {
+  const number = Number(value);
+  if (!Number.isFinite(number)) return null;
+  return Math.max(-90, Math.min(90, number));
+}
+
+function normalizeLongitude(value) {
+  const number = Number(value);
+  if (!Number.isFinite(number)) return null;
+  if (number >= -180 && number <= 180) return number;
+  return ((((number + 180) % 360) + 360) % 360) - 180;
+}
+
+function normalizeOptionalInteger(value) {
+  if (value == null || value === '') return null;
+  const number = Number(value);
+  return Number.isFinite(number) ? Math.trunc(number) : null;
+}
+
+function normalizeInteger(value) {
+  const number = Number(value);
+  return Number.isFinite(number) ? Math.trunc(number) : 0;
+}
+
+function normalizeCount(value) {
+  const number = Number(value);
+  return Number.isFinite(number) && number >= 0 ? Math.trunc(number) : 0;
+}
+
+function normalizePositiveNumber(value) {
+  const number = Number(value);
+  return Number.isFinite(number) && number > 0 ? number : null;
+}
+
+function normalizeNullableString(value) {
+  if (typeof value !== 'string') return null;
+  return value.trim() || null;
+}
+
+function parseJsonObject(value) {
+  try {
+    const parsed = JSON.parse(String(value ?? ''));
+    return isRecord(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function readOne(database, sql, parameters = {}) {
+  return readAll(database, sql, parameters, 1)[0] ?? null;
+}
+
+function readAll(database, sql, parameters = {}, maximum = Infinity) {
+  const statement = database.prepare(sql);
+  const rows = [];
+  try {
+    statement.bind(parameters);
+    while (rows.length < maximum && statement.step()) {
+      rows.push(statement.getAsObject());
+    }
+    return rows;
+  } finally {
+    statement.free();
+  }
+}
+
+function createEmptyResult({ skippedPoints = 0 } = {}) {
+  return {
+    points: [],
+    lines: [],
+    regions: [],
+    stats: {
+      skippedPoints,
+      skippedLines: 0,
+      skippedRegions: 0,
+      skippedPointsByTimeline: 0,
+      skippedLinesByTimeline: 0,
+      skippedRegionsByTimeline: 0,
+      skippedByTimeline: 0,
+      limitedToRenderBudget: null,
+      totalMatchingCount: 0,
+      returnedCount: 0,
+      hiddenByRenderBudget: 0,
+      overBudget: false,
+    },
+    timelineIndex: { entries: [] },
+  };
+}
+
+function requireDatabase(database) {
+  if (!database || typeof database.prepare !== 'function') {
+    throw new TypeError('A sql.js database with prepare() is required.');
+  }
+}
+
+function isRecord(value) {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}

--- a/src/data/browserSqlite/browserSqlitePointQueries.smoke.js
+++ b/src/data/browserSqlite/browserSqlitePointQueries.smoke.js
@@ -1,0 +1,337 @@
+import assert from 'node:assert/strict';
+import initSqlJs from 'sql.js';
+import {
+  closeBrowserSqliteDatabase,
+  createBrowserSqliteDatabase,
+} from './browserSqliteDatabase.js';
+import {
+  beginBrowserSqliteFileImport,
+  completeBrowserSqliteFileImport,
+  insertBrowserSqliteImportRowBatch,
+} from './browserSqliteImportTransaction.js';
+import {
+  setBrowserSqliteDatasetEnabled,
+  updateBrowserSqliteDatasetMapping,
+} from './browserSqliteDatasetMutations.js';
+import {
+  getBrowserSqliteDatasetSummary,
+} from './browserSqliteDatasetQueries.js';
+import {
+  getBrowserSqliteGroupRows,
+  getBrowserSqlitePointDetails,
+} from './browserSqlitePointDetails.js';
+import {
+  queryBrowserSqliteMapView,
+} from './browserSqlitePointQueries.js';
+
+const SQL = await initSqlJs();
+const database = createBrowserSqliteDatabase(SQL);
+
+try {
+  const firstRows = [
+    point('First', 10, 10, 2000, { marker: 'red', image: 'pin.png' }),
+    point('Second', 10, 10, 2001, { featureType: '' }),
+    point('Third', 10, 10, 2002),
+    point('Line only', 10, 10, 2001, { featureType: 'line' }),
+    point('Invalid', 999, 10, 2001),
+    point('Undated', 20, 20, ''),
+    point('East wrap', 0, 179, 2000),
+    point('West wrap', 0, -179, 2000),
+  ];
+  const firstImport = importDataset(database, 'dataset-a', firstRows);
+  assert.equal(firstImport.pointFeatureCount, 6);
+  assert.equal(firstImport.skippedPointCount, 1);
+  assert.equal(readCount(database, 'source_rows', 'dataset-a'), 8);
+  assert.equal(readCount(database, 'point_features', 'dataset-a'), 6);
+
+  importDataset(database, 'dataset-b', [
+    point('Dataset B', 11, 11, 2000),
+  ]);
+  importDataset(database, 'dataset-c', [
+    timelinePoint('Single date', { date: '1998-06-01' }),
+    timelinePoint('Reversed range', {
+      dateFrom: '2002-01-01',
+      dateTo: '2000-12-31',
+    }),
+    timelinePoint('No date', {}),
+  ], {
+    yearField: null,
+    dateField: 'date',
+    yearFromField: null,
+    yearToField: null,
+    dateFromField: 'dateFrom',
+    dateToField: 'dateTo',
+  });
+  const summary = getBrowserSqliteDatasetSummary(database);
+  assert.deepEqual(summary.timeline, { yearMin: 1998, yearMax: 2002 });
+  assert.equal(
+    summary.datasets.find((dataset) => dataset.id === 'dataset-a')
+      .importedFeatureCount,
+    6,
+  );
+
+  const exactQuery = {
+    bounds: { north: 30, south: 0, east: 30, west: 0 },
+    renderBudget: 10,
+  };
+  const exact = queryBrowserSqliteMapView(database, exactQuery);
+  assert.equal(exact.points.length, 5);
+  assert.equal(exact.stats.skippedPoints, 1);
+  assert.equal(exact.stats.overBudget, false);
+  assert.deepEqual(exact.points[0].sourceRef, {
+    datasetId: 'dataset-a',
+    rowIndex: 0,
+  });
+  assert.equal(exact.points[0].image, '/point-images/pin.png');
+  assert.equal(exact.points[0].renderType, 'exact');
+  assert.equal(JSON.stringify(exact).includes('row_json'), false);
+  assert.equal(exact.points.some((item) => Object.hasOwn(item, 'row')), false);
+
+  const timeline = queryBrowserSqliteMapView(database, {
+    ...exactQuery,
+    timeline: { timelineEnabled: true, startYear: 2001, endYear: 2001 },
+  });
+  assert.deepEqual(timeline.points.map((item) => item.id), ['dataset-a:1']);
+  assert.equal(timeline.stats.skippedPointsByTimeline, 4);
+
+  const dateTimeline = queryBrowserSqliteMapView(database, {
+    bounds: { north: 50, south: 30, east: 50, west: 30 },
+    datasetIds: ['dataset-c'],
+    timeline: { timelineEnabled: true, startYear: 2001, endYear: 2001 },
+    renderBudget: 10,
+  });
+  assert.deepEqual(dateTimeline.points.map((item) => item.id), ['dataset-c:1']);
+  assert.equal(dateTimeline.stats.skippedPointsByTimeline, 2);
+
+  const reversedTimeline = queryBrowserSqliteMapView(database, {
+    ...exactQuery,
+    timeline: { timelineEnabled: true, startYear: 2002, endYear: 2000 },
+  });
+  assert.equal(reversedTimeline.points.length, 4);
+
+  const wrapped = queryBrowserSqliteMapView(database, {
+    bounds: { north: 1, south: -1, east: -170, west: 170 },
+    renderBudget: 10,
+  });
+  assert.deepEqual(
+    wrapped.points.map((item) => item.id),
+    ['dataset-a:6', 'dataset-a:7'],
+  );
+  assert.equal(queryBrowserSqliteMapView(database, {
+    bounds: { north: -50, south: -60, east: 10, west: 0 },
+  }).points.length, 0);
+
+  setBrowserSqliteDatasetEnabled(database, 'dataset-b', false);
+  assert.equal(queryBrowserSqliteMapView(database, exactQuery).points.length, 4);
+  setBrowserSqliteDatasetEnabled(database, 'dataset-b', true);
+
+  const denseQuery = {
+    bounds: { north: 11, south: 9, east: 11, west: 9 },
+    renderBudget: 1,
+  };
+  const dense = queryBrowserSqliteMapView(database, denseQuery);
+  assert.equal(dense.stats.totalMatchingCount, 4);
+  assert.equal(dense.stats.overBudget, true);
+  assert.equal(dense.points.length, 1);
+  assert.equal(dense.points[0].count, 4);
+  assert.equal(dense.points[0].renderType, 'grouped');
+  assert.deepEqual(dense, queryBrowserSqliteMapView(database, denseQuery));
+  assert.deepEqual(dense.points[0].groupRef.datasetIds, [
+    'dataset-a',
+    'dataset-b',
+    'dataset-c',
+  ]);
+
+  const firstPage = getBrowserSqliteGroupRows(database, {
+    groupRef: dense.points[0].groupRef,
+    limit: 2,
+  });
+  const secondPage = getBrowserSqliteGroupRows(database, {
+    groupRef: dense.points[0].groupRef,
+    offset: 2,
+    limit: 2,
+  });
+  assert.deepEqual(firstPage.rows.map((row) => row.name), ['First', 'Second']);
+  assert.deepEqual(secondPage.rows.map((row) => row.name), [
+    'Third',
+    'Dataset B',
+  ]);
+  assert.equal(firstPage.totalRows, 4);
+  assert.equal(firstPage.hasMore, true);
+  assert.equal(secondPage.hasMore, false);
+
+  // Visibility is part of the captured dataset snapshot, so a later toggle
+  // does not broaden or narrow an already-open group.
+  setBrowserSqliteDatasetEnabled(database, 'dataset-b', false);
+  assert.equal(getBrowserSqliteGroupRows(database, {
+    groupRef: dense.points[0].groupRef,
+  }).totalRows, 4);
+  setBrowserSqliteDatasetEnabled(database, 'dataset-b', true);
+
+  const details = getBrowserSqlitePointDetails(database, {
+    sourceRef: exact.points[0].sourceRef,
+  });
+  assert.equal(details.featureId, 'dataset-a:0');
+  assert.equal(details.row.name, 'First');
+  assert.equal(details.latField, 'lat');
+  assert.equal(details.lonField, 'lon');
+  assert.deepEqual(
+    getBrowserSqlitePointDetails(database, {
+      sourceRef: { datasetId: 'dataset-a', rowIndex: 999 },
+    }),
+    { featureId: null, row: null, latField: null, lonField: null },
+  );
+  assert.equal(
+    getBrowserSqliteGroupRows(database, { groupRef: { sql: 'unsafe' } })
+      .totalRows,
+    0,
+  );
+
+  database.run('DELETE FROM datasets WHERE id = ?', ['dataset-b']);
+  const afterRemoval = getBrowserSqliteGroupRows(database, {
+    groupRef: dense.points[0].groupRef,
+  });
+  assert.equal(afterRemoval.totalRows, 3);
+
+  const remapped = updateBrowserSqliteDatasetMapping(database, 'dataset-a', {
+    latField: 'altLat',
+    lonField: 'altLon',
+  });
+  assert.equal(remapped.ok, true);
+  assert.equal(
+    queryBrowserSqliteMapView(database, exactQuery).points.length,
+    0,
+  );
+  assert.equal(
+    queryBrowserSqliteMapView(database, {
+      bounds: { north: 50, south: 30, east: 50, west: 30 },
+      renderBudget: 20,
+    }).points.length,
+    7,
+  );
+
+  const mappingBeforeFailure = readMapping(database, 'dataset-a');
+  database.run(`
+    CREATE TRIGGER fail_point_rebuild
+    BEFORE INSERT ON point_features
+    WHEN NEW.dataset_id = 'dataset-a'
+    BEGIN
+      SELECT RAISE(ABORT, 'simulated point rebuild failure');
+    END
+  `);
+  assert.throws(
+    () => updateBrowserSqliteDatasetMapping(database, 'dataset-a', {
+      latField: 'lat',
+      lonField: 'lon',
+    }),
+    (error) => error?.code === 'operation-failed',
+  );
+  database.run('DROP TRIGGER fail_point_rebuild');
+  assert.deepEqual(readMapping(database, 'dataset-a'), mappingBeforeFailure);
+  assert.equal(
+    queryBrowserSqliteMapView(database, {
+      bounds: { north: 50, south: 30, east: 50, west: 30 },
+      renderBudget: 20,
+    }).points.length,
+    7,
+  );
+
+  assert.equal(readScalar(database, 'PRAGMA foreign_key_check'), null);
+} finally {
+  closeBrowserSqliteDatabase(database);
+}
+
+console.log(
+  'Browser SQLite point derivation, viewport, detail, and paging smoke test passed.',
+);
+
+function point(name, lat, lon, year, overrides = {}) {
+  return {
+    name,
+    featureType: 'point',
+    lat: String(lat),
+    lon: String(lon),
+    altLat: String(Number(lat) + 30),
+    altLon: String(Number(lon) + 30),
+    year: String(year),
+    marker: '',
+    image: '',
+    imageWidthMeters: '',
+    imageHeightMeters: '',
+    ...overrides,
+  };
+}
+
+function timelinePoint(name, overrides) {
+  return {
+    name,
+    featureType: 'point',
+    lat: '40',
+    lon: '40',
+    altLat: '40',
+    altLon: '40',
+    date: '',
+    dateFrom: '',
+    dateTo: '',
+    marker: '',
+    image: '',
+    imageWidthMeters: '',
+    imageHeightMeters: '',
+    ...overrides,
+  };
+}
+
+function importDataset(targetDatabase, datasetId, rows, fieldOverrides = {}) {
+  const headers = Object.keys(rows[0]);
+  const activeImport = beginBrowserSqliteFileImport(targetDatabase, {
+    datasetId,
+    fileName: `${datasetId}.csv`,
+  });
+  insertBrowserSqliteImportRowBatch(activeImport, rows);
+  return completeBrowserSqliteFileImport(activeImport, {
+    headers,
+    totalParsedRowCount: rows.length,
+    skippedRowCount: 0,
+    detectedFields: {
+      latField: 'lat',
+      lonField: 'lon',
+      yearField: 'year',
+      dateField: null,
+      dayOfYearField: null,
+      yearFromField: null,
+      yearToField: null,
+      dateFromField: null,
+      dateToField: null,
+      ...fieldOverrides,
+    },
+    coordinateMapping: { latField: 'lat', lonField: 'lon' },
+    warnings: [],
+    importedAt: `2026-07-26T18:00:0${datasetId === 'dataset-a' ? 0 : 1}.000Z`,
+  });
+}
+
+function readCount(targetDatabase, table, datasetId) {
+  return readScalar(
+    targetDatabase,
+    `SELECT COUNT(*) FROM ${table} WHERE dataset_id = ?`,
+    [datasetId],
+  );
+}
+
+function readMapping(targetDatabase, datasetId) {
+  return JSON.parse(readScalar(
+    targetDatabase,
+    'SELECT coordinate_mapping_json FROM datasets WHERE id = ?',
+    [datasetId],
+  ));
+}
+
+function readScalar(targetDatabase, sql, parameters = []) {
+  const statement = targetDatabase.prepare(sql);
+  try {
+    statement.bind(parameters);
+    return statement.step() ? statement.get()[0] : null;
+  } finally {
+    statement.free();
+  }
+}

--- a/src/data/browserSqlite/browserSqliteProtocol.js
+++ b/src/data/browserSqlite/browserSqliteProtocol.js
@@ -13,6 +13,9 @@ export const BROWSER_SQLITE_OPERATIONS = Object.freeze({
   REMOVE_DATASET: 'remove-dataset',
   UPDATE_DATASET_MAPPING: 'update-dataset-mapping',
   GET_PREVIEW_PAGE: 'get-preview-page',
+  QUERY_MAP_VIEW: 'query-map-view',
+  GET_FEATURE_DETAILS: 'get-feature-details',
+  GET_GROUP_ROWS: 'get-group-rows',
   CLOSE: 'close',
 });
 
@@ -231,6 +234,12 @@ function normalizeOperationPayload(operation, payload) {
       return normalizeDatasetMappingPayload(payload);
     case BROWSER_SQLITE_OPERATIONS.GET_PREVIEW_PAGE:
       return normalizePreviewPayload(payload);
+    case BROWSER_SQLITE_OPERATIONS.QUERY_MAP_VIEW:
+      return normalizeMapViewPayload(payload);
+    case BROWSER_SQLITE_OPERATIONS.GET_FEATURE_DETAILS:
+      return normalizeFeatureDetailsPayload(payload);
+    case BROWSER_SQLITE_OPERATIONS.GET_GROUP_ROWS:
+      return normalizeGroupRowsPayload(payload);
     default:
       throwProtocolError(
         'unsupported-operation',
@@ -354,6 +363,172 @@ function normalizePreviewPayload(payload) {
   };
 }
 
+function normalizeMapViewPayload(payload) {
+  requirePayload(payload, [
+    'bounds',
+    'zoom',
+    'timeline',
+    'renderBudget',
+    'datasetIds',
+  ]);
+  return {
+    bounds: normalizeBoundsPayload(payload.bounds),
+    zoom: normalizeNullableFiniteNumber(payload.zoom, 'map zoom'),
+    timeline: normalizeTimelinePayload(payload.timeline),
+    renderBudget: normalizeOptionalInteger(
+      payload.renderBudget,
+      null,
+      1,
+      'render budget',
+    ),
+    datasetIds: normalizeDatasetIdsPayload(payload.datasetIds),
+  };
+}
+
+function normalizeFeatureDetailsPayload(payload) {
+  requirePayload(payload, ['featureId', 'sourceRef']);
+  return {
+    featureId: payload.featureId == null
+      ? null
+      : normalizeIdentifier(payload.featureId, 'feature ID', 'invalid-request'),
+    sourceRef: normalizeSourceRefPayload(payload.sourceRef),
+  };
+}
+
+function normalizeGroupRowsPayload(payload) {
+  requirePayload(payload, ['groupRef', 'offset', 'limit']);
+  return {
+    groupRef: normalizeGroupRefPayload(payload.groupRef),
+    offset: normalizeOptionalInteger(payload.offset, 0, 0, 'group offset'),
+    limit: Math.min(
+      normalizeOptionalInteger(payload.limit, 30, 1, 'group limit'),
+      100,
+    ),
+  };
+}
+
+function normalizeBoundsPayload(value) {
+  if (value == null) return null;
+  requirePlainRecord(value, 'invalid-request', 'Map bounds must be an object.');
+  requireOnlyKeys(value, ['north', 'south', 'east', 'west']);
+  return {
+    north: normalizeFiniteNumber(value.north, 'north bound'),
+    south: normalizeFiniteNumber(value.south, 'south bound'),
+    east: normalizeFiniteNumber(value.east, 'east bound'),
+    west: normalizeFiniteNumber(value.west, 'west bound'),
+  };
+}
+
+function normalizeTimelinePayload(value) {
+  if (value == null) return null;
+  requirePlainRecord(value, 'invalid-request', 'Timeline state must be an object.');
+  requireOnlyKeys(value, [
+    'timelineEnabled',
+    'startYear',
+    'endYear',
+    'yearMin',
+    'yearMax',
+    'dayFilterEnabled',
+    'startDay',
+    'endDay',
+  ]);
+  if (
+    Object.hasOwn(value, 'timelineEnabled') &&
+    typeof value.timelineEnabled !== 'boolean'
+  ) {
+    throwProtocolError('invalid-request', 'Timeline enabled state is invalid.');
+  }
+  if (
+    Object.hasOwn(value, 'dayFilterEnabled') &&
+    typeof value.dayFilterEnabled !== 'boolean'
+  ) {
+    throwProtocolError('invalid-request', 'Timeline day-filter state is invalid.');
+  }
+  return {
+    timelineEnabled: value.timelineEnabled === true,
+    startYear: normalizeNullableInteger(value.startYear, 'timeline start year'),
+    endYear: normalizeNullableInteger(value.endYear, 'timeline end year'),
+    yearMin: normalizeNullableInteger(value.yearMin, 'timeline minimum year'),
+    yearMax: normalizeNullableInteger(value.yearMax, 'timeline maximum year'),
+    dayFilterEnabled: value.dayFilterEnabled === true,
+    startDay: normalizeNullableInteger(value.startDay, 'timeline start day'),
+    endDay: normalizeNullableInteger(value.endDay, 'timeline end day'),
+  };
+}
+
+function normalizeDatasetIdsPayload(value) {
+  if (value == null) return null;
+  if (!Array.isArray(value) || value.length > 100) {
+    throwProtocolError('invalid-request', 'Dataset IDs must be a bounded array.');
+  }
+  return [...new Set(value.map((id) => (
+    normalizeIdentifier(id, 'dataset ID', 'invalid-request')
+  )))].sort();
+}
+
+function normalizeSourceRefPayload(value) {
+  if (value == null) return null;
+  requirePlainRecord(value, 'invalid-request', 'A source reference must be an object.');
+  requireOnlyKeys(value, ['datasetId', 'rowIndex']);
+  return {
+    datasetId: normalizeIdentifier(
+      value.datasetId,
+      'dataset ID',
+      'invalid-request',
+    ),
+    rowIndex: normalizeOptionalInteger(
+      value.rowIndex,
+      null,
+      0,
+      'source-row index',
+    ),
+  };
+}
+
+function normalizeGroupRefPayload(value) {
+  if (value == null) return null;
+  requirePlainRecord(value, 'invalid-request', 'A group reference must be an object.');
+  requireOnlyKeys(value, [
+    'groupId',
+    'bounds',
+    'datasetIds',
+    'timeline',
+    'grid',
+    'sortOrder',
+  ]);
+  if (value.sortOrder !== 'dataset-source-row') {
+    throwProtocolError('invalid-request', 'The group sort order is invalid.');
+  }
+  const datasetIds = normalizeDatasetIdsPayload(value.datasetIds);
+  if (!datasetIds || datasetIds.length === 0) {
+    throwProtocolError('invalid-request', 'A group dataset snapshot is required.');
+  }
+  const grid = normalizeGroupGridPayload(value.grid);
+  const groupId = normalizeIdentifier(value.groupId, 'group ID', 'invalid-request');
+  if (groupId !== `grid:${grid.cellLat}:${grid.cellLon}`) {
+    throwProtocolError('invalid-request', 'The group ID is invalid.');
+  }
+  return {
+    groupId,
+    bounds: normalizeBoundsPayload(value.bounds),
+    datasetIds,
+    timeline: normalizeTimelinePayload(value.timeline),
+    grid,
+    sortOrder: 'dataset-source-row',
+  };
+}
+
+function normalizeGroupGridPayload(value) {
+  requirePlainRecord(value, 'invalid-request', 'A group grid must be an object.');
+  requireOnlyKeys(value, ['cellLat', 'cellLon', 'cellHeight', 'cellWidth']);
+  return {
+    cellLat: normalizeRequiredInteger(value.cellLat, 'grid latitude cell'),
+    cellLon: normalizeRequiredInteger(value.cellLon, 'grid longitude cell'),
+    cellHeight: normalizePositiveFiniteNumber(value.cellHeight, 'grid cell height'),
+    cellWidth: normalizePositiveFiniteNumber(value.cellWidth, 'grid cell width'),
+  };
+}
+
 function requirePayload(payload, allowedKeys) {
   requirePlainRecord(payload, 'invalid-request', 'The payload must be an object.');
   requireOnlyKeys(payload, allowedKeys);
@@ -421,6 +596,40 @@ function normalizeOptionalInteger(value, fallback, minimum, label) {
     );
   }
   return value;
+}
+
+function normalizeNullableInteger(value, label) {
+  if (value == null) return null;
+  if (!Number.isSafeInteger(value)) {
+    throwProtocolError('invalid-request', `${label} must be an integer or null.`);
+  }
+  return value;
+}
+
+function normalizeRequiredInteger(value, label) {
+  if (!Number.isSafeInteger(value)) {
+    throwProtocolError('invalid-request', `${label} must be an integer.`);
+  }
+  return value;
+}
+
+function normalizeFiniteNumber(value, label) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throwProtocolError('invalid-request', `${label} must be a finite number.`);
+  }
+  return value;
+}
+
+function normalizeNullableFiniteNumber(value, label) {
+  return value == null ? null : normalizeFiniteNumber(value, label);
+}
+
+function normalizePositiveFiniteNumber(value, label) {
+  const number = normalizeFiniteNumber(value, label);
+  if (number <= 0) {
+    throwProtocolError('invalid-request', `${label} must be positive.`);
+  }
+  return number;
 }
 
 function normalizePositiveInteger(value, label, code) {

--- a/src/data/browserSqlite/browserSqliteProtocol.smoke.js
+++ b/src/data/browserSqlite/browserSqliteProtocol.smoke.js
@@ -124,6 +124,72 @@ assert.deepEqual(validateBrowserSqliteRequest({
   operation: 'get-preview-page',
   payload: { datasetId: 'dataset-1', offset: 10, limit: 25 },
 });
+assert.deepEqual(validateBrowserSqliteRequest({
+  requestId: 'request-map-view',
+  operation: BROWSER_SQLITE_OPERATIONS.QUERY_MAP_VIEW,
+  payload: {
+    bounds: { north: 10, south: -10, east: -170, west: 170 },
+    zoom: 5,
+    timeline: {
+      timelineEnabled: true,
+      startYear: 2002,
+      endYear: 2000,
+    },
+    renderBudget: 50,
+    datasetIds: ['dataset-2', 'dataset-1', 'dataset-1'],
+  },
+}), {
+  requestId: 'request-map-view',
+  operation: 'query-map-view',
+  payload: {
+    bounds: { north: 10, south: -10, east: -170, west: 170 },
+    zoom: 5,
+    timeline: {
+      timelineEnabled: true,
+      startYear: 2002,
+      endYear: 2000,
+      yearMin: null,
+      yearMax: null,
+      dayFilterEnabled: false,
+      startDay: null,
+      endDay: null,
+    },
+    renderBudget: 50,
+    datasetIds: ['dataset-1', 'dataset-2'],
+  },
+});
+assert.deepEqual(validateBrowserSqliteRequest({
+  requestId: 'request-details',
+  operation: BROWSER_SQLITE_OPERATIONS.GET_FEATURE_DETAILS,
+  payload: {
+    featureId: 'dataset-1:4',
+    sourceRef: { datasetId: 'dataset-1', rowIndex: 4 },
+  },
+}), {
+  requestId: 'request-details',
+  operation: 'get-feature-details',
+  payload: {
+    featureId: 'dataset-1:4',
+    sourceRef: { datasetId: 'dataset-1', rowIndex: 4 },
+  },
+});
+const groupRef = {
+  groupId: 'grid:4:5',
+  bounds: { north: 10, south: 0, east: 10, west: 0 },
+  datasetIds: ['dataset-1'],
+  timeline: null,
+  grid: { cellLat: 4, cellLon: 5, cellHeight: 1, cellWidth: 2 },
+  sortOrder: 'dataset-source-row',
+};
+assert.deepEqual(validateBrowserSqliteRequest({
+  requestId: 'request-group',
+  operation: BROWSER_SQLITE_OPERATIONS.GET_GROUP_ROWS,
+  payload: { groupRef, offset: 10, limit: 500 },
+}), {
+  requestId: 'request-group',
+  operation: 'get-group-rows',
+  payload: { groupRef, offset: 10, limit: 100 },
+});
 
 assertProtocolError(() => validateBrowserSqliteRequest(null), 'invalid-request');
 assertProtocolError(() => validateBrowserSqliteRequest([]), 'invalid-request');
@@ -247,6 +313,26 @@ assertProtocolError(() => validateBrowserSqliteRequest({
   requestId: 'request-preview-limit',
   operation: 'get-preview-page',
   payload: { datasetId: 'dataset-1', limit: 0 },
+}), 'invalid-request');
+assertProtocolError(() => validateBrowserSqliteRequest({
+  requestId: 'request-map-sql',
+  operation: 'query-map-view',
+  payload: { sql: 'SELECT row_json FROM source_rows' },
+}), 'invalid-request');
+assertProtocolError(() => validateBrowserSqliteRequest({
+  requestId: 'request-map-bounds',
+  operation: 'query-map-view',
+  payload: { bounds: { north: 1, south: 0, east: 1, west: Infinity } },
+}), 'invalid-request');
+assertProtocolError(() => validateBrowserSqliteRequest({
+  requestId: 'request-group-id',
+  operation: 'get-group-rows',
+  payload: { groupRef: { ...groupRef, groupId: 'grid:unsafe' } },
+}), 'invalid-request');
+assertProtocolError(() => validateBrowserSqliteRequest({
+  requestId: 'request-group-datasets',
+  operation: 'get-group-rows',
+  payload: { groupRef: { ...groupRef, datasetIds: [] } },
 }), 'invalid-request');
 
 assert.deepEqual(createBrowserSqliteSuccessResponse('request-1', {
@@ -397,6 +483,9 @@ assert.deepEqual(
     'remove-dataset',
     'update-dataset-mapping',
     'get-preview-page',
+    'query-map-view',
+    'get-feature-details',
+    'get-group-rows',
     'close',
   ]),
 );

--- a/src/data/browserSqlite/browserSqliteRealBrowser.validation.js
+++ b/src/data/browserSqlite/browserSqliteRealBrowser.validation.js
@@ -33,6 +33,8 @@ async function runRealBrowserValidation() {
   const dataSource = createBrowserSqliteDataSource();
   const progress = [];
   const startedAt = performance.now();
+  let queryHeartbeat = null;
+  let queryHeartbeatSafety = null;
 
   try {
     const initialization = await dataSource.initialize();
@@ -75,6 +77,13 @@ async function runRealBrowserValidation() {
     const summary = await dataSource.getDatasetSummary();
     requireEqual(summary.datasets.length, 1, 'dataset count after import');
     requireEqual(summary.datasets[0].rowCount, LARGE_ROW_COUNT, 'summary row count');
+    requireEqual(
+      summary.datasets[0].importedFeatureCount,
+      LARGE_ROW_COUNT,
+      'derived point count',
+    );
+    requireEqual(summary.timeline?.yearMin, 1000, 'timeline minimum year');
+    requireEqual(summary.timeline?.yearMax, 1999, 'timeline maximum year');
     assertNoSourceRows(summary, 'dataset summary');
     const datasetId = summary.datasets[0].id;
 
@@ -88,6 +97,97 @@ async function runRealBrowserValidation() {
     requireEqual(preview.rows[0]?.name, 'Row 12345', 'first preview row');
     requireEqual(preview.rows[2]?.name, 'Row 12347', 'last preview row');
     requireCondition(preview.hasMore, 'The preview should report more rows.');
+
+    let queryHeartbeatCount = 0;
+    queryHeartbeat = setInterval(() => {
+      queryHeartbeatCount += 1;
+    }, 0);
+    // Ensure a failed assertion cannot leave the validation page with a live timer.
+    queryHeartbeatSafety = setTimeout(() => {
+      clearInterval(queryHeartbeat);
+    }, 30_000);
+    const exactStartedAt = performance.now();
+    const exact = await dataSource.queryMapView({
+      bounds: { north: 1.01, south: 0.99, east: 1.01, west: 0.99 },
+      renderBudget: 100,
+    });
+    const exactDurationMs = performance.now() - exactStartedAt;
+    requireCondition(exact.points.length > 0, 'The exact query returned no points.');
+    requireCondition(!exact.stats.overBudget, 'The exact query grouped unexpectedly.');
+    requireCondition(
+      exact.points.every((point) => point.renderType === 'exact'),
+      'The exact query returned a grouped item.',
+    );
+    assertNoSourceRows(exact, 'exact viewport');
+
+    const denseStartedAt = performance.now();
+    const denseQuery = {
+      bounds: { north: 90, south: -90, east: 180, west: -180 },
+      renderBudget: 100,
+    };
+    const dense = await dataSource.queryMapView(denseQuery);
+    const denseDurationMs = performance.now() - denseStartedAt;
+    requireCondition(dense.stats.overBudget, 'The dense query did not group.');
+    requireCondition(dense.points.length <= 100, 'The dense query exceeded its budget.');
+    requireEqual(dense.stats.totalMatchingCount, LARGE_ROW_COUNT, 'dense match count');
+    assertNoSourceRows(dense, 'dense viewport');
+    const repeatedDense = await dataSource.queryMapView(denseQuery);
+    requireEqual(
+      JSON.stringify(repeatedDense.points),
+      JSON.stringify(dense.points),
+      'stable dense results',
+    );
+
+    const sparse = await dataSource.queryMapView({
+      bounds: { north: 3.1, south: 0.9, east: 3.1, west: 0.9 },
+      renderBudget: 100,
+    });
+    requireCondition(sparse.points.length > 0, 'The sparse query returned no points.');
+    requireCondition(!sparse.stats.overBudget, 'The sparse query grouped unexpectedly.');
+    const empty = await dataSource.queryMapView({
+      bounds: { north: -70, south: -80, east: -10, west: -20 },
+      renderBudget: 100,
+    });
+    requireEqual(empty.points.length, 0, 'empty viewport point count');
+
+    const timelineStartedAt = performance.now();
+    const timeline = await dataSource.queryMapView({
+      bounds: { north: 90, south: -90, east: 180, west: -180 },
+      timeline: { timelineEnabled: true, startYear: 1500, endYear: 1500 },
+      renderBudget: 100,
+    });
+    const timelineDurationMs = performance.now() - timelineStartedAt;
+    requireEqual(timeline.stats.totalMatchingCount, 30, 'timeline match count');
+
+    const details = await dataSource.getFeatureDetails({
+      sourceRef: exact.points[0].sourceRef,
+    });
+    requireCondition(details.row?.name, 'Exact detail lookup returned no row.');
+    requireEqual(details.latField, 'lat', 'detail latitude mapping');
+    requireEqual(details.lonField, 'lon', 'detail longitude mapping');
+
+    const groupedPoint = dense.points.find((point) => point.count > 30);
+    requireCondition(groupedPoint?.groupRef, 'No pageable dense group was returned.');
+    const firstGroupPage = await dataSource.getGroupRows({
+      groupRef: groupedPoint.groupRef,
+    });
+    const secondGroupPage = await dataSource.getGroupRows({
+      groupRef: groupedPoint.groupRef,
+      offset: firstGroupPage.limit,
+    });
+    clearInterval(queryHeartbeat);
+    clearTimeout(queryHeartbeatSafety);
+    requireEqual(firstGroupPage.rows.length, 30, 'first group page size');
+    requireCondition(secondGroupPage.rows.length > 0, 'The later group page was empty.');
+    requireEqual(
+      new Set([
+        ...firstGroupPage.rows.map((row) => row.name),
+        ...secondGroupPage.rows.map((row) => row.name),
+      ]).size,
+      firstGroupPage.rows.length + secondGroupPage.rows.length,
+      'unique rows across group pages',
+    );
+    requireCondition(queryHeartbeatCount > 0, 'The main thread stalled during queries.');
 
     let cancelPromise = null;
     const cancellationProgress = [];
@@ -134,14 +234,31 @@ async function runRealBrowserValidation() {
       previewRows: preview.rows.length,
       progressEventCount: progress.length,
       heartbeatCount,
+      queryHeartbeatCount,
+      queryResults: {
+        exact: exact.points.length,
+        dense: dense.points.length,
+        sparse: sparse.points.length,
+        empty: empty.points.length,
+        timeline: timeline.points.length,
+        denseGroups: dense.points.length,
+        groupTotalRows: firstGroupPage.totalRows,
+        groupPagesRead: 2,
+        detailFound: details.row != null,
+      },
       canceledImportRolledBack: true,
       restartVerifiedEmpty: await verifyRestartIsEmpty(dataSource),
       timingsMs: {
         largeImport: Math.round(largeImportDurationMs),
+        exactQuery: Math.round(exactDurationMs),
+        denseQuery: Math.round(denseDurationMs),
+        timelineQuery: Math.round(timelineDurationMs),
         total: Math.round(performance.now() - startedAt),
       },
     };
   } finally {
+    clearInterval(queryHeartbeat);
+    clearTimeout(queryHeartbeatSafety);
     dataSource.dispose();
   }
 }

--- a/src/data/browserSqlite/browserSqliteWorkerClient.js
+++ b/src/data/browserSqlite/browserSqliteWorkerClient.js
@@ -261,6 +261,21 @@ export function createBrowserSqliteWorkerClient(options = {}) {
     });
   }
 
+  function queryMapView(query = {}) {
+    if (!isPlainRecord(query)) return invalidRequestPromise();
+    return sendRequest(BROWSER_SQLITE_OPERATIONS.QUERY_MAP_VIEW, query);
+  }
+
+  function getFeatureDetails(query = {}) {
+    if (!isPlainRecord(query)) return invalidRequestPromise();
+    return sendRequest(BROWSER_SQLITE_OPERATIONS.GET_FEATURE_DETAILS, query);
+  }
+
+  function getGroupRows(query = {}) {
+    if (!isPlainRecord(query)) return invalidRequestPromise();
+    return sendRequest(BROWSER_SQLITE_OPERATIONS.GET_GROUP_ROWS, query);
+  }
+
   function close() {
     return sendRequest(BROWSER_SQLITE_OPERATIONS.CLOSE);
   }
@@ -300,9 +315,19 @@ export function createBrowserSqliteWorkerClient(options = {}) {
     removeDataset,
     updateDatasetMapping,
     getPreviewPage,
+    queryMapView,
+    getFeatureDetails,
+    getGroupRows,
     close,
     dispose,
   });
+}
+
+function invalidRequestPromise() {
+  return Promise.reject(new BrowserSqliteWorkerClientError(
+    'invalid-request',
+    BROWSER_SQLITE_ERROR_MESSAGES['invalid-request'],
+  ));
 }
 
 function createDefaultWorker() {

--- a/src/data/browserSqlite/browserSqliteWorkerClient.smoke.js
+++ b/src/data/browserSqlite/browserSqliteWorkerClient.smoke.js
@@ -90,7 +90,7 @@ respondSuccess(worker, worker.posted.at(-1), {
   initialized: true,
   reused: false,
   databaseStorage: 'memory',
-  schemaVersion: 1,
+  schemaVersion: 2,
 });
 assert.equal((await initializePromise).initialized, true);
 
@@ -218,6 +218,60 @@ assert.equal(
   worker.posted.at(-1).operation,
   BROWSER_SQLITE_OPERATIONS.UPDATE_DATASET_MAPPING,
 );
+
+const mapQuery = {
+  bounds: { north: 10, south: 0, east: 10, west: 0 },
+  renderBudget: 10,
+};
+await completeSuccess(worker, client.queryMapView(mapQuery), {
+  points: [],
+  lines: [],
+  regions: [],
+  stats: {},
+  timelineIndex: { entries: [] },
+});
+assert.deepEqual(worker.posted.at(-1), {
+  requestId: worker.posted.at(-1).requestId,
+  operation: BROWSER_SQLITE_OPERATIONS.QUERY_MAP_VIEW,
+  payload: {
+    ...mapQuery,
+    zoom: null,
+    timeline: null,
+    datasetIds: null,
+  },
+});
+await completeSuccess(worker, client.getFeatureDetails({
+  sourceRef: { datasetId: 'dataset-1', rowIndex: 0 },
+}), {
+  featureId: 'dataset-1:0',
+  row: { name: 'One' },
+  latField: 'lat',
+  lonField: 'lon',
+});
+assert.equal(
+  worker.posted.at(-1).operation,
+  BROWSER_SQLITE_OPERATIONS.GET_FEATURE_DETAILS,
+);
+await completeSuccess(worker, client.getGroupRows({
+  groupRef: {
+    groupId: 'grid:1:2',
+    bounds: { north: 10, south: 0, east: 10, west: 0 },
+    datasetIds: ['dataset-1'],
+    timeline: null,
+    grid: { cellLat: 1, cellLon: 2, cellHeight: 1, cellWidth: 1 },
+    sortOrder: 'dataset-source-row',
+  },
+}), {
+  rows: [],
+  offset: 0,
+  limit: 30,
+  totalRows: 0,
+});
+assert.equal(
+  worker.posted.at(-1).operation,
+  BROWSER_SQLITE_OPERATIONS.GET_GROUP_ROWS,
+);
+await assertClientError(client.queryMapView([]), 'invalid-request');
 
 const removeFailurePromise = client.removeDataset('missing-dataset');
 const removeFailureRequest = worker.posted.at(-1);

--- a/src/data/browserSqlite/browserSqliteWorkerRuntime.js
+++ b/src/data/browserSqlite/browserSqliteWorkerRuntime.js
@@ -18,6 +18,13 @@ import {
   importBrowserSqliteCsvBatch,
 } from './browserSqliteImportBatch.js';
 import {
+  getBrowserSqliteGroupRows,
+  getBrowserSqlitePointDetails,
+} from './browserSqlitePointDetails.js';
+import {
+  queryBrowserSqliteMapView,
+} from './browserSqlitePointQueries.js';
+import {
   BROWSER_SQLITE_OPERATIONS,
   BrowserSqliteProtocolError,
   createBrowserSqliteFailureResponse,
@@ -147,6 +154,21 @@ export function createBrowserSqliteWorkerRuntime({
         );
       case BROWSER_SQLITE_OPERATIONS.GET_PREVIEW_PAGE:
         return getBrowserSqlitePreviewPage(
+          requireDatabase(database),
+          request.payload,
+        );
+      case BROWSER_SQLITE_OPERATIONS.QUERY_MAP_VIEW:
+        return queryBrowserSqliteMapView(
+          requireDatabase(database),
+          request.payload,
+        );
+      case BROWSER_SQLITE_OPERATIONS.GET_FEATURE_DETAILS:
+        return getBrowserSqlitePointDetails(
+          requireDatabase(database),
+          request.payload,
+        );
+      case BROWSER_SQLITE_OPERATIONS.GET_GROUP_ROWS:
+        return getBrowserSqliteGroupRows(
           requireDatabase(database),
           request.payload,
         );

--- a/src/data/browserSqlite/browserSqliteWorkerRuntime.smoke.js
+++ b/src/data/browserSqlite/browserSqliteWorkerRuntime.smoke.js
@@ -63,7 +63,7 @@ try {
     initialized: true,
     reused: false,
     databaseStorage: 'memory',
-    schemaVersion: 1,
+    schemaVersion: 2,
   });
   const repeatedInitialize = await runtime.handleMessage(request(
     'initialize-repeated',
@@ -138,6 +138,43 @@ try {
     latField: 'lat',
     lonField: 'lon',
   });
+  await runtime.handleMessage(request(
+    'enable-first',
+    BROWSER_SQLITE_OPERATIONS.SET_DATASET_ENABLED,
+    { datasetId: firstDatasetId, enabled: true },
+  ));
+  const exactMap = await runtime.handleMessage(request(
+    'query-first',
+    BROWSER_SQLITE_OPERATIONS.QUERY_MAP_VIEW,
+    {
+      bounds: { north: 90, south: -90, east: 180, west: -180 },
+      renderBudget: 10,
+    },
+  ));
+  assert.equal(exactMap.result.points.length, 2);
+  assert.equal(Object.hasOwn(exactMap.result.points[0], 'row'), false);
+  const pointDetails = await runtime.handleMessage(request(
+    'details-first',
+    BROWSER_SQLITE_OPERATIONS.GET_FEATURE_DETAILS,
+    { sourceRef: exactMap.result.points[0].sourceRef },
+  ));
+  assert.equal(pointDetails.result.row.name, 'First');
+  const groupedMap = await runtime.handleMessage(request(
+    'group-first',
+    BROWSER_SQLITE_OPERATIONS.QUERY_MAP_VIEW,
+    {
+      bounds: { north: 90, south: -90, east: 180, west: -180 },
+      renderBudget: 1,
+    },
+  ));
+  assert.equal(groupedMap.result.points[0].count, 2);
+  const groupRows = await runtime.handleMessage(request(
+    'group-rows-first',
+    BROWSER_SQLITE_OPERATIONS.GET_GROUP_ROWS,
+    { groupRef: groupedMap.result.points[0].groupRef, offset: 0, limit: 1 },
+  ));
+  assert.equal(groupRows.result.rows[0].name, 'First');
+  assert.equal(groupRows.result.totalRows, 2);
 
   const cancelImportPromise = runtime.handleMessage(request(
     'import-cancel-request',

--- a/src/data/dataSource.js
+++ b/src/data/dataSource.js
@@ -419,6 +419,9 @@ export const BACKEND_FAILURE_CATEGORIES = Object.freeze({
  * @typedef {object} GroupRef
  * @property {string} groupId
  * @property {MapBounds} bounds
+ * @property {string[]} [datasetIds]
+ *   Enabled dataset snapshot captured by grouped backends so later paging
+ *   cannot broaden when the current UI selection or visibility changes.
  * @property {TimelineFilter|null} timeline
  * @property {GroupGridRef} grid
  * @property {GroupRowsSortOrder} sortOrder

--- a/src/data/dataSourceNormalization.js
+++ b/src/data/dataSourceNormalization.js
@@ -550,16 +550,26 @@ function normalizeGroupRef(value) {
   const bounds = normalizeBounds(value.bounds);
   const grid = normalizeGroupGrid(value.grid);
   const timeline = normalizeCapturedTimeline(value.timeline);
+  const datasetIds = value.datasetIds == null
+    ? null
+    : normalizeGroupDatasetIds(value.datasetIds);
   if (!groupId || !bounds || !grid || timeline === undefined) return null;
+  if (value.datasetIds != null && datasetIds.length === 0) return null;
   if (groupId !== ['grid', grid.cellLat, grid.cellLon].join(':')) return null;
 
   return {
     groupId,
     bounds,
+    ...(datasetIds == null ? {} : { datasetIds }),
     timeline,
     grid,
     sortOrder: 'dataset-source-row',
   };
+}
+
+function normalizeGroupDatasetIds(value) {
+  if (!Array.isArray(value)) return [];
+  return [...new Set(value.map(normalizeNullableId).filter(Boolean))].sort();
 }
 
 function normalizeBounds(value) {


### PR DESCRIPTION
## Summary

Adds the browser SQLite point-feature pipeline, including compact point derivation, viewport queries, timeline filtering, deterministic render-budget grouping, exact details, and group-row paging.

## Changes

- Adds indexed compact point records derived from stored source rows.
- Preserves original rows when coordinates are invalid.
- Excludes rows intended for lines or regions from point results.
- Rebuilds point records transactionally when coordinate mappings change.
- Supports enabled datasets, geographic bounds, and antimeridian-crossing viewports.
- Applies timeline filtering before render-budget grouping.
- Returns exact points below the render budget.
- Returns deterministic grouped or representative points above the budget.
- Keeps complete source rows out of viewport results.
- Adds separate exact-detail lookup using stable source references.
- Adds deterministic group-row paging tied to captured query context.
- Extends the strict worker protocol, client, runtime, and data-source adapter.
- Documents the browser SQLite point-query architecture.

## Validation

- Browser SQLite point, importer, transaction, protocol, worker, and adapter smoke tests pass.
- Browser parity and data-source normalization tests pass.
- Desktop SQLite dataset, store, viewport, and detail regressions pass.
- Browser and desktop production builds pass.
- Lint passes.
- The real-browser 30,000-row fixture passes:
  - 30,000 derived points
  - Exact, dense, sparse, empty, and timeline queries verified
  - Stable grouped results verified
  - Exact details and multiple group pages verified
  - Main thread and worker remained responsive

## Scope

- Does not activate browser SQLite in the normal GitHub Pages UI.
- Does not implement line or region queries.
- Does not change desktop SQLite behavior.
- Does not remove the existing browser data path.

Closes #105
