### PR TITLE
Disable marker clustering by default and add proximity selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "smoke:browser-sqlite-worker-client": "node src/data/browserSqlite/browserSqliteWorkerClient.smoke.js",
     "smoke:browser-sqlite-data-source": "node src/data/browserSqlite/browserSqliteDataSource.smoke.js",
     "smoke:browser-sqlite-ui": "node src/components/browserSqliteUiCoordination.smoke.js",
+    "smoke:marker-proximity": "node src/components/markerProximitySelection.smoke.js",
     "smoke:browser-sqlite-points": "node src/data/browserSqlite/browserSqlitePointQueries.smoke.js",
     "validate:browser-sqlite-worker": "node desktop/run-electron.cjs desktop/browserSqliteWorkerValidation.cjs",
     "smoke:csv-compatibility": "node src/data/csvParsingCompatibility.smoke.js",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -103,6 +103,7 @@ export default function App() {
 
   // App owns marker selection so the map and details panel share one lifecycle.
   const [selectedMarker, setSelectedMarker] = useState(null);
+  const [selectedMarkers, setSelectedMarkers] = useState([]);
   const [isMarkerPanelCollapsed, setIsMarkerPanelCollapsed] = useState(false);
 
   // The details panel uses the CSV panel's visible edge as its left position.
@@ -310,9 +311,14 @@ export default function App() {
     }
   }, [dataSource, databasePreviewState]);
 
-  const handleMarkerSelect = useCallback((marker) => {
+  const handleMarkerSelect = useCallback((marker, nearbyMarkers) => {
     // Selecting a marker always reveals its details, even after a collapse.
     setSelectedMarker(marker);
+    setSelectedMarkers(
+      Array.isArray(nearbyMarkers) && nearbyMarkers.length > 0
+        ? nearbyMarkers
+        : [marker],
+    );
     setIsMarkerPanelCollapsed(false);
   }, []);
 
@@ -323,6 +329,7 @@ export default function App() {
   const handleMarkerPanelClose = useCallback(() => {
     // Clearing the selection unmounts both the panel and its collapsed control.
     setSelectedMarker(null);
+    setSelectedMarkers([]);
     setIsMarkerPanelCollapsed(false);
   }, []);
 
@@ -354,6 +361,7 @@ export default function App() {
         )),
       }));
       setSelectedMarker(null);
+      setSelectedMarkers([]);
       setIsMarkerPanelCollapsed(false);
       setDesktopDataRevision((revision) => revision + 1);
       setDesktopVisibilityState((current) => ({
@@ -412,6 +420,7 @@ export default function App() {
         datasets: current.datasets.filter((item) => item.id !== datasetId),
       }));
       setSelectedMarker(null);
+      setSelectedMarkers([]);
       setIsMarkerPanelCollapsed(false);
       if (databaseSelectedId === datasetId) {
         previewRequestRef.current += 1;
@@ -457,6 +466,7 @@ export default function App() {
         )),
       }));
       setSelectedMarker(null);
+      setSelectedMarkers([]);
       setIsMarkerPanelCollapsed(false);
       setDesktopDataRevision((revision) => revision + 1);
       setDatabaseMappingState({ pendingDatasetId: null, error: null });
