### PR TITLE
Add browser SQLite line and region parity

### DIFF
--- a/docs/browser-sqlite-geometry-query-architecture.md
+++ b/docs/browser-sqlite-geometry-query-architecture.md
@@ -1,0 +1,88 @@
+# Browser SQLite line and region architecture
+
+Issue #106 extends the temporary browser SQLite backend with line and region
+parity. It does not select that backend in the normal browser runtime. GitHub
+Pages continues to use the in-memory data source, and desktop SQLite behavior is
+unchanged.
+
+## Geometry storage and indexing
+
+`source_rows` remains authoritative for complete normalized CSV rows. Compact
+line and region records live in `geometry_features`. Each record contains its
+stable dataset and logical feature identity, optional region part, ordered
+coordinates, resolved rendering style, line arrow mode, timeline extent,
+detail source reference, and conservative latitude/longitude bounding box.
+
+The geometry table is indexed by dataset, type, bounds, and timeline extent.
+It never contains a complete source row. Foreign keys cascade from the selected
+source row, so dataset removal cannot leave derived geometry behind.
+
+## Derivation and ordering
+
+Rebuilds step through source rows in original order and stage only valid line
+and region vertices in a temporary SQLite table. SQLite then orders those
+vertices by explicit numeric `order`, falling back to source-row index. Equal
+sort keys use source-row index as the deterministic tie breaker. One geometry
+group is held in JavaScript memory at a time.
+
+Lines group by `featureId` and require two valid vertices. Regions group by
+`featureId` and `part`, default an empty part to `0`, require three valid
+vertices, and close rings when necessary. Stable output IDs include dataset ID,
+logical feature ID, and region part where applicable.
+
+Multipart regions share the first valid source row of their logical region for
+details and timeline identity. Lines use the first vertex in resolved order.
+This preserves the raw browser popup and timeline behavior.
+
+## Style resolution and worker compatibility
+
+Styles use the first usable value in resolved vertex order. Line weights are
+rounded and clamped to 1 through 20, and arrows accept `none`, `start`, `end`,
+or `both`. Region color/fill-color fallback and existing defaults are retained.
+
+Workers do not expose the main-thread-only `CSS.supports` API. Line color
+resolution therefore follows the existing helper's no-CSS fallback: any
+trimmed non-empty color token is retained for the renderer. This deterministic
+difference is covered by the geometry parity smoke test.
+
+## Viewport and timeline queries
+
+Geometry queries first intersect the requested dataset set with currently
+enabled, completely imported datasets. SQLite applies latitude and longitude
+bounding-box overlap and inclusive timeline overlap before records are
+returned. Timeline-disabled queries include undated geometry; timeline-enabled
+queries exclude it. Day-of-year state remains intentionally unapplied.
+
+Wrapped viewports use the two longitude segments around the antimeridian.
+Bounding boxes are conservative: false positives are acceptable, while lines
+or polygons crossing the viewport cannot be missed merely because every vertex
+is outside it.
+
+Complete coordinate sequences are returned because Leaflet needs them to draw
+the matching geometry. Complete source rows are not selected during viewport
+work and are available only through explicit detail lookup.
+
+## Dense geometry bounds
+
+Lines and regions are not grouped. Their combined result is deterministically
+limited by the normalized map render budget, defaulting to 1,000 and capped at
+10,000. Point grouping retains its existing independent behavior. Query
+statistics report matching and returned counts per geometry type, hidden
+geometry count, the applied limit, and whether the limit was reached.
+
+This means a response can contain the bounded point result plus the separately
+bounded geometry result. The split deliberately avoids allowing a dense point
+viewport to starve all lines and regions.
+
+## Transaction and detail behavior
+
+Import finalization derives points, lines, and regions before committing the
+file transaction. Coordinate mapping updates rebuild all three feature types
+inside one transaction. Any failure rolls back the new mapping and every
+derived change, preserving the previous working state and leaving other
+datasets untouched.
+
+Exact detail lookup accepts only a stable source reference currently owned by a
+derived point or geometry. It cannot expose arbitrary source-row or SQL access.
+Removed datasets or references invalidated by remapping return the defined empty
+detail result.

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "smoke:sqlite-detail": "node desktop/sqliteDetailQuery.smoke.cjs",
     "validate:desktop-large-file": "node desktop/largeFileValidation.cjs",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "smoke:browser-sqlite-geometries": "node src/data/browserSqlite/browserSqliteGeometryQueries.smoke.js"
   },
   "dependencies": {
     "better-sqlite3": "^12.11.1",

--- a/src/data/browserSqlite/browserSqliteDataSource.js
+++ b/src/data/browserSqlite/browserSqliteDataSource.js
@@ -36,8 +36,8 @@ const CAPABILITIES = normalizeBackendCapabilities({
   datasetMapping: true,
   previewPaging: true,
   points: true,
-  lines: false,
-  regions: false,
+  lines: true,
+  regions: true,
   groupedViewportResults: true,
 });
 

--- a/src/data/browserSqlite/browserSqliteDataSource.smoke.js
+++ b/src/data/browserSqlite/browserSqliteDataSource.smoke.js
@@ -205,6 +205,8 @@ assert.equal(initialized.capabilities.droppedFileImport, true);
 assert.equal(initialized.capabilities.datasetSelection, true);
 assert.equal(initialized.capabilities.previewPaging, true);
 assert.equal(initialized.capabilities.points, true);
+assert.equal(initialized.capabilities.lines, true);
+assert.equal(initialized.capabilities.regions, true);
 assert.equal(initialized.capabilities.groupedViewportResults, true);
 assert.deepEqual(dataSource.getCapabilities(), initialized.capabilities);
 

--- a/src/data/browserSqlite/browserSqliteDatabase.js
+++ b/src/data/browserSqlite/browserSqliteDatabase.js
@@ -4,7 +4,7 @@
  * The version describes databases created during the current page session. It
  * does not imply that database bytes are persisted or migrated across sessions.
  */
-export const BROWSER_SQLITE_SCHEMA_VERSION = 2;
+export const BROWSER_SQLITE_SCHEMA_VERSION = 3;
 
 const closedDatabases = new WeakSet();
 
@@ -39,6 +39,8 @@ export function createBrowserSqliteDatabase(SQL) {
  * Foreign keys are enabled before the schema transaction so dataset deletion
  * can safely cascade to original source rows. The composite source-row primary
  * key preserves deterministic row order without a separate imported array.
+ * Compact geometry rows store only render data, source references, timeline
+ * extents, and indexed bounding boxes; complete rows remain in `source_rows`.
  *
  * @param {{ run: (sql: string) => void }} database Fresh sql.js database.
  */
@@ -71,6 +73,14 @@ export function initializeBrowserSqliteSchema(database) {
           CHECK (point_feature_count >= 0),
         skipped_point_count INTEGER NOT NULL DEFAULT 0
           CHECK (skipped_point_count >= 0),
+        line_feature_count INTEGER NOT NULL DEFAULT 0
+          CHECK (line_feature_count >= 0),
+        skipped_line_count INTEGER NOT NULL DEFAULT 0
+          CHECK (skipped_line_count >= 0),
+        region_feature_count INTEGER NOT NULL DEFAULT 0
+          CHECK (region_feature_count >= 0),
+        skipped_region_count INTEGER NOT NULL DEFAULT 0
+          CHECK (skipped_region_count >= 0),
         enabled INTEGER NOT NULL DEFAULT 1
           CHECK (enabled IN (0, 1)),
         detected_fields_json TEXT NOT NULL DEFAULT '{}'
@@ -132,6 +142,60 @@ export function initializeBrowserSqliteSchema(database) {
         )
       ) WITHOUT ROWID;
 
+      CREATE TABLE geometry_features (
+        dataset_id TEXT NOT NULL,
+        geometry_type TEXT NOT NULL
+          CHECK (geometry_type IN ('line', 'region')),
+        feature_id TEXT NOT NULL
+          CHECK (length(trim(feature_id)) > 0),
+        part TEXT NOT NULL DEFAULT '',
+        source_row_index INTEGER NOT NULL
+          CHECK (source_row_index >= 0),
+        feature_order_index INTEGER NOT NULL
+          CHECK (feature_order_index >= 0),
+        part_order_index INTEGER NOT NULL
+          CHECK (part_order_index >= 0),
+        min_lat REAL NOT NULL
+          CHECK (min_lat >= -90 AND min_lat <= 90),
+        max_lat REAL NOT NULL
+          CHECK (max_lat >= -90 AND max_lat <= 90),
+        min_lon REAL NOT NULL
+          CHECK (min_lon >= -180 AND min_lon <= 180),
+        max_lon REAL NOT NULL
+          CHECK (max_lon >= -180 AND max_lon <= 180),
+        timeline_start_year INTEGER,
+        timeline_end_year INTEGER,
+        coordinates_json TEXT NOT NULL DEFAULT '[]'
+          CHECK (json_valid(coordinates_json)),
+        style_json TEXT NOT NULL DEFAULT '{}'
+          CHECK (json_valid(style_json)),
+        arrow_mode TEXT
+          CHECK (
+            arrow_mode IS NULL
+            OR arrow_mode IN ('none', 'start', 'end', 'both')
+          ),
+        PRIMARY KEY (dataset_id, geometry_type, feature_id, part),
+        FOREIGN KEY (dataset_id, source_row_index)
+          REFERENCES source_rows(dataset_id, source_row_index)
+          ON DELETE CASCADE,
+        CHECK (min_lat <= max_lat),
+        CHECK (min_lon <= max_lon),
+        CHECK (
+          (geometry_type = 'line' AND part = '' AND arrow_mode IS NOT NULL)
+          OR
+          (geometry_type = 'region' AND arrow_mode IS NULL)
+        ),
+        CHECK (
+          (timeline_start_year IS NULL AND timeline_end_year IS NULL)
+          OR
+          (
+            timeline_start_year IS NOT NULL
+            AND timeline_end_year IS NOT NULL
+            AND timeline_start_year <= timeline_end_year
+          )
+        )
+      ) WITHOUT ROWID;
+
       CREATE INDEX idx_datasets_imported_order
         ON datasets(imported_at DESC, id);
 
@@ -145,7 +209,24 @@ export function initializeBrowserSqliteSchema(database) {
           timeline_end_year
         );
 
-      PRAGMA user_version = 2;
+      CREATE INDEX idx_geometry_features_dataset_bounds
+        ON geometry_features(
+          dataset_id,
+          geometry_type,
+          min_lat,
+          max_lat,
+          min_lon,
+          max_lon
+        );
+
+      CREATE INDEX idx_geometry_features_dataset_timeline
+        ON geometry_features(
+          dataset_id,
+          timeline_start_year,
+          timeline_end_year
+        );
+
+      PRAGMA user_version = 3;
     `);
     database.run('COMMIT');
   } catch (error) {

--- a/src/data/browserSqlite/browserSqliteDatabase.smoke.js
+++ b/src/data/browserSqlite/browserSqliteDatabase.smoke.js
@@ -26,7 +26,7 @@ try {
     FROM sqlite_schema
     WHERE type = 'table' AND name NOT LIKE 'sqlite_%'
     ORDER BY name
-  `), ['datasets', 'point_features', 'source_rows']);
+  `), ['datasets', 'geometry_features', 'point_features', 'source_rows']);
   assert.deepEqual(
     readColumn(database, 'PRAGMA table_info(datasets)', 'name'),
     [
@@ -41,6 +41,10 @@ try {
       'skipped_row_count',
       'point_feature_count',
       'skipped_point_count',
+      'line_feature_count',
+      'skipped_line_count',
+      'region_feature_count',
+      'skipped_region_count',
       'enabled',
       'detected_fields_json',
       'coordinate_mapping_json',
@@ -66,12 +70,34 @@ try {
     ],
   );
   assert.deepEqual(
+    readColumn(database, 'PRAGMA table_info(geometry_features)', 'name'),
+    [
+      'dataset_id',
+      'geometry_type',
+      'feature_id',
+      'part',
+      'source_row_index',
+      'feature_order_index',
+      'part_order_index',
+      'min_lat',
+      'max_lat',
+      'min_lon',
+      'max_lon',
+      'timeline_start_year',
+      'timeline_end_year',
+      'coordinates_json',
+      'style_json',
+      'arrow_mode',
+    ],
+  );
+  assert.deepEqual(
     readColumn(database, 'PRAGMA index_list(datasets)', 'name'),
     ['idx_datasets_imported_order', 'sqlite_autoindex_datasets_1'],
   );
   assert.equal(readScalar(database, 'SELECT COUNT(*) FROM datasets'), 0);
   assert.equal(readScalar(database, 'SELECT COUNT(*) FROM source_rows'), 0);
   assert.equal(readScalar(database, 'SELECT COUNT(*) FROM point_features'), 0);
+  assert.equal(readScalar(database, 'SELECT COUNT(*) FROM geometry_features'), 0);
   assert.equal(persistenceAccessCount, 0);
   assert.equal(closeBrowserSqliteDatabase(database), true);
   assert.equal(closeBrowserSqliteDatabase(database), false);

--- a/src/data/browserSqlite/browserSqliteDatasetMutations.js
+++ b/src/data/browserSqlite/browserSqliteDatasetMutations.js
@@ -4,6 +4,9 @@ import {
 import {
   rebuildBrowserSqlitePointFeatures,
 } from './browserSqlitePointDerivation.js';
+import {
+  rebuildBrowserSqliteGeometryFeatures,
+} from './browserSqliteGeometryDerivation.js';
 
 /**
  * Enable or disable one completely imported dataset.
@@ -54,7 +57,10 @@ export function setBrowserSqliteDatasetEnabled(
  *
  * Omitted fields retain their current value. Explicit null or blank values
  * clear one side of the mapping. Non-null fields must match normalized stored
- * headers. Detected coordinate and timeline metadata remains unchanged.
+ * headers. Points, lines, and regions rebuild inside the same transaction as
+ * the metadata update, so callers never observe mixed mappings. Any failure
+ * rolls the affected dataset back to its previous working mapping and features;
+ * detected coordinate and timeline metadata remains unchanged.
  *
  * @param {{ prepare: (sql: string) => object, run: Function }} database sql.js database.
  * @param {string} datasetId Stable dataset identifier.
@@ -95,6 +101,7 @@ export function updateBrowserSqliteDatasetMapping(
       WHERE id = ? AND import_state = 'complete'
     `, [JSON.stringify({ latField, lonField }), normalizedId]);
     rebuildBrowserSqlitePointFeatures(database, normalizedId);
