### PR TITLE
Improve marker details layout and collapsed controls

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -135,16 +135,10 @@
   box-sizing: border-box;
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-end;
   gap: 12px;
   border-bottom: 1px solid rgba(255, 255, 255, 0.08);
   background: rgba(255, 255, 255, 0.03);
-}
-
-.markerDetailsPanelTitle {
-  font-size: 14px;
-  font-weight: 700;
-  letter-spacing: 0.2px;
 }
 
 .markerDetailsPanelHeaderActions {
@@ -171,32 +165,87 @@
   background: rgba(255, 255, 255, 0.08);
 }
 
-.markerDetailsPanelExpand {
+.markerDetailsPanelCollapsedClose {
   position: absolute;
-  top: 50%;
-  left: 0;
-  transform: translateY(-50%);
-  width: 34px;
-  height: 64px;
-  padding: 0;
-  border-radius: 0 12px 12px 0;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  background: rgba(15, 23, 42, 0.95);
-  color: #e2e8f0;
-  cursor: pointer;
-  font-size: 18px;
-  font-weight: 800;
+  /* Match the expanded header controls while the CSV handle stays centered. */
+  top: 8px;
+  left: 1px;
+  z-index: 1;
+  border-radius: 8px;
 }
 
-.markerDetailsPanelExpand:hover {
-  background: rgba(15, 23, 42, 1);
+/* The blank rail expands the panel without competing visually with Close. */
+.markerDetailsPanelExpandRail {
+  position: absolute;
+  top: 48px;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+}
+
+.markerDetailsPanelExpandRail:hover {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.markerDetailsPanelExpandRail:focus-visible {
+  outline: 2px solid rgba(226, 232, 240, 0.9);
+  outline-offset: -2px;
 }
 
 .markerDetailsPanelContent {
   flex: 1;
   min-height: 0;
+  display: flex;
+  flex-direction: column;
   overflow: auto;
   padding: 12px;
+}
+
+/* Flex display rules must not override the panel's collapsed hidden state. */
+.markerDetailsPanelHeader[hidden],
+.markerDetailsPanelContent[hidden] {
+  display: none;
+}
+
+.groupedMarkerDetails {
+  flex: 1;
+  min-height: 0;
+  width: 100%;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  overflow-wrap: anywhere;
+}
+
+.groupedMarkerDetailsHeading {
+  font-weight: 700;
+  margin-bottom: 6px;
+}
+
+.groupedMarkerShowMore {
+  margin-top: 2px;
+}
+
+.groupedMarkerRowsSection,
+.groupedMarkerRowsList {
+  min-height: 0;
+}
+
+/* Give represented rows the remaining panel height and keep scrolling local. */
+.groupedMarkerRowsSection {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.groupedMarkerRowsList {
+  flex: 1;
+  overflow-y: auto;
 }
 
 /* Right-edge drag target for changing the marker panel width. */

--- a/src/components/MarkerDetails.jsx
+++ b/src/components/MarkerDetails.jsx
@@ -257,8 +257,10 @@ export function GroupedMarkerDetails({ point, getGroupRows, isActive }) {
     : 'Grouped markers';
 
   return (
-    <div style={{ minWidth: 280, maxWidth: 420 }}>
-      <div style={{ fontWeight: 700, marginBottom: 6 }}>{title}</div>
+    <div className='groupedMarkerDetails'>
+      <div className='groupedMarkerDetailsHeading'>
+        {title}
+      </div>
       <div>
         <b>count:</b> {point.count ?? 1}
       </div>
@@ -271,6 +273,7 @@ export function GroupedMarkerDetails({ point, getGroupRows, isActive }) {
 
       {canLoadGroupRows && (
         <div
+          className='groupedMarkerRowsSection'
           style={{
             borderTop: '1px solid rgba(0, 0, 0, 0.15)',
             marginTop: 8,
@@ -294,9 +297,8 @@ export function GroupedMarkerDetails({ point, getGroupRows, isActive }) {
                 {pagingState.totalRows ?? pagingState.rows.length} rows
               </div>
               <div
+                className='groupedMarkerRowsList'
                 style={{
-                  maxHeight: 260,
-                  overflowY: 'auto',
                   paddingRight: 4,
                 }}
               >
@@ -317,23 +319,24 @@ export function GroupedMarkerDetails({ point, getGroupRows, isActive }) {
                     </div>
                   </details>
                 ))}
+                {/* Keep paging after loaded rows so it scrolls with the list. */}
+                {canShowMore && (
+                  <button
+                    type='button'
+                    className='groupedMarkerShowMore'
+                    onClick={handleShowMore}
+                    disabled={pagingState.status === 'loading-more'}
+                  >
+                    {pagingState.status === 'loading-more'
+                      ? 'Loading...'
+                      : 'Show 30 more'}
+                  </button>
+                )}
               </div>
             </>
           )}
           {pagingState.rows.length > 0 && pagingState.error && (
             <div style={{ marginTop: 6 }}>{pagingState.error}</div>
-          )}
-          {canShowMore && (
-            <button
-              type='button'
-              onClick={handleShowMore}
-              disabled={pagingState.status === 'loading-more'}
-              style={{ marginTop: 8 }}
-            >
-              {pagingState.status === 'loading-more'
-                ? 'Loading...'
-                : 'Show 30 more'}
-            </button>
           )}
         </div>
       )}

--- a/src/components/MarkerDetailsPanel.jsx
+++ b/src/components/MarkerDetailsPanel.jsx
@@ -83,19 +83,27 @@ export function MarkerDetailsPanel({
       }}
       aria-label='Marker details'
     >
+      {/* Keep Close visible while the remaining collapsed rail expands. */}
       <button
         type='button'
-        className='markerDetailsPanelExpand'
-        onClick={onToggleCollapse}
-        aria-label='Expand marker details'
-        title='Expand'
+        className='markerDetailsPanelClose markerDetailsPanelCollapsedClose'
+        onClick={onClose}
+        aria-label='Close marker details'
+        title='Close'
         hidden={!isCollapsed}
       >
-        &gt;
+        &times;
       </button>
+      <button
+        type='button'
+        className='markerDetailsPanelExpandRail'
+        onClick={onToggleCollapse}
+        aria-label='Expand marker details'
+        title='Expand marker details'
+        hidden={!isCollapsed}
+      />
 
       <div className='markerDetailsPanelHeader' hidden={isCollapsed}>
-        <div className='markerDetailsPanelTitle'>Marker details</div>
         <div className='markerDetailsPanelHeaderActions'>
           <button
             type='button'

--- a/src/components/markerProximitySelection.smoke.js
+++ b/src/components/markerProximitySelection.smoke.js
@@ -94,6 +94,64 @@ try {
 
   assert.match(singleMarkup, />Point</);
   assert.doesNotMatch(singleMarkup, /Markers near this location/);
+  assert.match(singleMarkup, /aria-label="Marker details"/);
+  assert.doesNotMatch(singleMarkup, />Marker details</);
+
+  for (const renderType of ['grouped', 'representative']) {
+    const groupedMarkup = renderToStaticMarkup(React.createElement(
+      MarkerDetailsPanel,
+      {
+        marker: {
+          ...clicked,
+          renderType,
+          count: 2,
+          groupRef: { queryId: 'group-query' },
+        },
+        markers: [],
+        leftOffset: 420,
+        getGroupRows() {},
+        isCollapsed: false,
+        onToggleCollapse() {},
+        onClose() {},
+      },
+    ));
+
+    assert.match(groupedMarkup, /class="groupedMarkerDetails"/);
+    assert.match(groupedMarkup, /class="groupedMarkerDetailsHeading"/);
+    assert.match(groupedMarkup, /class="groupedMarkerRowsSection"/);
+    assert.doesNotMatch(groupedMarkup, /class="groupedMarkerShowMore"/);
+    assert.doesNotMatch(groupedMarkup, /max-width:420px/);
+  }
+
+  const collapsedMarkup = renderToStaticMarkup(React.createElement(
+    MarkerDetailsPanel,
+    {
+      marker: clicked,
+      markers: [clicked],
+      leftOffset: 420,
+      isCollapsed: true,
+      onToggleCollapse() {},
+      onClose() {},
+    },
+  ));
+
+  assert.match(
+    collapsedMarkup,
+    /class="markerDetailsPanelClose markerDetailsPanelCollapsedClose"/,
+  );
+  assert.match(
+    collapsedMarkup,
+    /class="markerDetailsPanelExpandRail"[^>]*aria-label="Expand marker details"/,
+  );
+  assert.doesNotMatch(collapsedMarkup, /&gt;/);
+  assert.match(
+    collapsedMarkup,
+    /class="markerDetailsPanelHeader" hidden=""/,
+  );
+  assert.match(
+    collapsedMarkup,
+    /class="markerDetailsPanelContent" hidden=""/,
+  );
 } finally {
   await vite.close();
 }


### PR DESCRIPTION
## Summary

- Allow grouped and representative marker details to use the full available panel width.
- Wrap long field values within the available content area.
- Let grouped-row content use the remaining vertical panel space.
- Place “Show 30 more” after the currently loaded rows when additional rows are available.
- Keep the CSV panel handle vertically centered.
- Prevent CSV and Marker details controls from overlapping.
- Add a collapsed-state Close control and an accessible expand rail.
- Remove the visible Marker details header title.
- Add focused smoke-test coverage for the updated layout states.

## Testing

- `npm run smoke:marker-proximity`
- `npm run lint`
- `npm run build`
- Manual browser and desktop layout verification

Closes #118