@@ -835,6 +845,7 @@ export default function App() {
 
         <MarkerDetailsPanel
           marker={selectedMarker}
+          markers={selectedMarkers}
           leftOffset={csvPanelVisibleWidth}
           getSourceRow={activeMapFeatures.getSourceRow}
           getFeatureDetails={activeFeatureDetailsLoader}

--- a/src/components/GeoMap.jsx
+++ b/src/components/GeoMap.jsx
@@ -27,6 +27,10 @@ import "leaflet-polylinedecorator";
 
 import { getClusterMarkerIcon, getMarkerIcon } from "./markerIcons";
 import { buildMarkerDetailFields } from "./markerDetailFields";
+import {
+  findMarkersNearClickedMarker,
+  MARKER_PROXIMITY_RADIUS_PIXELS,
+} from "./markerProximitySelection";
 
 function getFeaturePopupRow(feature, getSourceRow) {
   return feature?.row ?? getSourceRow?.(feature?.sourceFileId, feature?.sourceRowIndex) ?? null;
@@ -259,6 +263,79 @@ function ViewportChangeReporter({ onViewportChange }) {
 
   return null;
 }
+
+/**
+ * Render exact point markers and keep proximity selection separate from clustering.
+ * The points prop is already scoped by active dataset visibility and timeline filters.
+ */
+function ExactPointMarkers({
+  points,
+  clusterMarkersEnabled,
+  clusterRadius,
+  markerClusterGroupRef,
+  onMarkerSelect,
+}) {
+  const map = useMap();
+
+  /** Project from the clicked marker anchor and forward its ordered nearby matches. */
+  function selectWithProximity(clickedMarker) {
+    const nearbyMarkers = findMarkersNearClickedMarker(
+      points,
+      clickedMarker,
+      // Container-point projection measures from each marker's map anchor,
+      // rather than from the mouse pointer inside the marker icon.
+      (marker) => map.latLngToContainerPoint([marker.lat, marker.lon]),
+    );
+    onMarkerSelect?.(clickedMarker, nearbyMarkers);
+  }
+
+  if (clusterMarkersEnabled) {
+    return (
+      <MarkerClusterGroup
+        ref={markerClusterGroupRef}
+        // Force a re-init when clustering settings change.
+        // Leaflet.markercluster does not always apply maxClusterRadius updates dynamically.
+        key={`cluster:${clusterMarkersEnabled ? 1 : 0}:${clusterRadius}`}
+        // chunkedLoading improves responsiveness when there are many markers.
+        // It progressively adds markers to the map instead of blocking the UI.
+        chunkedLoading
+        iconCreateFunction={createMarkerClusterIcon}
+        maxClusterRadius={clusterRadius}
+      >
+        {points.map((point) => {
+          const icon = getMarkerIcon(point.marker);
+
+          return (
+            <Marker
+              key={point.id}
+              ref={(marker) => setCsvMarkerValue(marker, point.marker)}
+              position={[point.lat, point.lon]}
+              {...(icon ? { icon } : {})}
+              // Cluster mode deliberately bypasses proximity selection so
+              // expansion and spiderfying retain their existing behavior.
+              eventHandlers={{
+                click: () => onMarkerSelect?.(point, [point]),
+              }}
+            />
+          );
+        })}
+      </MarkerClusterGroup>
+    );
+  }
+
+  return points.map((point) => {
+    const icon = getMarkerIcon(point.marker);
+
+    return (
+      <Marker
+        key={point.id}
+        position={[point.lat, point.lon]}
+        {...(icon ? { icon } : {})}
+        eventHandlers={{ click: () => selectWithProximity(point) }}
+      />
+    );
+  });
+}
 /**
  * Map tile providers.
  * We expose:
@@ -412,7 +489,7 @@ export default function GeoMap({
       {selectedMarker && (
         <CircleMarker
           center={[selectedMarker.lat, selectedMarker.lon]}
-          radius={18}
+          radius={MARKER_PROXIMITY_RADIUS_PIXELS}
           pathOptions={{
             color: "#facc15",
             weight: 4,
@@ -431,46 +508,13 @@ export default function GeoMap({
         - Clicking a cluster zooms in and reveals the markers inside.
         - When disabled, markers are shown normally (current behavior).
       */}
-      {clusterMarkersEnabled ? (
-        <MarkerClusterGroup
-          ref={markerClusterGroupRef}
-          // Force a re-init when clustering settings change.
-          // Leaflet.markercluster does not always apply maxClusterRadius updates dynamically.
-          key={`cluster:${clusterMarkersEnabled ? 1 : 0}:${clusterRadius}`}
-          // chunkedLoading improves responsiveness when there are many markers.
-          // It progressively adds markers to the map instead of blocking the UI.
-          chunkedLoading
-          iconCreateFunction={createMarkerClusterIcon}
-          maxClusterRadius={clusterRadius}
-        >
-          {exactMarkerPoints.map((p) => {
-            const icon = getMarkerIcon(p.marker);
-
-            return (
-              <Marker
-                key={p.id}
-                ref={(marker) => setCsvMarkerValue(marker, p.marker)}
-                position={[p.lat, p.lon]}
-                {...(icon ? { icon } : {})}
-                eventHandlers={{ click: () => onMarkerSelect?.(p) }}
-              />
-            );
-          })}
-        </MarkerClusterGroup>
-      ) : (
-        exactMarkerPoints.map((p) => {
-          const icon = getMarkerIcon(p.marker);
-
-          return (
-            <Marker
-              key={p.id}
-              position={[p.lat, p.lon]}
-              {...(icon ? { icon } : {})}
-              eventHandlers={{ click: () => onMarkerSelect?.(p) }}
-            />
-          );
-        })
-      )}
+      <ExactPointMarkers
+        points={exactMarkerPoints}
+        clusterMarkersEnabled={clusterMarkersEnabled}
+        clusterRadius={clusterRadius}
+        markerClusterGroupRef={markerClusterGroupRef}
+        onMarkerSelect={onMarkerSelect}
+      />
 
       {/* Render grouped SQLite summaries as count markers, separate from exact marker clustering. */}
       {groupedMarkerPoints.map((p) => {

--- a/src/components/MarkerDetails.jsx
+++ b/src/components/MarkerDetails.jsx
@@ -108,6 +108,66 @@ export function PointMarkerDetails({
   );
 }
 
+/**
+ * Show every marker in an ordered proximity result while loading details on expansion.
+ * The first item is the originally clicked marker and starts expanded.
+ */
+export function NearbyMarkerDetails({
+  points,
+  getSourceRow,
+  getFeatureDetails,
+}) {
+  return (
+    <div style={{ minWidth: 280 }}>
+      <div style={{ fontWeight: 700, marginBottom: 8 }}>
+        Markers near this location
+      </div>
+
+      {points.map((point, index) => (
+        <NearbyMarkerDetailsItem
+          key={`${point.id}:${index}`}
+          point={point}
+          index={index}
+          getSourceRow={getSourceRow}
+          getFeatureDetails={getFeatureDetails}
+        />
+      ))}
+    </div>
+  );
+}
+
+/** Render one expandable nearby-marker item and load backend details only when open. */
+function NearbyMarkerDetailsItem({
+  point,
+  index,
+  getSourceRow,
+  getFeatureDetails,
+}) {
+  const [isOpen, setIsOpen] = useState(index === 0);
+
+  return (
+    <details
+      open={isOpen}
+      onToggle={(event) => setIsOpen(event.currentTarget.open)}
+      style={{ marginBottom: 8 }}
+    >
+      <summary>
+        Marker {index + 1}{index === 0 ? ' (selected)' : ''}
+      </summary>
+      <div style={{ padding: '6px 0 2px 12px' }}>
+        <PointMarkerDetails
+          point={point}
+          latField={point.latField}
+          lonField={point.lonField}
+          getSourceRow={getSourceRow}
+          getFeatureDetails={getFeatureDetails}
+          isActive={isOpen}
+        />
+      </div>
+    </details>
+  );
+}
+
 export function GroupedMarkerDetails({ point, getGroupRows, isActive }) {
   const requestVersionRef = useRef(0);
   const [pagingState, setPagingState] = useState({

--- a/src/components/MarkerDetailsPanel.jsx
+++ b/src/components/MarkerDetailsPanel.jsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 
 import {
   GroupedMarkerDetails,
+  NearbyMarkerDetails,
   PointMarkerDetails,
 } from './MarkerDetails';
 
@@ -11,6 +12,7 @@ const COLLAPSED_PANEL_WIDTH = 34;
 
 export function MarkerDetailsPanel({
   marker,
+  markers = [],
   leftOffset,
   getSourceRow,
   getFeatureDetails,
@@ -64,8 +66,11 @@ export function MarkerDetailsPanel({
   if (!marker) return null;
 
   const grouped = isGroupedMarker(marker);
+  const showsProximityResults = !grouped && markers.length > 1;
   // Remount details when selection changes so old loading/paging state cannot leak.
-  const detailKey = `${marker.renderType ?? 'exact'}:${marker.id}`;
+  const detailKey = showsProximityResults
+    ? `nearby:${marker.id}:${markers.length}`
+    : `${marker.renderType ?? 'exact'}:${marker.id}`;
 
   return (
     <aside
@@ -115,7 +120,14 @@ export function MarkerDetailsPanel({
 
       {/* hidden keeps detail state mounted while the panel is collapsed. */}
       <div className='markerDetailsPanelContent' hidden={isCollapsed}>
-        {grouped ? (
+        {showsProximityResults ? (
+          <NearbyMarkerDetails
+            key={detailKey}
+            points={markers}
+            getSourceRow={getSourceRow}
+            getFeatureDetails={getFeatureDetails}
+          />
+        ) : grouped ? (
           <GroupedMarkerDetails
             key={detailKey}
             point={marker}

--- a/src/components/markerProximitySelection.js
+++ b/src/components/markerProximitySelection.js
@@ -1,0 +1,56 @@
+export const MARKER_PROXIMITY_RADIUS_PIXELS = 18;
+
+/**
+ * Find visible markers inside a circular screen-pixel radius of the clicked marker.
+ * The caller supplies the already filtered marker set and the current map projection.
+ */
+export function findMarkersNearClickedMarker(
+  markers,
+  clickedMarker,
+  projectMarker,
+  radius = MARKER_PROXIMITY_RADIUS_PIXELS,
+) {
+  if (
+    !Array.isArray(markers) ||
+    !clickedMarker ||
+    typeof projectMarker !== 'function' ||
+    !Number.isFinite(radius) ||
+    radius < 0
+  ) {
+    return [];
+  }
+
+  const clickedPoint = projectMarker(clickedMarker);
+  if (!isProjectedPoint(clickedPoint)) return [];
+
+  const radiusSquared = radius * radius;
+  const nearby = [];
+
+  markers.forEach((marker, sourceIndex) => {
+    const projectedPoint = projectMarker(marker);
+    if (!isProjectedPoint(projectedPoint)) return;
+
+    // Leaflet container points use screen pixels, so squared Euclidean distance
+    // gives a circular hit area without converting the radius to map units.
+    const deltaX = projectedPoint.x - clickedPoint.x;
+    const deltaY = projectedPoint.y - clickedPoint.y;
+    const distanceSquared = (deltaX * deltaX) + (deltaY * deltaY);
+    if (distanceSquared > radiusSquared) return;
+
+    nearby.push({ marker, sourceIndex, distanceSquared });
+  });
+
+  nearby.sort((left, right) => {
+    if (left.marker === clickedMarker) return -1;
+    if (right.marker === clickedMarker) return 1;
+    return left.distanceSquared - right.distanceSquared ||
+      left.sourceIndex - right.sourceIndex;
+  });
+
+  return nearby.map(({ marker }) => marker);
+}
+
+/** Return whether a map projection produced finite screen-pixel coordinates. */
+function isProjectedPoint(point) {
+  return Number.isFinite(point?.x) && Number.isFinite(point?.y);
+}

--- a/src/components/markerProximitySelection.smoke.js
+++ b/src/components/markerProximitySelection.smoke.js
@@ -1,0 +1,101 @@
+import assert from 'node:assert/strict';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { createServer } from 'vite';
+
+import {
+  findMarkersNearClickedMarker,
+  MARKER_PROXIMITY_RADIUS_PIXELS,
+} from './markerProximitySelection.js';
+import { getInitialMapToolsState } from './useMapToolsState.js';
+
+assert.equal(getInitialMapToolsState().clusterMarkersEnabled, false);
+assert.equal(MARKER_PROXIMITY_RADIUS_PIXELS, 18);
+
+const clicked = { id: 'clicked', lat: 1, lon: 1 };
+const equallyNearFirst = { id: 'equally-near-first', lat: 2, lon: 2 };
+const equallyNearSecond = { id: 'equally-near-second', lat: 3, lon: 3 };
+const boundary = { id: 'boundary', lat: 4, lon: 4 };
+const outsideCircle = { id: 'outside-circle', lat: 5, lon: 5 };
+const filteredOut = { id: 'filtered-out', lat: 6, lon: 6 };
+const projectedPoints = new Map([
+  [clicked, { x: 100, y: 100 }],
+  [equallyNearFirst, { x: 106, y: 108 }],
+  [equallyNearSecond, { x: 94, y: 92 }],
+  [boundary, { x: 118, y: 100 }],
+  [outsideCircle, { x: 113, y: 113 }],
+  [filteredOut, { x: 101, y: 101 }],
+]);
+
+const visibleMarkers = [
+  equallyNearFirst,
+  boundary,
+  clicked,
+  outsideCircle,
+  equallyNearSecond,
+];
+const nearby = findMarkersNearClickedMarker(
+  visibleMarkers,
+  clicked,
+  (marker) => projectedPoints.get(marker),
+);
+
+assert.deepEqual(
+  nearby.map((marker) => marker.id),
+  ['clicked', 'equally-near-first', 'equally-near-second', 'boundary'],
+);
+assert.equal(nearby.includes(outsideCircle), false);
+assert.equal(nearby.includes(filteredOut), false);
+assert.deepEqual(
+  findMarkersNearClickedMarker(
+    [clicked],
+    clicked,
+    (marker) => projectedPoints.get(marker),
+  ),
+  [clicked],
+);
+
+const vite = await createServer({
+  appType: 'custom',
+  optimizeDeps: { noDiscovery: true },
+  server: { middlewareMode: true },
+});
+try {
+  const { MarkerDetailsPanel } = await vite.ssrLoadModule(
+    '/src/components/MarkerDetailsPanel.jsx',
+  );
+  const markup = renderToStaticMarkup(React.createElement(
+    MarkerDetailsPanel,
+    {
+      marker: clicked,
+      markers: [clicked, equallyNearFirst],
+      leftOffset: 420,
+      isCollapsed: false,
+      onToggleCollapse() {},
+      onClose() {},
+    },
+  ));
+
+  assert.match(markup, /Markers near this location/);
+  assert.match(markup, /Marker 1 \(selected\)/);
+  assert.match(markup, /Marker 2/);
+
+  const singleMarkup = renderToStaticMarkup(React.createElement(
+    MarkerDetailsPanel,
+    {
+      marker: clicked,
+      markers: [clicked],
+      leftOffset: 420,
+      isCollapsed: false,
+      onToggleCollapse() {},
+      onClose() {},
+    },
+  ));
+
+  assert.match(singleMarkup, />Point</);
+  assert.doesNotMatch(singleMarkup, /Markers near this location/);
+} finally {
+  await vite.close();
+}
+
+console.log('Marker proximity-selection smoke test passed.');

--- a/src/components/useExampleCsvFilesFromUrl.js
+++ b/src/components/useExampleCsvFilesFromUrl.js
@@ -15,10 +15,9 @@ export function useExampleCsvFilesFromUrl({
    * Behavior:
    * - If one or more valid ?example=*.csv values are present:
    *   - The files are auto-loaded from /public/examples
-   *   - Marker clustering is enabled by default to reduce visual noise
    * - Otherwise:
    *   - No file is auto-loaded
-   *   - Clustering remains off by default
+   * - Marker clustering keeps the shared Map tools default in either case
    *
    * This is intended for the live demo and shareable links.
    */

--- a/src/components/useMapToolsState.js
+++ b/src/components/useMapToolsState.js
@@ -2,9 +2,10 @@ import { useMemo, useState } from "react";
 
 const DEFAULT_CLUSTER_RADIUS = 80;
 
-function getInitialState() {
+/** Create the shared, non-persisted default state used by every runtime mode. */
+export function getInitialMapToolsState() {
   return {
-    clusterMarkersEnabled: true,
+    clusterMarkersEnabled: false,
     clusterRadius: DEFAULT_CLUSTER_RADIUS,
     clusterRadiusDraft: DEFAULT_CLUSTER_RADIUS,
   };
@@ -12,7 +13,7 @@ function getInitialState() {
 
 export function useMapToolsState() {
   // Initialize ONCE on first render (no persistence)
-  const initial = useMemo(() => getInitialState(), []);
+  const initial = useMemo(() => getInitialMapToolsState(), []);
   const [state, setState] = useState(initial);
 
   function patch(partial) {


### PR DESCRIPTION
## Summary

- Disable marker clustering by default across all runtime modes and example imports.
- Add 18-pixel circular proximity selection when clustering is disabled.
- Center proximity selection and the yellow selection ring on the clicked marker’s map anchor.
- Show multiple nearby markers together in the Marker details panel, with the clicked marker first and remaining markers ordered by distance.
- Preserve existing clustering, expansion, and spiderfying behavior when clustering is enabled.
- Add focused smoke coverage for proximity matching and single/multiple marker details.

## Validation

- Manually verified clustering defaults, proximity selection, marker ordering, filtering, selection-ring placement, and existing clustering behavior.
- `npm run smoke:marker-proximity`
- `npm run smoke:browser-sqlite`
- `npm run lint`
- `npm run build`
- `npm run build:desktop`
- `git diff --check`

Closes #117