+    rebuildBrowserSqliteGeometryFeatures(database, normalizedId);
     database.run('COMMIT');
   } catch (error) {
     safeRollback(database);

--- a/src/data/browserSqlite/browserSqliteDatasetQueries.js
+++ b/src/data/browserSqlite/browserSqliteDatasetQueries.js
@@ -23,6 +23,8 @@ export function getBrowserSqliteDatasetSummary(database) {
       stored_row_count,
       skipped_row_count,
       point_feature_count,
+      line_feature_count,
+      region_feature_count,
       enabled,
       detected_fields_json,
       coordinate_mapping_json,
@@ -34,13 +36,24 @@ export function getBrowserSqliteDatasetSummary(database) {
   `);
 
   const timelineExtent = readOne(database, `
-    SELECT
-      MIN(point_features.timeline_start_year) AS year_min,
-      MAX(point_features.timeline_end_year) AS year_max
-    FROM point_features
-    INNER JOIN datasets ON datasets.id = point_features.dataset_id
-    WHERE datasets.import_state = 'complete'
-      AND datasets.enabled = 1
+    SELECT MIN(start_year) AS year_min, MAX(end_year) AS year_max
+    FROM (
+      SELECT
+        point_features.timeline_start_year AS start_year,
+        point_features.timeline_end_year AS end_year
+      FROM point_features
+      INNER JOIN datasets ON datasets.id = point_features.dataset_id
+      WHERE datasets.import_state = 'complete'
+        AND datasets.enabled = 1
+      UNION ALL
+      SELECT
+        geometry_features.timeline_start_year AS start_year,
+        geometry_features.timeline_end_year AS end_year
+      FROM geometry_features
+      INNER JOIN datasets ON datasets.id = geometry_features.dataset_id
+      WHERE datasets.import_state = 'complete'
+        AND datasets.enabled = 1
+    )
   `);
   const yearMin = normalizeStoredYear(timelineExtent?.year_min);
   const yearMax = normalizeStoredYear(timelineExtent?.year_max);
@@ -57,7 +70,10 @@ export function getBrowserSqliteDatasetSummary(database) {
         rowCount: normalizeStoredCount(row.stored_row_count),
         totalRows: normalizeStoredCount(row.total_parsed_row_count),
         sizeBytes: normalizeNullableStoredCount(row.size_bytes),
-        importedFeatureCount: normalizeStoredCount(row.point_feature_count),
+        importedFeatureCount:
+          normalizeStoredCount(row.point_feature_count) +
+          normalizeStoredCount(row.line_feature_count) +
+          normalizeStoredCount(row.region_feature_count),
         skippedRowCount: normalizeStoredCount(row.skipped_row_count),
         importedAt: normalizeNullableString(row.imported_at),
         latField: normalizeNullableString(mapping.latField),

--- a/src/data/browserSqlite/browserSqliteGeometryDerivation.js
+++ b/src/data/browserSqlite/browserSqliteGeometryDerivation.js
@@ -1,0 +1,566 @@
+import {
+  isValidLat,
+  isValidLon,
+  parseFlexibleFloat,
+} from '../../components/geoColumns.js';
+import {
+  detectFeatureTypeField,
+  getRowFeatureType,
+} from '../../components/featureTypes.js';
+import {
+  getBrowserSqliteTimelineExtent,
+} from './browserSqliteTimeline.js';
+
+const DEFAULT_LINE_STYLE = Object.freeze({ color: '#3388ff', weight: 3 });
+const DEFAULT_REGION_STYLE = Object.freeze({
+  color: '#3388ff',
+  weight: 2,
+  opacity: 1,
+  fillColor: '#3388ff',
+  fillOpacity: 0.25,
+});
+const ALLOWED_ARROW_MODES = new Set(['none', 'start', 'end', 'both']);
+const MIN_LINE_WEIGHT = 1;
+const MAX_LINE_WEIGHT = 20;
+const STAGING_TABLE = 'browser_geometry_vertices';
+
+/**
+ * Rebuild compact line and region records from authoritative source rows.
+ *
+ * Valid vertices are staged in temporary SQLite storage, ordered there, and
+ * consumed one geometry at a time. This preserves source/order semantics
+ * without creating a second complete source-row array in worker memory. The
+ * caller owns the surrounding transaction.
+ *
+ * @param {{ prepare: Function, run: Function }} database sql.js database.
+ * @param {string} datasetId Stable dataset identifier.
+ * @returns {object} Derived and skipped feature counts.
+ */
+export function rebuildBrowserSqliteGeometryFeatures(database, datasetId) {
+  requireDatabase(database);
+  const normalizedId = normalizeRequiredId(datasetId);
+  const metadata = readDatasetMetadata(database, normalizedId);
+  if (!metadata) {
+    throw new BrowserSqliteGeometryDerivationError(
+      'dataset-not-found',
+      'The requested dataset is unavailable.',
+    );
+  }
+
+  const headers = parseJsonStringList(metadata.columns_json);
+  const mapping = parseJsonObject(metadata.coordinate_mapping_json);
+  const detectedFields = parseJsonObject(metadata.detected_fields_json);
+  const featureTypeField = detectFeatureTypeField(headers);
+  const latField = normalizeNullableString(mapping.latField);
+  const lonField = normalizeNullableString(mapping.lonField);
+  const counts = {
+    lineFeatureCount: 0,
+    skippedLineCount: 0,
+    regionFeatureCount: 0,
+    skippedRegionCount: 0,
+  };
+
+  database.run(
+    'DELETE FROM geometry_features WHERE dataset_id = ?',
+    [normalizedId],
+  );
+  dropStagingTable(database);
+
+  try {
+    createStagingTable(database);
+    if (latField && lonField && featureTypeField) {
+      stageGeometryVertices(database, {
+        datasetId: normalizedId,
+        featureTypeField,
+        latField,
+        lonField,
+        counts,
+      });
+      writeGeometryFeatures(database, {
+        datasetId: normalizedId,
+        detectedFields,
+        counts,
+      });
+    }
+
+    database.run(`
+      UPDATE datasets
+      SET line_feature_count = ?,
+          skipped_line_count = ?,
+          region_feature_count = ?,
+          skipped_region_count = ?
+      WHERE id = ?
+    `, [
+      counts.lineFeatureCount,
+      counts.skippedLineCount,
+      counts.regionFeatureCount,
+      counts.skippedRegionCount,
+      normalizedId,
+    ]);
+    return counts;
+  } finally {
+    dropStagingTable(database);
+  }
+}
+
+/**
+ * Store valid line and region vertices in temporary indexed worker storage.
+ *
+ * Invalid geometry never removes or changes the corresponding source row.
+ * Missing identifiers and invalid coordinates increment the same skipped
+ * counters as the current raw-browser derivation helpers.
+ */
+function stageGeometryVertices(database, {
+  datasetId,
+  featureTypeField,
+  latField,
+  lonField,
+  counts,
+}) {
+  const sourceRows = database.prepare(`
+    SELECT source_row_index, row_json
+    FROM source_rows
+    WHERE dataset_id = ?
+    ORDER BY source_row_index
+  `);
+  let insertVertex = null;
+
+  try {
+    insertVertex = database.prepare(`
+      INSERT INTO ${STAGING_TABLE} (
+        geometry_type,
+        feature_id,
+        part,
+        source_row_index,
+        sort_order,
+        lat,
+        lon,
+        color,
+        weight,
+        opacity,
+        fill_color,
+        fill_opacity,
+        arrow_mode
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+    sourceRows.bind([datasetId]);
+
+    while (sourceRows.step()) {
+      const stored = sourceRows.getAsObject();
+      const sourceRowIndex = normalizeSourceRowIndex(stored.source_row_index);
+      const row = parseJsonObject(stored.row_json);
+      const geometryType = getRowFeatureType(row, featureTypeField);
+      if (geometryType !== 'line' && geometryType !== 'region') continue;
+
+      const featureId = normalizeNullableString(row.featureId);
+      const lat = parseFlexibleFloat(row[latField]);
+      const lon = parseFlexibleFloat(row[lonField]);
+      if (!featureId || !isValidLat(lat) || !isValidLon(lon)) {
+        incrementSkipped(counts, geometryType);
+        continue;
+      }
+
+      const order = parseOrderValue(row.order);
+      insertVertex.run([
+        geometryType,
+        featureId,
+        geometryType === 'region'
+          ? normalizeNullableString(row.part) ?? '0'
+          : '',
+        sourceRowIndex,
+        order ?? sourceRowIndex,
+        lat,
+        lon,
+        compactString(row.color),
+        compactString(row.weight),
+        compactString(row.opacity),
+        compactString(row.fillColor),
+        compactString(row.fillOpacity),
+        compactString(row.arrow),
+      ]);
+    }
+  } finally {
+    sourceRows.free();
+    insertVertex?.free();
+  }
+}
+
+/**
+ * Resolve ordered staged vertices and insert one compact indexed geometry.
+ *
+ * Feature and part order use their first valid source rows. Vertex order uses
+ * explicit numeric order when present and source order otherwise. Equal keys
+ * fall back to source order, matching stable JavaScript sorting.
+ */
+function writeGeometryFeatures(database, context) {
+  const vertices = database.prepare(`
+    WITH ordered_vertices AS (
+      SELECT
+        *,
+        MIN(source_row_index) OVER (
+          PARTITION BY geometry_type, feature_id
+        ) AS feature_order_index,
+        MIN(source_row_index) OVER (
+          PARTITION BY geometry_type, feature_id, part
+        ) AS part_order_index
+      FROM ${STAGING_TABLE}
+    )
+    SELECT *
+    FROM ordered_vertices
+    ORDER BY
+      geometry_type,
+      feature_order_index,
+      part_order_index,
+      sort_order,
+      source_row_index
+  `);
+  const sourceRow = database.prepare(`
+    SELECT row_json
+    FROM source_rows
+    WHERE dataset_id = ? AND source_row_index = ?
+  `);
+  const insertGeometry = database.prepare(`
+    INSERT INTO geometry_features (
+      dataset_id,
+      geometry_type,
+      feature_id,
+      part,
+      source_row_index,
+      feature_order_index,
+      part_order_index,
+      min_lat,
+      max_lat,
+      min_lon,
+      max_lon,
+      timeline_start_year,
+      timeline_end_year,
+      coordinates_json,
+      style_json,
+      arrow_mode
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+  let group = null;
+
+  try {
+    while (vertices.step()) {
+      const vertex = vertices.getAsObject();
+      const key = [
+        vertex.geometry_type,
+        vertex.feature_id,
+        vertex.part,
+      ].join('\u0000');
+
+      if (group?.key !== key) {
+        if (group) writeGeometryGroup(group, context, sourceRow, insertGeometry);
+        group = createGeometryGroup(key, vertex);
+      }
+      addVertexToGroup(group, vertex);
+    }
+    if (group) writeGeometryGroup(group, context, sourceRow, insertGeometry);
+  } finally {
+    vertices.free();
+    sourceRow.free();
+    insertGeometry.free();
+  }
+}
+
+function createGeometryGroup(key, vertex) {
+  return {
+    key,
+    geometryType: String(vertex.geometry_type),
+    featureId: String(vertex.feature_id),
+    part: String(vertex.part),
+    featureOrderIndex: normalizeSourceRowIndex(vertex.feature_order_index),
+    partOrderIndex: normalizeSourceRowIndex(vertex.part_order_index),
+    vertices: [],
+  };
+}
+
+function addVertexToGroup(group, vertex) {
+  group.vertices.push({
+    sourceRowIndex: normalizeSourceRowIndex(vertex.source_row_index),
+    lat: Number(vertex.lat),
+    lon: Number(vertex.lon),
+    color: vertex.color,
+    weight: vertex.weight,
+    opacity: vertex.opacity,
+    fillColor: vertex.fill_color,
+    fillOpacity: vertex.fill_opacity,
+    arrow: vertex.arrow_mode,
+  });
+}
+
+function writeGeometryGroup(group, context, sourceRow, insertGeometry) {
+  const minimumVertices = group.geometryType === 'line' ? 2 : 3;
+  if (group.vertices.length < minimumVertices) return;
+
+  const coordinates = group.vertices.map(({ lat, lon }) => [lat, lon]);
+  // Preserve already-closed rings and append exactly one closing coordinate
+  // only when the resolved region vertices leave the ring open.
+  if (group.geometryType === 'region' && !isRingClosed(coordinates)) {
+    coordinates.push([...coordinates[0]]);
+  }
+
+  // Multipart regions intentionally share the first valid row of the logical
+  // feature. Lines use their first resolved vertex, matching raw-browser detail
+  // and timeline identity.
+  const sourceRowIndex = group.geometryType === 'region'
+    ? group.featureOrderIndex
+    : group.vertices[0].sourceRowIndex;
+  const detailRow = readSourceRow(
+    sourceRow,
+    context.datasetId,
+    sourceRowIndex,
+  );
+  const timeline = getBrowserSqliteTimelineExtent(
+    detailRow,
+    context.detectedFields,
+  );
+  const bounds = getCoordinateBounds(coordinates);
+  const style = group.geometryType === 'line'
+    ? resolveLineStyle(group.vertices)
+    : resolveRegionStyle(group.vertices);
+  const arrow = group.geometryType === 'line'
+    ? resolveArrowMode(group.vertices)
+    : null;
+
+  insertGeometry.run([
+    context.datasetId,
+    group.geometryType,
+    group.featureId,
+    group.part,
+    sourceRowIndex,
+    group.featureOrderIndex,
+    group.partOrderIndex,
+    bounds.minLat,
+    bounds.maxLat,
+    bounds.minLon,
+    bounds.maxLon,
+    timeline?.startYear ?? null,
+    timeline?.endYear ?? null,
+    JSON.stringify(coordinates),
+    JSON.stringify(style),
+    arrow,
+  ]);
+
+  if (group.geometryType === 'line') {
+    context.counts.lineFeatureCount += 1;
+  } else {
+    context.counts.regionFeatureCount += 1;
+  }
+}
+
+function readSourceRow(statement, datasetId, sourceRowIndex) {
+  statement.reset();
+  statement.bind([datasetId, sourceRowIndex]);
+  return statement.step()
+    ? parseJsonObject(statement.getAsObject().row_json)
+    : {};
+}
+
+/** Resolve first-valid line style values without main-thread DOM APIs. */
+function resolveLineStyle(vertices) {
+  const style = {};
+  for (const vertex of vertices) {
+    applyFirstNonEmpty(style, 'color', vertex.color, parseWorkerColor);
+    applyFirstNonEmpty(style, 'weight', vertex.weight, parseLineWeight);
+  }
+  return { ...DEFAULT_LINE_STYLE, ...style };
+}
+
+/** Resolve per-part region styles and the existing color/fill fallback. */
+function resolveRegionStyle(vertices) {
+  const style = {};
+  for (const vertex of vertices) {
+    applyFirstNonEmpty(style, 'color', vertex.color);
+    applyFirstNonEmpty(style, 'weight', vertex.weight, parseNumber);
+    applyFirstNonEmpty(style, 'opacity', vertex.opacity, parseNumber);
+    applyFirstNonEmpty(style, 'fillColor', vertex.fillColor);
+    applyFirstNonEmpty(style, 'fillOpacity', vertex.fillOpacity, parseNumber);
+  }
+
+  const hasColor = Object.hasOwn(style, 'color');
+  const hasFillColor = Object.hasOwn(style, 'fillColor');
+  const resolved = { ...DEFAULT_REGION_STYLE, ...style };
+  if (!hasFillColor && resolved.color) resolved.fillColor = resolved.color;
+  if (!hasColor && resolved.fillColor) resolved.color = resolved.fillColor;
+  return resolved;
+}
+
+function resolveArrowMode(vertices) {
+  for (const vertex of vertices) {
+    const arrow = normalizeNullableString(vertex.arrow)?.toLowerCase();
+    if (arrow && ALLOWED_ARROW_MODES.has(arrow)) return arrow;
+  }
+  return 'none';
+}
+
+function parseWorkerColor(value) {
+  // CSS.supports is a main-thread API. The worker retains any non-empty color
+  // string and lets the renderer apply it, matching the existing no-CSS path.
+  return normalizeNullableString(value);
+}
+
+function parseLineWeight(value) {
+  const number = Number.parseFloat(String(value ?? '').trim());
+  if (!Number.isFinite(number)) return null;
+  return Math.min(
+    MAX_LINE_WEIGHT,
+    Math.max(MIN_LINE_WEIGHT, Math.round(number)),
+  );
+}
+
+function parseNumber(value) {
+  const number = Number.parseFloat(String(value ?? '').trim());
+  return Number.isFinite(number) ? number : null;
+}
+
+function parseOrderValue(value) {
+  const number = Number.parseFloat(String(value ?? '').trim());
+  return Number.isFinite(number) ? number : null;
+}
+
+function applyFirstNonEmpty(target, key, value, parser) {
+  if (target[key] != null && target[key] !== '') return;
+  const raw = normalizeNullableString(value);
+  if (!raw) return;
+  const parsed = parser ? parser(raw) : raw;
+  if (parsed != null && parsed !== '') target[key] = parsed;
+}
+
+function getCoordinateBounds(coordinates) {
+  let minLat = Number.POSITIVE_INFINITY;
+  let maxLat = Number.NEGATIVE_INFINITY;
+  let minLon = Number.POSITIVE_INFINITY;
+  let maxLon = Number.NEGATIVE_INFINITY;
+  for (const [lat, lon] of coordinates) {
+    minLat = Math.min(minLat, lat);
+    maxLat = Math.max(maxLat, lat);
+    minLon = Math.min(minLon, lon);
+    maxLon = Math.max(maxLon, lon);
+  }
+  return { minLat, maxLat, minLon, maxLon };
+}
+
+function isRingClosed(coordinates) {
+  if (coordinates.length === 0) return true;
+  const first = coordinates[0];
+  const last = coordinates.at(-1);
+  return first[0] === last[0] && first[1] === last[1];
+}
+
+function incrementSkipped(counts, geometryType) {
+  if (geometryType === 'line') counts.skippedLineCount += 1;
+  else counts.skippedRegionCount += 1;
+}
+
+function createStagingTable(database) {
+  database.run(`
+    CREATE TEMP TABLE ${STAGING_TABLE} (
+      geometry_type TEXT NOT NULL,
+      feature_id TEXT NOT NULL,
+      part TEXT NOT NULL,
+      source_row_index INTEGER NOT NULL,
+      sort_order REAL NOT NULL,
+      lat REAL NOT NULL,
+      lon REAL NOT NULL,
+      color TEXT,
+      weight TEXT,
+      opacity TEXT,
+      fill_color TEXT,
+      fill_opacity TEXT,
+      arrow_mode TEXT
+    )
+  `);
+}
+
+function dropStagingTable(database) {
+  database.run(`DROP TABLE IF EXISTS temp.${STAGING_TABLE}`);
+}
+
+function readDatasetMetadata(database, datasetId) {
+  const statement = database.prepare(`
+    SELECT columns_json, detected_fields_json, coordinate_mapping_json
+    FROM datasets
+    WHERE id = ?
+  `);
+  try {
+    statement.bind([datasetId]);
+    return statement.step() ? statement.getAsObject() : null;
+  } finally {
+    statement.free();
+  }
+}
+
+function parseJsonObject(value) {
+  try {
+    const parsed = JSON.parse(String(value ?? ''));
+    return isRecord(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function parseJsonStringList(value) {
+  try {
+    const parsed = JSON.parse(String(value ?? ''));
+    return Array.isArray(parsed)
+      ? parsed.filter((item) => typeof item === 'string')
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+function normalizeRequiredId(value) {
+  const id = normalizeNullableString(value);
+  if (id) return id;
+  throw new BrowserSqliteGeometryDerivationError(
+    'invalid-geometry-rebuild',
+    'A dataset ID is required.',
+  );
+}
+
+function normalizeSourceRowIndex(value) {
+  const number = Number(value);
+  if (Number.isSafeInteger(number) && number >= 0) return number;
+  throw new BrowserSqliteGeometryDerivationError(
+    'invalid-geometry-rebuild',
+    'A stored source-row index is invalid.',
+  );
+}
+
+function compactString(value) {
+  if (value == null) return null;
+  const string = String(value);
+  return string === '' ? null : string;
+}
+
+function normalizeNullableString(value) {
+  if (typeof value !== 'string') return null;
+  return value.trim() || null;
+}
+
+function requireDatabase(database) {
+  if (
+    !database ||
+    typeof database.prepare !== 'function' ||
+    typeof database.run !== 'function'
+  ) {
+    throw new TypeError(
+      'A sql.js database with prepare() and run() is required.',
+    );
+  }
+}
+
+function isRecord(value) {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+export class BrowserSqliteGeometryDerivationError extends Error {
+  constructor(code, message) {
+    super(message);
+    this.name = 'BrowserSqliteGeometryDerivationError';
+    this.code = code;
+  }
+}

--- a/src/data/browserSqlite/browserSqliteGeometryQueries.js
+++ b/src/data/browserSqlite/browserSqliteGeometryQueries.js
@@ -1,0 +1,407 @@
+export const DEFAULT_BROWSER_SQLITE_GEOMETRY_LIMIT = 1_000;
+export const MAX_BROWSER_SQLITE_GEOMETRY_LIMIT = 10_000;
+
+/**
+ * Query compact line and region records whose bounding boxes may intersect a
+ * viewport. Dataset, spatial, and inclusive timeline filters execute entirely
+ * in SQLite; complete source-row JSON is never selected.
+ *
+ * Bounding-box false positives are intentionally retained. This conservative
+ * first pass cannot miss a crossing geometry merely because every individual
+ * vertex lies outside the viewport.
+ *
+ * @param {{ prepare: Function }} database sql.js database.
+ * @param {object} [query] Backend-neutral map-view query.
+ * @returns {object} Compact bounded geometry result and statistics.
+ */
+export function queryBrowserSqliteGeometries(database, query = {}) {
+  requireDatabase(database);
+  const bounds = normalizeBounds(query.bounds);
+  const geometryLimit = normalizeGeometryLimit(query.renderBudget);
+  const datasetIds = resolveEnabledDatasetIds(database, query.datasetIds);
+  const skipped = sumSkippedGeometries(database, datasetIds);
+
+  if (!bounds || datasetIds.length === 0) {
+    return createEmptyGeometryResult(skipped);
+  }
+
+  const filter = buildGeometryFilter({
+    bounds,
+    datasetIds,
+    timeline: query.timeline,
+  });
+  const matching = countMatchingGeometries(database, filter);
+  const boundsOnly = filter.usesTimeline
+    ? countMatchingGeometries(database, filter.boundsOnly)
+    : matching;
+  const rows = selectGeometries(database, filter, geometryLimit);
+  const features = rows.map(storedRowToGeometry).filter(Boolean);
+  const lines = features
+    .filter((feature) => feature.geometryType === 'line')
+    .map(removeGeometryType);
+  const regions = features
+    .filter((feature) => feature.geometryType === 'region')
+    .map(removeGeometryType);
+  const returnedGeometryCount = lines.length + regions.length;
+  const totalMatchingGeometryCount = matching.lines + matching.regions;
+  const hiddenGeometryCount = Math.max(
+    0,
+    totalMatchingGeometryCount - returnedGeometryCount,
+  );
+
+  return {
+    lines,
+    regions,
+    stats: {
+      skippedLines: skipped.lines,
+      skippedRegions: skipped.regions,
+      skippedLinesByTimeline: Math.max(0, boundsOnly.lines - matching.lines),
+      skippedRegionsByTimeline: Math.max(
+        0,
+        boundsOnly.regions - matching.regions,
+      ),
+      totalMatchingLineCount: matching.lines,
+      totalMatchingRegionCount: matching.regions,
+      returnedLineCount: lines.length,
+      returnedRegionCount: regions.length,
+      totalMatchingGeometryCount,
+      returnedGeometryCount,
+      hiddenGeometryCount,
+      geometryLimit: hiddenGeometryCount > 0 ? geometryLimit : null,
+      geometryOverLimit: hiddenGeometryCount > 0,
+    },
+  };
+}
+
+/** Select complete compact coordinate sequences in deterministic source order. */
+function selectGeometries(database, filter, geometryLimit) {
+  return readAll(database, `
+    SELECT
+      geometry_features.dataset_id,
+      geometry_features.geometry_type,
+      geometry_features.feature_id,
+      geometry_features.part,
+      geometry_features.source_row_index,
+      geometry_features.coordinates_json,
+      geometry_features.style_json,
+      geometry_features.arrow_mode,
+      datasets.coordinate_mapping_json
+    FROM geometry_features
+    INNER JOIN datasets ON datasets.id = geometry_features.dataset_id
+    ${filter.sql}
+    ORDER BY
+      geometry_features.dataset_id,
+      geometry_features.feature_order_index,
+      geometry_features.part_order_index,
+      geometry_features.geometry_type,
+      geometry_features.feature_id,
+      geometry_features.part
+    LIMIT $geometryLimit
+  `, { ...filter.params, $geometryLimit: geometryLimit });
+}
+
+function storedRowToGeometry(row) {
+  const datasetId = normalizeNullableString(row.dataset_id);
+  const geometryType = normalizeNullableString(row.geometry_type);
+  const featureId = normalizeNullableString(row.feature_id);
+  const sourceRowIndex = normalizeNonNegativeInteger(row.source_row_index);
+  const coordinates = parseCoordinates(row.coordinates_json);
+  if (
+    !datasetId ||
+    !featureId ||
+    sourceRowIndex == null ||
+    !coordinates ||
+    (geometryType !== 'line' && geometryType !== 'region')
+  ) {
+    return null;
+  }
+
+  const mapping = parseJsonObject(row.coordinate_mapping_json);
+  const part = geometryType === 'region'
+    ? normalizeNullableString(row.part) ?? '0'
+    : null;
+  return {
+    geometryType,
+    id: geometryType === 'line'
+      ? `${datasetId}:${featureId}`
+      : `${datasetId}:${featureId}:${part}`,
+    featureId,
+    ...(geometryType === 'region' ? { part } : {}),
+    coordinates,
+    style: parseJsonObject(row.style_json),
+    ...(geometryType === 'line'
+      ? { arrow: normalizeArrowMode(row.arrow_mode) }
+      : {}),
+    sourceRef: { datasetId, rowIndex: sourceRowIndex },
+    latField: normalizeNullableString(mapping.latField),
+    lonField: normalizeNullableString(mapping.lonField),
+  };
+}
+
+function removeGeometryType(feature) {
+  const { geometryType: _geometryType, ...normalized } = feature;
+  return normalized;
+}
+
+/** Build conservative viewport and timeline overlap clauses. */
+function buildGeometryFilter({ bounds, datasetIds, timeline }) {
+  const datasetFilter = createDatasetFilter(datasetIds);
+  const boundsClauses = [
+    datasetFilter.sql,
+    'geometry_features.max_lat >= $south',
+    'geometry_features.min_lat <= $north',
+    bounds.crossesAntimeridian
+      ? '('
+        + 'geometry_features.max_lon >= $west '
+        + 'OR geometry_features.min_lon <= $east'
+        + ')'
+      : 'geometry_features.max_lon >= $west '
+        + 'AND geometry_features.min_lon <= $east',
+  ];
+  const boundsParams = {
+    ...datasetFilter.params,
+    $south: bounds.south,
+    $north: bounds.north,
+    $west: bounds.west,
+    $east: bounds.east,
+  };
+  const normalizedTimeline = normalizeTimeline(timeline);
+  const clauses = [...boundsClauses];
+  const params = { ...boundsParams };
+
+  if (normalizedTimeline) {
+    clauses.push(
+      'geometry_features.timeline_start_year IS NOT NULL',
+      'geometry_features.timeline_end_year IS NOT NULL',
+      'geometry_features.timeline_start_year <= $timelineEndYear',
+      'geometry_features.timeline_end_year >= $timelineStartYear',
+    );
+    params.$timelineStartYear = normalizedTimeline.startYear;
+    params.$timelineEndYear = normalizedTimeline.endYear;
+  }
+
+  return {
+    sql: `WHERE ${clauses.join(' AND ')}`,
+    params,
+    usesTimeline: normalizedTimeline != null,
+    boundsOnly: {
+      sql: `WHERE ${boundsClauses.join(' AND ')}`,
+      params: boundsParams,
+    },
+  };
+}
+
+function countMatchingGeometries(database, filter) {
+  const rows = readAll(database, `
+    SELECT
+      geometry_features.geometry_type,
+      COUNT(*) AS count
+    FROM geometry_features
+    INNER JOIN datasets ON datasets.id = geometry_features.dataset_id
+    ${filter.sql}
+    GROUP BY geometry_features.geometry_type
+  `, filter.params);
+  const result = { lines: 0, regions: 0 };
+  for (const row of rows) {
+    if (row.geometry_type === 'line') {
+      result.lines = normalizeCount(row.count);
+    } else if (row.geometry_type === 'region') {
+      result.regions = normalizeCount(row.count);
+    }
+  }
+  return result;
+}
+
+function sumSkippedGeometries(database, datasetIds) {
+  if (datasetIds.length === 0) return { lines: 0, regions: 0 };
+  const filter = createDatasetFilter(datasetIds, 'id');
+  const row = readAll(database, `
+    SELECT
+      COALESCE(SUM(skipped_line_count), 0) AS skipped_lines,
+      COALESCE(SUM(skipped_region_count), 0) AS skipped_regions
+    FROM datasets
+    WHERE ${filter.sql}
+  `, filter.params, 1)[0];
+  return {
+    lines: normalizeCount(row?.skipped_lines),
+    regions: normalizeCount(row?.skipped_regions),
+  };
+}
+
+function resolveEnabledDatasetIds(database, requestedIds) {
+  const rows = readAll(database, `
+    SELECT id
+    FROM datasets
+    WHERE enabled = 1 AND import_state = 'complete'
+    ORDER BY id
+  `);
+  const enabled = rows.map((row) => String(row.id));
+  if (requestedIds == null) return enabled;
+  if (!Array.isArray(requestedIds)) return [];
+  const requested = new Set(
+    requestedIds.map(normalizeNullableString).filter(Boolean),
+  );
+  return enabled.filter((id) => requested.has(id));
+}
+
+function createDatasetFilter(datasetIds, column = 'geometry_features.dataset_id') {
+  const params = {};
+  const placeholders = datasetIds.map((datasetId, index) => {
+    const key = `$dataset${index}`;
+    params[key] = datasetId;
+    return key;
+  });
+  return {
+    sql: `${column} IN (${placeholders.join(', ')})`,
+    params,
+  };
+}
+
+function normalizeBounds(value) {
+  if (!isRecord(value)) return null;
+  const north = normalizeLatitude(value.north);
+  const south = normalizeLatitude(value.south);
+  const east = normalizeLongitude(value.east);
+  const west = normalizeLongitude(value.west);
+  if (north == null || south == null || east == null || west == null) {
+    return null;
+  }
+  return {
+    north: Math.max(north, south),
+    south: Math.min(north, south),
+    east,
+    west,
+    crossesAntimeridian: west > east,
+  };
+}
+
+function normalizeTimeline(value) {
+  if (!value?.timelineEnabled) return null;
+  const startYear = normalizeOptionalInteger(value.startYear ?? value.yearMin);
+  const endYear = normalizeOptionalInteger(value.endYear ?? value.yearMax);
+  if (startYear == null || endYear == null) return null;
+  return {
+    startYear: Math.min(startYear, endYear),
+    endYear: Math.max(startYear, endYear),
+  };
+}
+
+function normalizeGeometryLimit(value) {
+  const number = Number(value);
+  if (!Number.isSafeInteger(number) || number < 1) {
+    return DEFAULT_BROWSER_SQLITE_GEOMETRY_LIMIT;
+  }
+  return Math.min(number, MAX_BROWSER_SQLITE_GEOMETRY_LIMIT);
+}
+
+function normalizeLatitude(value) {
+  const number = Number(value);
+  return Number.isFinite(number) && number >= -90 && number <= 90
+    ? number
+    : null;
+}
+
+function normalizeLongitude(value) {
+  const number = Number(value);
+  return Number.isFinite(number) && number >= -180 && number <= 180
+    ? number
+    : null;
+}
+
+function normalizeOptionalInteger(value) {
+  if (value == null || value === '') return null;
+  const number = Number(value);
+  return Number.isFinite(number) ? Math.trunc(number) : null;
+}
+
+function normalizeNonNegativeInteger(value) {
+  const number = Number(value);
+  return Number.isSafeInteger(number) && number >= 0 ? number : null;
+}
+
+function normalizeCount(value) {
+  return normalizeNonNegativeInteger(value) ?? 0;
+}
+
+function normalizeArrowMode(value) {
+  return ['none', 'start', 'end', 'both'].includes(value) ? value : 'none';
+}
+
+function parseCoordinates(value) {
+  try {
+    const parsed = JSON.parse(String(value ?? ''));
+    if (!Array.isArray(parsed)) return null;
+    const coordinates = parsed.map((coordinate) => (
+      Array.isArray(coordinate) && coordinate.length >= 2
+        ? [Number(coordinate[0]), Number(coordinate[1])]
+        : null
+    ));
+    return coordinates.every((coordinate) => (
+      coordinate &&
+      Number.isFinite(coordinate[0]) &&
+      Number.isFinite(coordinate[1])
+    )) ? coordinates : null;
+  } catch {
+    return null;
+  }
+}
+
+function parseJsonObject(value) {
+  try {
+    const parsed = JSON.parse(String(value ?? ''));
+    return isRecord(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function normalizeNullableString(value) {
+  if (typeof value !== 'string') return null;
+  return value.trim() || null;
+}
+
+function readAll(database, sql, parameters = {}, maximumRows = Infinity) {
+  const statement = database.prepare(sql);
+  const rows = [];
+  try {
+    statement.bind(parameters);
+    while (rows.length < maximumRows && statement.step()) {
+      rows.push(statement.getAsObject());
+    }
+  } finally {
+    statement.free();
+  }
+  return rows;
+}
+
+function createEmptyGeometryResult(skipped) {
+  return {
+    lines: [],
+    regions: [],
+    stats: {
+      skippedLines: skipped.lines,
+      skippedRegions: skipped.regions,
+      skippedLinesByTimeline: 0,
+      skippedRegionsByTimeline: 0,
+      totalMatchingLineCount: 0,
+      totalMatchingRegionCount: 0,
+      returnedLineCount: 0,
+      returnedRegionCount: 0,
+      totalMatchingGeometryCount: 0,
+      returnedGeometryCount: 0,
+      hiddenGeometryCount: 0,
+      geometryLimit: null,
+      geometryOverLimit: false,
+    },
+  };
+}
+
+function requireDatabase(database) {
+  if (!database || typeof database.prepare !== 'function') {
+    throw new TypeError('A sql.js database with prepare() is required.');
+  }
+}
+
+function isRecord(value) {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}

--- a/src/data/browserSqlite/browserSqliteGeometryQueries.smoke.js
+++ b/src/data/browserSqlite/browserSqliteGeometryQueries.smoke.js
@@ -1,0 +1,510 @@
+import assert from 'node:assert/strict';
+import initSqlJs from 'sql.js';
+import {
+  closeBrowserSqliteDatabase,
+  createBrowserSqliteDatabase,
+} from './browserSqliteDatabase.js';
+import {
+  beginBrowserSqliteFileImport,
+  completeBrowserSqliteFileImport,
+  insertBrowserSqliteImportRowBatch,
+} from './browserSqliteImportTransaction.js';
+import {
+  setBrowserSqliteDatasetEnabled,
+  updateBrowserSqliteDatasetMapping,
+} from './browserSqliteDatasetMutations.js';
+import {
+  removeBrowserSqliteDataset,
+} from './browserSqliteDatasetRemoval.js';
+import {
+  getBrowserSqliteDatasetSummary,
+} from './browserSqliteDatasetQueries.js';
+import {
+  getBrowserSqliteFeatureDetails,
+} from './browserSqlitePointDetails.js';
+import {
+  queryBrowserSqliteMapView,
+} from './browserSqlitePointQueries.js';
+
+const HEADERS = [
+  'name',
+  'featureType',
+  'featureId',
+  'part',
+  'order',
+  'lat',
+  'lon',
+  'altLat',
+  'altLon',
+  'year',
+  'date',
+  'dateFrom',
+  'dateTo',
+  'color',
+  'weight',
+  'opacity',
+  'fillColor',
+  'fillOpacity',
+  'arrow',
+];
+
+const SQL = await initSqlJs();
+const database = createBrowserSqliteDatabase(SQL);
+
+try {
+  const rows = [
+    geometry('Route metadata', 'line', 'route', 0, 10, {
+      order: '2', color: '#123456', weight: '25', arrow: 'end', year: '2002',
+    }),
+    geometry('Route detail', 'line', 'route', 0, -10, {
+      order: '1', weight: '1.6', arrow: 'both', year: '2001',
+    }),
+    geometry('Fallback first', 'line', 'fallback', 5, 5, {
+      color: 'worker-color-token', arrow: 'invalid',
+    }),
+    geometry('Fallback second', 'line', 'fallback', 6, 6, {
+      arrow: 'end',
+    }),
+    geometry('Start first', 'line', 'arrow-start', 20, 20, { arrow: 'start' }),
+    geometry('Start second', 'line', 'arrow-start', 21, 21),
+    geometry('End first', 'line', 'arrow-end', 22, 22, { arrow: 'end' }),
+    geometry('End second', 'line', 'arrow-end', 23, 23),
+    geometry('None first', 'line', 'arrow-none', 24, 24, { arrow: 'none' }),
+    geometry('None second', 'line', 'arrow-none', 25, 25),
+    geometry('Heavy first', 'line', 'heavy', 26, 26, { weight: '25' }),
+    geometry('Heavy second', 'line', 'heavy', 27, 27),
+    geometry('Light first', 'line', 'light', 28, 28, { weight: '0' }),
+    geometry('Light second', 'line', 'light', 29, 29),
+    geometry('Too short', 'line', 'short-line', 30, 30),
+    geometry('Missing line ID', 'line', '', 31, 31),
+    geometry('Invalid line coordinate', 'line', 'invalid-line', 999, 31),
+    geometry('Area source', 'region', 'area', 2, 2, {
+      part: 'south', order: '2', fillColor: '#abcdef', year: '2001',
+    }),
+    geometry('Area south first', 'region', 'area', 1, 1, {
+      part: 'south', order: '1', year: '2020',
+    }),
+    geometry('Area south third', 'region', 'area', 1, 3, {
+      part: 'south', order: '3',
+    }),
+    geometry('Area north first', 'region', 'area', 10, 10, {
+      part: 'north', order: '1', color: '#fedcba',
+    }),
+    geometry('Area north second', 'region', 'area', 11, 10, {
+      part: 'north', order: '2',
+    }),
+    geometry('Area north third', 'region', 'area', 10, 11, {
+      part: 'north', order: '3',
+    }),
+    geometry('Cross left', 'region', 'crossing', -5, -5, {
+      order: '1', year: '2001',
+    }),
+    geometry('Cross right', 'region', 'crossing', -5, 5, { order: '2' }),
+    geometry('Cross top', 'region', 'crossing', 5, 0, { order: '3' }),
+    geometry('Default part first', 'region', 'default-part', 40, 40),
+    geometry('Default part second', 'region', 'default-part', 41, 40),
+    geometry('Default part third', 'region', 'default-part', 40, 41),
+    geometry('Short region one', 'region', 'short-region', 42, 42),
+    geometry('Short region two', 'region', 'short-region', 43, 42),
+    geometry('Missing region ID', 'region', '', 44, 44),
+    geometry('Invalid region coordinate', 'region', 'invalid-region', -999, 44),
+    geometry('Mixed point', 'point', '', 50, 50, { year: '1999' }),
+  ];
+
+  const imported = importDataset(database, 'dataset-a', rows);
+  assert.equal(imported.pointFeatureCount, 1);
+  assert.equal(imported.lineFeatureCount, 7);
+  assert.equal(imported.regionFeatureCount, 4);
+  assert.equal(imported.skippedLineCount, 2);
+  assert.equal(imported.skippedRegionCount, 2);
+  assert.equal(readCount(database, 'geometry_features', 'dataset-a'), 11);
+
+  importDataset(database, 'dataset-b', [
+    geometry('Duplicate first', 'line', 'route', 50, 50, { order: '1' }),
+    geometry('Duplicate second', 'line', 'route', 51, 51, { order: '2' }),
+  ]);
+
+  const all = queryBrowserSqliteMapView(database, {
+    bounds: { north: 90, south: -90, east: 180, west: -180 },
+    renderBudget: 100,
+  });
+  assert.equal(all.lines.length, 8);
+  assert.equal(all.regions.length, 4);
+  assert.equal(all.points.length, 1);
+  assert.equal(all.stats.skippedLines, 2);
+  assert.equal(all.stats.skippedRegions, 2);
+  assert.equal(all.stats.totalMatchingLineCount, 8);
+  assert.equal(all.stats.totalMatchingRegionCount, 4);
+  assert.equal(JSON.stringify(all).includes('Route detail'), false);
+  assert.equal(JSON.stringify(all).includes('row_json'), false);
+
+  const route = all.lines.find((line) => line.id === 'dataset-a:route');
+  assert.deepEqual(route.coordinates, [[0, -10], [0, 10]]);
+  assert.deepEqual(route.style, { color: '#123456', weight: 2 });
+  assert.equal(route.arrow, 'both');
+  assert.deepEqual(route.sourceRef, { datasetId: 'dataset-a', rowIndex: 1 });
+  assert.notEqual(
+    route.id,
+    all.lines.find((line) => line.id === 'dataset-b:route').id,
+  );
+
+  const fallback = all.lines.find((line) => line.featureId === 'fallback');
+  assert.deepEqual(fallback.coordinates, [[5, 5], [6, 6]]);
+  assert.equal(fallback.style.color, 'worker-color-token');
+  assert.equal(fallback.arrow, 'end');
+  assert.equal(all.lines.find((line) => line.featureId === 'heavy').style.weight, 20);
+  assert.equal(all.lines.find((line) => line.featureId === 'light').style.weight, 1);
+  assert.equal(all.lines.find((line) => line.featureId === 'arrow-start').arrow, 'start');
+  assert.equal(all.lines.find((line) => line.featureId === 'arrow-end').arrow, 'end');
+  assert.equal(all.lines.find((line) => line.featureId === 'arrow-none').arrow, 'none');
+
+  const south = all.regions.find((region) => region.part === 'south');
+  const north = all.regions.find((region) => region.part === 'north');
+  assert.deepEqual(south.coordinates[0], [1, 1]);
+  assert.deepEqual(south.coordinates.at(-1), south.coordinates[0]);
+  assert.equal(south.style.fillColor, '#abcdef');
+  assert.equal(south.style.color, '#abcdef');
+  assert.equal(north.style.color, '#fedcba');
+  assert.equal(north.style.fillColor, '#fedcba');
+  assert.deepEqual(south.sourceRef, { datasetId: 'dataset-a', rowIndex: 17 });
+  assert.deepEqual(north.sourceRef, south.sourceRef);
+  assert.equal(
+    all.regions.find((region) => region.featureId === 'default-part').part,
+    '0',
+  );
+
+  const crossing = queryBrowserSqliteMapView(database, {
+    bounds: { north: 0.5, south: -0.5, east: 0.5, west: -0.5 },
+    renderBudget: 100,
+  });
+  assert.deepEqual(crossing.lines.map((line) => line.featureId), ['route']);
+  assert.deepEqual(crossing.regions.map((region) => region.featureId), ['crossing']);
+
+  const timeline = queryBrowserSqliteMapView(database, {
+    bounds: { north: 90, south: -90, east: 180, west: -180 },
+    timeline: { timelineEnabled: true, startYear: 2001, endYear: 2001 },
+    renderBudget: 100,
+  });
+  assert.deepEqual(timeline.lines.map((line) => line.featureId), ['route']);
+  assert.deepEqual(
+    timeline.regions.map((region) => `${region.featureId}:${region.part}`),
+    ['area:south', 'area:north', 'crossing:0'],
+  );
+  assert.equal(timeline.stats.skippedLinesByTimeline, 7);
+  assert.equal(timeline.stats.skippedRegionsByTimeline, 1);
+
+  const details = getBrowserSqliteFeatureDetails(database, {
+    featureId: north.id,
+    sourceRef: north.sourceRef,
+  });
+  assert.equal(details.featureId, north.id);
+  assert.equal(details.row.name, 'Area source');
+  assert.equal(details.latField, 'lat');
+  assert.equal(details.lonField, 'lon');
+  assert.deepEqual(
+    getBrowserSqliteFeatureDetails(database, {
+      sourceRef: { datasetId: 'dataset-a', rowIndex: 14 },
+    }),
+    { featureId: null, row: null, latField: null, lonField: null },
+  );
+
+  const limitedQuery = {
+    bounds: { north: 90, south: -90, east: 180, west: -180 },
+    datasetIds: ['dataset-a'],
+    renderBudget: 1,
+  };
+  const limited = queryBrowserSqliteMapView(database, limitedQuery);
+  assert.equal(limited.lines.length + limited.regions.length, 1);
+  assert.equal(limited.stats.geometryOverLimit, true);
+  assert.equal(limited.stats.geometryLimit, 1);
+  assert.equal(limited.stats.totalMatchingLineCount, 7);
+  assert.equal(limited.stats.totalMatchingRegionCount, 4);
+  assert.equal(limited.stats.hiddenGeometryCount, 10);
+  assert.deepEqual(limited, queryBrowserSqliteMapView(database, limitedQuery));
+
+  setBrowserSqliteDatasetEnabled(database, 'dataset-b', false);
+  assert.equal(queryBrowserSqliteMapView(database, {
+    bounds: { north: 90, south: -90, east: 180, west: -180 },
+    renderBudget: 100,
+  }).lines.length, 7);
+  setBrowserSqliteDatasetEnabled(database, 'dataset-b', true);
+
+  importDataset(database, 'dataset-edge-cases', [
+    geometry('Wrap east', 'line', 'wrapped', 0, 179, { order: '1' }),
+    geometry('Wrap west', 'line', 'wrapped', 0, -179, { order: '2' }),
+    geometry('Closed first', 'region', 'closed', 60, 60, { order: '1' }),
+    geometry('Closed second', 'region', 'closed', 61, 60, { order: '2' }),
+    geometry('Closed third', 'region', 'closed', 60, 61, { order: '3' }),
+    geometry('Closed repeat', 'region', 'closed', 60, 60, { order: '4' }),
+  ]);
+  const wrapped = queryBrowserSqliteMapView(database, {
+    bounds: { north: 1, south: -1, east: -170, west: 170 },
+    datasetIds: ['dataset-edge-cases'],
+    renderBudget: 10,
+  });
+  assert.deepEqual(wrapped.lines.map((line) => line.featureId), ['wrapped']);
+  const alreadyClosed = queryBrowserSqliteMapView(database, {
+    bounds: { north: 90, south: -90, east: 180, west: -180 },
+    datasetIds: ['dataset-edge-cases'],
+    renderBudget: 10,
+  }).regions[0];
+  assert.equal(alreadyClosed.coordinates.length, 4);
+  assert.deepEqual(alreadyClosed.coordinates.at(-1), alreadyClosed.coordinates[0]);
+  assert.equal(removeBrowserSqliteDataset(
+    database,
+    'dataset-edge-cases',
+  ).ok, true);
+  assert.equal(readCount(
+    database,
+    'geometry_features',
+    'dataset-edge-cases',
+  ), 0);
+
+  importDataset(database, 'dataset-coverage-a', [
+    geometry('Dated line first', 'line', 'dated-line', 70, 70, {
+      date: '2005-06-01',
+    }),
+    geometry('Dated line second', 'line', 'dated-line', 71, 71),
+    geometry('Dated line third', 'line', 'dated-line', 72, 72),
+    geometry('Invalid arrow first', 'line', 'invalid-arrow', 65, 65, {
+      arrow: 'sideways',
+    }),
+    geometry('Invalid arrow second', 'line', 'invalid-arrow', 66, 66),
+    geometry('Fallback region first', 'region', 'same-region', 55, 55),
+    geometry('Fallback region second', 'region', 'same-region', 56, 55),
+    geometry('Fallback region third', 'region', 'same-region', 55, 56),
+    geometry('Range region first', 'region', 'range-region', 45, 45, {
+      dateFrom: '2000-01-01', dateTo: '2002-12-31',
+    }),
+    geometry('Range region second', 'region', 'range-region', 46, 45),
+    geometry('Range region third', 'region', 'range-region', 45, 46),
+    geometry('Undated region first', 'region', 'undated-region', 35, 35),
+    geometry('Undated region second', 'region', 'undated-region', 36, 35),
+    geometry('Undated region third', 'region', 'undated-region', 35, 36),
+  ], {
+    yearField: null,
+    dateField: 'date',
+    dateFromField: 'dateFrom',
+    dateToField: 'dateTo',
+  });
+  importDataset(database, 'dataset-coverage-b', [
+    geometry('Duplicate region first', 'region', 'same-region', 50, 50),
+    geometry('Duplicate region second', 'region', 'same-region', 51, 50),
+    geometry('Duplicate region third', 'region', 'same-region', 50, 51),
+  ]);
+
+  const coverage = queryBrowserSqliteMapView(database, {
+    bounds: { north: 90, south: -90, east: 180, west: -180 },
+    datasetIds: ['dataset-coverage-a', 'dataset-coverage-b'],
+    renderBudget: 100,
+  });
+  const datedLine = coverage.lines.find(
+    (line) => line.featureId === 'dated-line',
+  );
+  const invalidArrow = coverage.lines.find(
+    (line) => line.featureId === 'invalid-arrow',
+  );
+  const fallbackRegion = coverage.regions.find(
+    (region) => region.id.startsWith('dataset-coverage-a:'),
+  );
+  const duplicateRegion = coverage.regions.find(
+    (region) => region.id.startsWith('dataset-coverage-b:'),
+  );
+  assert.equal(datedLine.coordinates.length, 3);
+  assert.deepEqual(datedLine.style, { color: '#3388ff', weight: 3 });
+  assert.equal(invalidArrow.arrow, 'none');
+  assert.deepEqual(fallbackRegion.coordinates.slice(0, 3), [
+    [55, 55],
+    [56, 55],
+    [55, 56],
+  ]);
+  assert.deepEqual(fallbackRegion.style, {
+    color: '#3388ff',
+    weight: 2,
+    opacity: 1,
+    fillColor: '#3388ff',
+    fillOpacity: 0.25,
+  });
+  assert.equal(fallbackRegion.featureId, duplicateRegion.featureId);
+  assert.notEqual(fallbackRegion.id, duplicateRegion.id);
+
+  const insideGeometry = queryBrowserSqliteMapView(database, {
+    bounds: { north: 57, south: 54, east: 57, west: 54 },
+    datasetIds: ['dataset-coverage-a'],
+    renderBudget: 100,
+  });
+  assert.deepEqual(
+    insideGeometry.regions.map((region) => region.featureId),
+    ['same-region'],
+  );
+
+  const emptyGeometry = queryBrowserSqliteMapView(database, {
+    bounds: { north: -70, south: -80, east: -10, west: -20 },
+    datasetIds: ['dataset-coverage-a', 'dataset-coverage-b'],
+    renderBudget: 100,
+  });
+  assert.deepEqual([emptyGeometry.lines.length, emptyGeometry.regions.length], [0, 0]);
+
+  const rangeTimeline = queryBrowserSqliteMapView(database, {
+    bounds: { north: 90, south: -90, east: 180, west: -180 },
+    datasetIds: ['dataset-coverage-a'],
+    timeline: { timelineEnabled: true, startYear: 2002, endYear: 2002 },
+    renderBudget: 100,
+  });
+  assert.deepEqual(
+    rangeTimeline.regions.map((region) => region.featureId),
+    ['range-region'],
+  );
+  const dateTimeline = queryBrowserSqliteMapView(database, {
+    bounds: { north: 90, south: -90, east: 180, west: -180 },
+    datasetIds: ['dataset-coverage-a'],
+    timeline: { timelineEnabled: true, startYear: 2005, endYear: 2005 },
+    renderBudget: 100,
+  });
+  assert.deepEqual(dateTimeline.lines.map((line) => line.featureId), ['dated-line']);
+  assert.equal(
+    coverage.regions.some((region) => region.featureId === 'undated-region'),
+    true,
+  );
+  assert.equal(
+    dateTimeline.regions.some((region) => region.featureId === 'undated-region'),
+    false,
+  );
+  removeBrowserSqliteDataset(database, 'dataset-coverage-a');
+  removeBrowserSqliteDataset(database, 'dataset-coverage-b');
+
+  const summary = getBrowserSqliteDatasetSummary(database);
+  assert.equal(
+    summary.datasets.find((dataset) => dataset.id === 'dataset-a')
+      .importedFeatureCount,
+    12,
+  );
+  assert.deepEqual(summary.timeline, { yearMin: 1999, yearMax: 2001 });
+
+  const remapped = updateBrowserSqliteDatasetMapping(database, 'dataset-a', {
+    latField: 'altLat',
+    lonField: 'altLon',
+  });
+  assert.equal(remapped.ok, true);
+  const remappedRoute = queryBrowserSqliteMapView(database, {
+    bounds: { north: 31, south: 29, east: 31, west: 29 },
+    datasetIds: ['dataset-a'],
+    renderBudget: 100,
+  }).lines.find((line) => line.featureId === 'route');
+  assert.deepEqual(remappedRoute.coordinates, [[30, 10], [30, 30]]);
+
+  const mappingBeforeFailure = readMapping(database, 'dataset-a');
+  const resultBeforeFailure = queryBrowserSqliteMapView(database, {
+    bounds: { north: 90, south: -90, east: 180, west: -180 },
+    datasetIds: ['dataset-a'],
+    renderBudget: 100,
+  });
+  database.run(`
+    CREATE TRIGGER fail_geometry_rebuild
+    BEFORE INSERT ON geometry_features
+    WHEN NEW.dataset_id = 'dataset-a'
+    BEGIN
+      SELECT RAISE(ABORT, 'simulated geometry rebuild failure');
+    END
+  `);
+  assert.throws(
+    () => updateBrowserSqliteDatasetMapping(database, 'dataset-a', {
+      latField: 'lat',
+      lonField: 'lon',
+    }),
+    (error) => error?.code === 'operation-failed',
+  );
+  database.run('DROP TRIGGER fail_geometry_rebuild');
+  assert.deepEqual(readMapping(database, 'dataset-a'), mappingBeforeFailure);
+  assert.deepEqual(queryBrowserSqliteMapView(database, {
+    bounds: { north: 90, south: -90, east: 180, west: -180 },
+    datasetIds: ['dataset-a'],
+    renderBudget: 100,
+  }), resultBeforeFailure);
+  assert.equal(readScalar(database, 'PRAGMA foreign_key_check'), null);
+} finally {
+  closeBrowserSqliteDatabase(database);
+}
+
+console.log('Browser SQLite line and region parity smoke test passed.');
+
+function geometry(name, featureType, featureId, lat, lon, overrides = {}) {
+  return {
+    name,
+    featureType,
+    featureId,
+    part: '',
+    order: '',
+    lat: String(lat),
+    lon: String(lon),
+    altLat: String(Number(lat) + 30),
+    altLon: String(Number(lon) + 20),
+    year: '',
+    date: '',
+    dateFrom: '',
+    dateTo: '',
+    color: '',
+    weight: '',
+    opacity: '',
+    fillColor: '',
+    fillOpacity: '',
+    arrow: '',
+    ...overrides,
+  };
+}
+
+function importDataset(targetDatabase, datasetId, rows, fieldOverrides = {}) {
+  const activeImport = beginBrowserSqliteFileImport(targetDatabase, {
+    datasetId,
+    fileName: `${datasetId}.csv`,
+  });
+  insertBrowserSqliteImportRowBatch(activeImport, rows);
+  return completeBrowserSqliteFileImport(activeImport, {
+    headers: HEADERS,
+    totalParsedRowCount: rows.length,
+    skippedRowCount: 0,
+    detectedFields: {
+      latField: 'lat',
+      lonField: 'lon',
+      yearField: 'year',
+      dateField: null,
+      dayOfYearField: null,
+      yearFromField: null,
+      yearToField: null,
+      dateFromField: null,
+      dateToField: null,
+      ...fieldOverrides,
+    },
+    coordinateMapping: { latField: 'lat', lonField: 'lon' },
+    warnings: [],
+    importedAt: datasetId === 'dataset-a'
+      ? '2026-07-26T18:00:00.000Z'
+      : '2026-07-26T18:00:01.000Z',
+  });
+}
+
+function readCount(targetDatabase, table, datasetId) {
+  return readScalar(
+    targetDatabase,
+    `SELECT COUNT(*) FROM ${table} WHERE dataset_id = ?`,
+    [datasetId],
+  );
+}
+
+function readMapping(targetDatabase, datasetId) {
+  return JSON.parse(readScalar(
+    targetDatabase,
+    'SELECT coordinate_mapping_json FROM datasets WHERE id = ?',
+    [datasetId],
+  ));
+}
+
+function readScalar(targetDatabase, sql, parameters = []) {
+  const statement = targetDatabase.prepare(sql);
+  try {
+    statement.bind(parameters);
+    return statement.step() ? statement.get()[0] : null;
+  } finally {
+    statement.free();
+  }
+}

--- a/src/data/browserSqlite/browserSqliteImportBatch.js
+++ b/src/data/browserSqlite/browserSqliteImportBatch.js
@@ -249,7 +249,7 @@ function normalizeSuccessfulFileResult(value, fileName) {
     fileName,
     datasetId: normalizeNullableId(value.datasetId),
     rowCount: normalizeCount(value.rowCount),
-    importedFeatureCount: 0,
+    importedFeatureCount: normalizeCount(value.importedFeatureCount),
     skippedRowCount: normalizeCount(value.skippedRowCount),
     warnings: Array.isArray(value.warnings) ? [...value.warnings] : [],
     detectedFields: isRecord(value.detectedFields)

--- a/src/data/browserSqlite/browserSqliteImportTransaction.js
+++ b/src/data/browserSqlite/browserSqliteImportTransaction.js
@@ -2,6 +2,9 @@ import { MAX_CSV_PARSE_WARNINGS } from '../csvParsingCompatibility.js';
 import {
   rebuildBrowserSqlitePointFeatures,
 } from './browserSqlitePointDerivation.js';
+import {
+  rebuildBrowserSqliteGeometryFeatures,
+} from './browserSqliteGeometryDerivation.js';
 
 /** Maximum already-normalized rows accepted by one storage call. */
 export const MAX_BROWSER_SQLITE_IMPORT_BATCH_ROWS = 1_000;
@@ -186,6 +189,10 @@ export function completeBrowserSqliteFileImport(activeImport, metadata) {
       state.database,
       state.datasetId,
     );
+    const geometryResult = rebuildBrowserSqliteGeometryFeatures(
+      state.database,
+      state.datasetId,
+    );
     state.database.run('COMMIT');
     finishActiveImport(state, 'complete');
 
@@ -196,6 +203,10 @@ export function completeBrowserSqliteFileImport(activeImport, metadata) {
       skippedRowCount: normalized.skippedRowCount,
       pointFeatureCount: pointResult.pointFeatureCount,
       skippedPointCount: pointResult.skippedPointCount,
+      lineFeatureCount: geometryResult.lineFeatureCount,
+      skippedLineCount: geometryResult.skippedLineCount,
+      regionFeatureCount: geometryResult.regionFeatureCount,
+      skippedRegionCount: geometryResult.skippedRegionCount,
       importedAt: normalized.importedAt,
     };
   } catch (error) {

--- a/src/data/browserSqlite/browserSqliteImportTransaction.smoke.js
+++ b/src/data/browserSqlite/browserSqliteImportTransaction.smoke.js
@@ -78,6 +78,10 @@ try {
     skippedRowCount: 1,
     pointFeatureCount: 2,
     skippedPointCount: 1,
+    lineFeatureCount: 0,
+    skippedLineCount: 0,
+    regionFeatureCount: 0,
+    skippedRegionCount: 0,
     importedAt: '2026-07-26T14:00:00.000Z',
   });
   assert.equal(freedInsertStatementCount, 1);

--- a/src/data/browserSqlite/browserSqliteImporter.js
+++ b/src/data/browserSqlite/browserSqliteImporter.js
@@ -244,7 +244,10 @@ function finalizeParsedFile(state) {
     datasetId: committed.datasetId,
     rowCount: committed.rowCount,
     totalParsedRowCount: committed.totalParsedRowCount,
-    importedFeatureCount: committed.pointFeatureCount,
+    importedFeatureCount:
+      committed.pointFeatureCount +
+      committed.lineFeatureCount +
+      committed.regionFeatureCount,
     skippedRowCount: committed.skippedRowCount,
     warnings: [...state.warnings],
     detectedFields,

--- a/src/data/browserSqlite/browserSqlitePointDerivation.js
+++ b/src/data/browserSqlite/browserSqlitePointDerivation.js
@@ -8,9 +8,8 @@ import {
   getRowFeatureType,
 } from '../../components/featureTypes.js';
 import {
-  parseDateValue,
-  parseYearValue,
-} from '../../components/timeline.js';
+  getBrowserSqliteTimelineExtent,
+} from './browserSqliteTimeline.js';
 
 const DEFAULT_IMAGE_SIZE_METERS = 100;
 const MIN_IMAGE_SIZE_METERS = 1;
@@ -102,7 +101,7 @@ export function rebuildBrowserSqlitePointFeatures(database, datasetId) {
           continue;
         }
 
-        const timeline = getTimelineExtent(row, detectedFields);
+        const timeline = getBrowserSqliteTimelineExtent(row, detectedFields);
         insertPoint.run([
           normalizedId,
           normalizeSourceRowIndex(stored.source_row_index),
@@ -128,47 +127,6 @@ export function rebuildBrowserSqlitePointFeatures(database, datasetId) {
   `, [pointFeatureCount, skippedPointCount, normalizedId]);
 
   return { pointFeatureCount, skippedPointCount };
-}
-
-function getTimelineExtent(row, fields) {
-  const yearFrom = getRangeYear(
-    row,
-    normalizeNullableString(fields.yearFromField),
-    normalizeNullableString(fields.dateFromField),
-  );
-  const yearTo = getRangeYear(
-    row,
-    normalizeNullableString(fields.yearToField),
-    normalizeNullableString(fields.dateToField),
-  );
-
-  if (yearFrom != null || yearTo != null) {
-    const first = yearFrom ?? yearTo;
-    const last = yearTo ?? yearFrom;
-    return {
-      startYear: Math.min(first, last),
-      endYear: Math.max(first, last),
-    };
-  }
-
-  const year = getRangeYear(
-    row,
-    normalizeNullableString(fields.yearField),
-    normalizeNullableString(fields.dateField),
-  );
-  return year == null ? null : { startYear: year, endYear: year };
-}
-
-function getRangeYear(row, yearField, dateField) {
-  if (yearField) {
-    const year = parseYearValue(row[yearField]);
-    if (year != null) return year;
-  }
-  if (dateField) {
-    const date = parseDateValue(row[dateField]);
-    if (date) return date.getUTCFullYear();
-  }
-  return null;
 }
 
 function getCompactFields(row, mapping) {

--- a/src/data/browserSqlite/browserSqlitePointDetails.js
+++ b/src/data/browserSqlite/browserSqlitePointDetails.js
@@ -4,43 +4,61 @@ export const MAX_BROWSER_SQLITE_GROUP_ROWS_LIMIT = 100;
 const GROUP_ROWS_SORT_ORDER = 'dataset-source-row';
 
 /**
- * Fetch one original source row for an exact point reference.
+ * Fetch one original source row for an exact map-feature reference.
  *
- * Full row JSON is read only for this explicit lookup, never for viewport work.
+ * The reference must belong to a currently derived point, line, or region, so
+ * this operation cannot expose arbitrary stored rows. Full row JSON is read
+ * only for this explicit lookup, never for viewport work. Multipart regions
+ * deliberately carry the same derivation-selected reference, so every part
+ * resolves the same logical metadata row.
  *
  * @param {{ prepare: Function }} database sql.js database.
  * @param {{ sourceRef?: object }} [query] Exact detail request.
  * @returns {object} Normalized detail input or a defined empty result.
  */
-export function getBrowserSqlitePointDetails(database, query = {}) {
+export function getBrowserSqliteFeatureDetails(database, query = {}) {
   requireDatabase(database);
   const sourceRef = normalizeSourceRef(query.sourceRef);
   if (!sourceRef) return createEmptyDetailsResult();
 
   const row = readOne(database, `
-    SELECT
-      source_rows.row_json,
-      datasets.coordinate_mapping_json
-    FROM point_features
-    INNER JOIN source_rows
-      ON source_rows.dataset_id = point_features.dataset_id
-      AND source_rows.source_row_index = point_features.source_row_index
-    INNER JOIN datasets ON datasets.id = point_features.dataset_id
-    WHERE point_features.dataset_id = ?
-      AND point_features.source_row_index = ?
+    SELECT source_rows.row_json, datasets.coordinate_mapping_json
+    FROM source_rows
+    INNER JOIN datasets ON datasets.id = source_rows.dataset_id
+    WHERE source_rows.dataset_id = ?
+      AND source_rows.source_row_index = ?
       AND datasets.import_state = 'complete'
+      AND (
+        EXISTS (
+          SELECT 1
+          FROM point_features
+          WHERE point_features.dataset_id = source_rows.dataset_id
+            AND point_features.source_row_index = source_rows.source_row_index
+        )
+        OR EXISTS (
+          SELECT 1
+          FROM geometry_features
+          WHERE geometry_features.dataset_id = source_rows.dataset_id
+            AND geometry_features.source_row_index = source_rows.source_row_index
+        )
+      )
     LIMIT 1
   `, [sourceRef.datasetId, sourceRef.rowIndex]);
   if (!row) return createEmptyDetailsResult();
 
   const mapping = parseJsonObject(row.coordinate_mapping_json);
   return {
-    featureId: `${sourceRef.datasetId}:${sourceRef.rowIndex}`,
+    featureId: normalizeNullableString(query.featureId) ??
+      `${sourceRef.datasetId}:${sourceRef.rowIndex}`,
     row: parseJsonObject(row.row_json),
     latField: normalizeNullableString(mapping.latField),
     lonField: normalizeNullableString(mapping.lonField),
   };
 }
+
+// Keep the issue-#105 export available to focused point-query tests and any
+// temporary callers while the worker runtime uses the feature-neutral name.
+export const getBrowserSqlitePointDetails = getBrowserSqliteFeatureDetails;
 
 /**
  * Return a stable page of source rows represented by one grouped point.

--- a/src/data/browserSqlite/browserSqlitePointQueries.js
+++ b/src/data/browserSqlite/browserSqlitePointQueries.js
@@ -1,3 +1,7 @@
+import {
+  queryBrowserSqliteGeometries,
+} from './browserSqliteGeometryQueries.js';
+
 export const DEFAULT_BROWSER_SQLITE_RENDER_BUDGET = 1_000;
 export const MAX_BROWSER_SQLITE_RENDER_BUDGET = 10_000;
 
@@ -13,13 +17,17 @@ export const MAX_BROWSER_SQLITE_RENDER_BUDGET = 10_000;
  */
 export function queryBrowserSqliteMapView(database, query = {}) {
   requireDatabase(database);
+  const geometryResult = queryBrowserSqliteGeometries(database, query);
   const bounds = normalizeBounds(query.bounds);
   const renderBudget = normalizeRenderBudget(query.renderBudget);
   const datasetIds = resolveEnabledDatasetIds(database, query.datasetIds);
   const skippedPoints = sumSkippedPoints(database, datasetIds);
 
   if (!bounds || datasetIds.length === 0) {
-    return createEmptyResult({ skippedPoints });
+    return mergeGeometryResult(
+      createEmptyResult({ skippedPoints }),
+      geometryResult,
+    );
   }
 
   const filter = buildPointFilter({ bounds, datasetIds, timeline: query.timeline });
@@ -48,7 +56,7 @@ export function queryBrowserSqliteMapView(database, query = {}) {
     ? points.reduce((sum, point) => sum + point.count, 0)
     : points.length;
 
-  return {
+  return mergeGeometryResult({
     points,
     lines: [],
     regions: [],
@@ -72,6 +80,49 @@ export function queryBrowserSqliteMapView(database, query = {}) {
     // Dataset-wide extent is returned by getDatasetSummary; per-row entries
     // would defeat the compact viewport contract.
     timelineIndex: { entries: [] },
+  }, geometryResult);
+}
+
+function mergeGeometryResult(pointResult, geometryResult) {
+  const geometryStats = geometryResult.stats;
+  const skippedLinesByTimeline = geometryStats.skippedLinesByTimeline;
+  const skippedRegionsByTimeline = geometryStats.skippedRegionsByTimeline;
+  const geometryOverLimit = geometryStats.geometryOverLimit;
+
+  return {
+    ...pointResult,
+    lines: geometryResult.lines,
+    regions: geometryResult.regions,
+    stats: {
+      ...pointResult.stats,
+      skippedLines: geometryStats.skippedLines,
+      skippedRegions: geometryStats.skippedRegions,
+      skippedLinesByTimeline,
+      skippedRegionsByTimeline,
+      skippedByTimeline:
+        pointResult.stats.skippedPointsByTimeline +
+        skippedLinesByTimeline +
+        skippedRegionsByTimeline,
+      limitedToRenderBudget:
+        pointResult.stats.limitedToRenderBudget ?? geometryStats.geometryLimit,
+      totalMatchingCount:
+        pointResult.stats.totalMatchingCount +
+        geometryStats.totalMatchingGeometryCount,
+      returnedCount:
+        pointResult.points.length +
+        geometryStats.returnedGeometryCount,
+      hiddenByRenderBudget:
+        pointResult.stats.hiddenByRenderBudget +
+        geometryStats.hiddenGeometryCount,
+      overBudget: pointResult.stats.overBudget || geometryOverLimit,
+      totalMatchingLineCount: geometryStats.totalMatchingLineCount,
+      totalMatchingRegionCount: geometryStats.totalMatchingRegionCount,
+      returnedLineCount: geometryStats.returnedLineCount,
+      returnedRegionCount: geometryStats.returnedRegionCount,
+      hiddenGeometryCount: geometryStats.hiddenGeometryCount,
+      geometryLimit: geometryStats.geometryLimit,
+      geometryOverLimit,
+    },
   };
 }
 

--- a/src/data/browserSqlite/browserSqliteRealBrowser.validation.js
+++ b/src/data/browserSqlite/browserSqliteRealBrowser.validation.js
@@ -43,6 +43,10 @@ async function runRealBrowserValidation() {
       initialization.capabilities.persistence === 'temporary',
       'The browser SQLite adapter did not report temporary storage.',
     );
+    requireCondition(
+      initialization.capabilities.lines && initialization.capabilities.regions,
+      'The browser SQLite adapter did not report geometry parity.',
+    );
 
     const unsubscribeProgress = dataSource.subscribeImportProgress((event) => {
       progress.push(event);
@@ -189,6 +193,65 @@ async function runRealBrowserValidation() {
     );
     requireCondition(queryHeartbeatCount > 0, 'The main thread stalled during queries.');
 
+    const geometryImport = await dataSource.importBrowserFiles({
+      files: [createGeometryCsvFile()],
+    });
+    requireCondition(geometryImport.ok, 'The geometry CSV import failed.');
+    requireEqual(
+      geometryImport.results[0]?.importedFeatureCount,
+      3,
+      'geometry derived feature count',
+    );
+    const geometryDatasetId = geometryImport.results[0]?.datasetId;
+    const geometry = await dataSource.queryMapView({
+      bounds: { north: 0.5, south: -0.5, east: 0.5, west: -0.5 },
+      datasetIds: [geometryDatasetId],
+      renderBudget: 10,
+    });
+    requireEqual(geometry.lines.length, 1, 'real-worker line count');
+    requireEqual(geometry.regions.length, 1, 'real-worker crossing region count');
+    requireEqual(geometry.lines[0].arrow, 'end', 'real-worker line arrow');
+    requireEqual(
+      geometry.regions[0].coordinates.length,
+      4,
+      'real-worker closed region coordinate count',
+    );
+    assertNoSourceRows(geometry, 'geometry viewport');
+
+    const geometryTimeline = await dataSource.queryMapView({
+      bounds: { north: 90, south: -90, east: 180, west: -180 },
+      datasetIds: [geometryDatasetId],
+      timeline: { timelineEnabled: true, startYear: 2001, endYear: 2001 },
+      renderBudget: 10,
+    });
+    requireEqual(geometryTimeline.lines.length, 1, 'timeline line count');
+    requireEqual(geometryTimeline.regions.length, 2, 'timeline region count');
+
+    const geometryDetails = await dataSource.getFeatureDetails({
+      featureId: geometryTimeline.regions[1].id,
+      sourceRef: geometryTimeline.regions[1].sourceRef,
+    });
+    requireEqual(
+      geometryDetails.row?.name,
+      'Region detail',
+      'multipart region detail source',
+    );
+
+    const limitedGeometry = await dataSource.queryMapView({
+      bounds: { north: 90, south: -90, east: 180, west: -180 },
+      datasetIds: [geometryDatasetId],
+      renderBudget: 1,
+    });
+    requireCondition(
+      limitedGeometry.stats.geometryOverLimit,
+      'The real-worker geometry query did not enforce its limit.',
+    );
+    requireEqual(
+      limitedGeometry.lines.length + limitedGeometry.regions.length,
+      1,
+      'limited real-worker geometry count',
+    );
+
     let cancelPromise = null;
     const cancellationProgress = [];
     const unsubscribeCancellation = dataSource.subscribeImportProgress((event) => {
@@ -218,13 +281,18 @@ async function runRealBrowserValidation() {
     const summaryAfterCancellation = await dataSource.getDatasetSummary();
     requireEqual(
       summaryAfterCancellation.datasets.length,
-      1,
+      2,
       'dataset count after canceled rollback',
     );
-    requireEqual(
-      summaryAfterCancellation.datasets[0].id,
-      datasetId,
-      'preserved committed dataset',
+    requireCondition(
+      summaryAfterCancellation.datasets.some((dataset) => dataset.id === datasetId),
+      'The committed point dataset was not preserved.',
+    );
+    requireCondition(
+      summaryAfterCancellation.datasets.some(
+        (dataset) => dataset.id === geometryDatasetId,
+      ),
+      'The committed geometry dataset was not preserved.',
     );
 
     return {
@@ -245,6 +313,9 @@ async function runRealBrowserValidation() {
         groupTotalRows: firstGroupPage.totalRows,
         groupPagesRead: 2,
         detailFound: details.row != null,
+        lines: geometry.lines.length,
+        regions: geometryTimeline.regions.length,
+        geometryDetailFound: geometryDetails.row != null,
       },
       canceledImportRolledBack: true,
       restartVerifiedEmpty: await verifyRestartIsEmpty(dataSource),
@@ -286,6 +357,24 @@ function createCsvFile(rowCount, name) {
   return new File([lines.join('\n')], name, {
     type: 'text/csv',
     lastModified: 1_750_000_000_000,
+  });
+}
+
+function createGeometryCsvFile() {
+  const csv = [
+    'name,featureType,featureId,part,order,lat,lon,year,color,weight,fillColor,arrow',
+    'Line end,line,route,,2,0,10,2002,#123456,5,,end',
+    'Line detail,line,route,,1,0,-10,2001,,,,',
+    'Region detail,region,area,south,2,-5,5,2001,,,#abcdef,',
+    'Region south first,region,area,south,1,-5,-5,2020,,,,',
+    'Region south top,region,area,south,3,5,0,,,,,',
+    'Region north first,region,area,north,1,10,10,,,,,',
+    'Region north second,region,area,north,2,11,10,,,,,',
+    'Region north third,region,area,north,3,10,11,,,,,',
+  ].join('\n');
+  return new File([csv], 'geometry.csv', {
+    type: 'text/csv',
+    lastModified: 1_750_000_000_001,
   });
 }
 

--- a/src/data/browserSqlite/browserSqliteTimeline.js
+++ b/src/data/browserSqlite/browserSqliteTimeline.js
@@ -1,0 +1,62 @@
+import {
+  parseDateValue,
+  parseYearValue,
+} from '../../components/timeline.js';
+
+/**
+ * Resolve the inclusive year extent used by browser-SQLite features.
+ *
+ * Explicit from/to fields take precedence over single-value fields. A missing
+ * side of a range reuses the available side, matching the raw browser timeline
+ * index. Null means the feature is undated and is excluded only when timeline
+ * filtering is enabled.
+ *
+ * @param {Record<string, unknown>} row Original normalized source row.
+ * @param {Record<string, unknown>} fields Detected timeline field metadata.
+ * @returns {{ startYear: number, endYear: number }|null} Inclusive year extent.
+ */
+export function getBrowserSqliteTimelineExtent(row, fields) {
+  const yearFrom = getRangeYear(
+    row,
+    normalizeNullableString(fields.yearFromField),
+    normalizeNullableString(fields.dateFromField),
+  );
+  const yearTo = getRangeYear(
+    row,
+    normalizeNullableString(fields.yearToField),
+    normalizeNullableString(fields.dateToField),
+  );
+
+  if (yearFrom != null || yearTo != null) {
+    const first = yearFrom ?? yearTo;
+    const last = yearTo ?? yearFrom;
+    return {
+      startYear: Math.min(first, last),
+      endYear: Math.max(first, last),
+    };
+  }
+
+  const year = getRangeYear(
+    row,
+    normalizeNullableString(fields.yearField),
+    normalizeNullableString(fields.dateField),
+  );
+  return year == null ? null : { startYear: year, endYear: year };
+}
+
+function getRangeYear(row, yearField, dateField) {
+  if (yearField) {
+    const year = parseYearValue(row[yearField]);
+    if (year != null) return year;
+  }
+  if (dateField) {
+    const date = parseDateValue(row[dateField]);
+    if (date) return date.getUTCFullYear();
+  }
+  return null;
+}
+
+function normalizeNullableString(value) {
+  if (typeof value !== 'string') return null;
+  return value.trim() || null;
+}

--- a/src/data/browserSqlite/browserSqliteWorkerClient.smoke.js
+++ b/src/data/browserSqlite/browserSqliteWorkerClient.smoke.js
@@ -90,7 +90,7 @@ respondSuccess(worker, worker.posted.at(-1), {
   initialized: true,
   reused: false,
   databaseStorage: 'memory',
-  schemaVersion: 2,
+  schemaVersion: 3,
 });
 assert.equal((await initializePromise).initialized, true);
 

--- a/src/data/browserSqlite/browserSqliteWorkerRuntime.js
+++ b/src/data/browserSqlite/browserSqliteWorkerRuntime.js
@@ -19,7 +19,7 @@ import {
 } from './browserSqliteImportBatch.js';
 import {
   getBrowserSqliteGroupRows,
-  getBrowserSqlitePointDetails,
+  getBrowserSqliteFeatureDetails,
 } from './browserSqlitePointDetails.js';
 import {
   queryBrowserSqliteMapView,
@@ -163,7 +163,7 @@ export function createBrowserSqliteWorkerRuntime({
           request.payload,
         );
       case BROWSER_SQLITE_OPERATIONS.GET_FEATURE_DETAILS:
-        return getBrowserSqlitePointDetails(
+        return getBrowserSqliteFeatureDetails(
           requireDatabase(database),
           request.payload,
         );

--- a/src/data/browserSqlite/browserSqliteWorkerRuntime.smoke.js
+++ b/src/data/browserSqlite/browserSqliteWorkerRuntime.smoke.js
@@ -63,7 +63,7 @@ try {
     initialized: true,
     reused: false,
     databaseStorage: 'memory',
-    schemaVersion: 2,
+    schemaVersion: 3,
   });
   const repeatedInitialize = await runtime.handleMessage(request(
     'initialize-repeated',

--- a/src/data/dataSource.js
+++ b/src/data/dataSource.js
@@ -441,6 +441,13 @@ export const BACKEND_FAILURE_CATEGORIES = Object.freeze({
  * @property {number} [returnedCount]
  * @property {number} [hiddenByRenderBudget]
  * @property {boolean} [overBudget]
+ * @property {number} [totalMatchingLineCount]
+ * @property {number} [totalMatchingRegionCount]
+ * @property {number} [returnedLineCount]
+ * @property {number} [returnedRegionCount]
+ * @property {number} [hiddenGeometryCount]
+ * @property {number|null} [geometryLimit]
+ * @property {boolean} [geometryOverLimit]
  */
 
 /**

--- a/src/data/dataSourceNormalization.js
+++ b/src/data/dataSourceNormalization.js
@@ -516,6 +516,21 @@ function normalizeMapViewStats(value, returnedCount) {
   const skippedPointsByTimeline = normalizeNonNegativeInteger(source.skippedPointsByTimeline);
   const skippedLinesByTimeline = normalizeNonNegativeInteger(source.skippedLinesByTimeline);
   const skippedRegionsByTimeline = normalizeNonNegativeInteger(source.skippedRegionsByTimeline);
+  const totalMatchingLineCount = normalizeNonNegativeInteger(
+    source.totalMatchingLineCount,
+  );
+  const totalMatchingRegionCount = normalizeNonNegativeInteger(
+    source.totalMatchingRegionCount,
+  );
+  const returnedLineCount = normalizeNonNegativeInteger(
+    source.returnedLineCount,
+  );
+  const returnedRegionCount = normalizeNonNegativeInteger(
+    source.returnedRegionCount,
+  );
+  const hiddenGeometryCount = normalizeNonNegativeInteger(
+    source.hiddenGeometryCount,
+  );
 
   return {
     skippedPoints: normalizeNonNegativeInteger(source.skippedPoints),
@@ -533,6 +548,14 @@ function normalizeMapViewStats(value, returnedCount) {
     returnedCount: normalizedReturnedCount,
     hiddenByRenderBudget,
     overBudget: source.overBudget === true || hiddenByRenderBudget > 0,
+    totalMatchingLineCount,
+    totalMatchingRegionCount,
+    returnedLineCount,
+    returnedRegionCount,
+    hiddenGeometryCount,
+    geometryLimit: normalizeOptionalNonNegativeInteger(source.geometryLimit),
+    geometryOverLimit:
+      source.geometryOverLimit === true || hiddenGeometryCount > 0,
   };
 }
 


### PR DESCRIPTION
## Summary

Add browser SQLite line and region feature parity to the temporary browser backend.

## Changes

- Add compact indexed SQLite storage for line and region geometries.
- Derive lines and multipart regions from stored source rows.
- Preserve ordering, styles, weights, arrows, ring closure, and detail-source behavior.
- Add viewport bounding-box and timeline filtering inside SQLite.
- Support wrapped viewports and crossing geometries.
- Add bounded dense-geometry results with useful statistics.
- Fetch complete line and region details separately by stable source reference.
- Rebuild points, lines, and regions transactionally after mapping changes.
- Include all feature types in dataset summaries and timeline metadata.
- Add focused parity tests and real browser-worker validation.
- Document geometry derivation, querying, limits, details, and rollback behavior.
- Keep the normal GitHub Pages and desktop workflows unchanged.

## Validation

- Full smoke-test suite passes.
- Real Electron browser-worker validation passes.
- ESLint passes.
- Browser production build passes.
- Desktop production build passes.
- `git diff --check` passes.

Closes #106
