### PR TITLE
Improve timeline range selection and slider controls

### DIFF
--- a/desktop/csvImportService.cjs
+++ b/desktop/csvImportService.cjs
@@ -41,6 +41,10 @@ function importCsvFileToSqlite({ db, filePath }) {
   const csvText = fs.readFileSync(filePath, "utf8");
   const parsed = parseCsvText(csvText);
   const detectedFields = detectFields(parsed.headers);
+  const recommendedTimelineRange = getRecommendedTimelineRange(
+    parsed.rows,
+    detectedFields,
+  );
   const datasetId = randomUUID();
 
   const importRows = buildImportRows({
@@ -60,11 +64,29 @@ function importCsvFileToSqlite({ db, filePath }) {
     columns: parsed.headers,
     detectedFields,
     parseErrors: parsed.parseErrors,
+    recommendedTimelineRange,
   };
 
   insertImportResult(db, summary, importRows.features);
 
   return summary;
+}
+
+/** Calculate the immutable per-file recommendation from all parsed feature rows. */
+function getRecommendedTimelineRange(rows, detectedFields) {
+  let startYear = null;
+  let endYear = null;
+
+  for (const row of rows) {
+    const extent = getRowTimelineExtent(row, detectedFields);
+    if (!extent) continue;
+    const first = Math.min(extent.startYear, extent.endYear);
+    const last = Math.max(extent.startYear, extent.endYear);
+    startYear = startYear == null ? first : Math.min(startYear, first);
+    endYear = endYear == null ? last : Math.max(endYear, last);
+  }
+
+  return startYear == null || endYear == null ? null : { startYear, endYear };
 }
 
 /**
@@ -278,9 +300,11 @@ function insertImportResult(db, summary, features) {
       imported_feature_count,
       skipped_row_count,
       columns_json,
+      recommended_timeline_start_year,
+      recommended_timeline_end_year,
       imported_at
     )
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `);
 
   const insertFeature = db.prepare(`
@@ -307,6 +331,8 @@ function insertImportResult(db, summary, features) {
       summary.importedFeatureCount,
       summary.skippedRowCount,
       JSON.stringify(summary.columns),
+      summary.recommendedTimelineRange?.startYear ?? null,
+      summary.recommendedTimelineRange?.endYear ?? null,
       new Date().toISOString(),
     );
 

--- a/desktop/csvImportService.smoke.cjs
+++ b/desktop/csvImportService.smoke.cjs
@@ -22,7 +22,7 @@ function verifyMixedBatchImport() {
   const firstPath = path.join(tempDir, "first.csv");
   const secondPath = path.join(tempDir, "second.csv");
   const missingPath = path.join(tempDir, "missing.csv");
-  fs.writeFileSync(firstPath, "lat,lon,name\n1,2,one\n3,4,two\n", "utf8");
+  fs.writeFileSync(firstPath, "lat,lon,name,year\n1,2,one,900\n3,4,two,1200\n", "utf8");
   fs.writeFileSync(secondPath, "lat,lon,name\n5,6,three\nbad,7,skip\n", "utf8");
 
   const db = openSqliteStore(path.join(tempDir, "mixed.sqlite"));
@@ -57,7 +57,18 @@ function verifyMixedBatchImport() {
       { state: "completed", fileName: "second.csv", fileNumber: 3, totalFiles: 3, ok: true },
     ]);
     assert.equal(JSON.stringify(progressEvents).includes(tempDir), false);
-    assert.equal(getSqliteDatasetSummary({ db }).datasets.length, 2);
+    const datasets = getSqliteDatasetSummary({ db }).datasets;
+    assert.equal(datasets.length, 2);
+    assert.deepEqual(
+      datasets.find((dataset) => dataset.name === "first.csv")
+        ?.recommendedTimelineRange,
+      { startYear: 900, endYear: 1200 },
+    );
+    assert.equal(
+      datasets.find((dataset) => dataset.name === "second.csv")
+        ?.recommendedTimelineRange,
+      null,
+    );
     assert.equal(db.prepare("SELECT COUNT(*) AS count FROM features").get().count, 3);
   } finally {
     closeSqliteStore(db);

--- a/desktop/sqliteDatasetService.cjs
+++ b/desktop/sqliteDatasetService.cjs
@@ -15,6 +15,8 @@ function getSqliteDatasetSummary({ db } = {}) {
       skipped_row_count,
       columns_json,
       enabled,
+      recommended_timeline_start_year,
+      recommended_timeline_end_year,
       imported_at
     FROM datasets
     ORDER BY imported_at DESC, id ASC
@@ -75,7 +77,23 @@ function toDatasetSummaryItem(row) {
     totalRows: normalizeCount(row.row_count),
     importedFeatureCount: normalizeCount(row.imported_feature_count),
     skippedRowCount: normalizeCount(row.skipped_row_count),
+    recommendedTimelineRange: normalizeRecommendedTimelineRange(
+      row.recommended_timeline_start_year,
+      row.recommended_timeline_end_year,
+    ),
     importedAt: String(row.imported_at),
+  };
+}
+
+/** Return a complete ordered recommendation, or an explicit null absence. */
+function normalizeRecommendedTimelineRange(startValue, endValue) {
+  if (startValue == null || endValue == null) return null;
+  const startYear = Number(startValue);
+  const endYear = Number(endValue);
+  if (!Number.isFinite(startYear) || !Number.isFinite(endYear)) return null;
+  return {
+    startYear: Math.min(Math.trunc(startYear), Math.trunc(endYear)),
+    endYear: Math.max(Math.trunc(startYear), Math.trunc(endYear)),
   };
 }
 

--- a/desktop/sqliteDatasetService.smoke.cjs
+++ b/desktop/sqliteDatasetService.smoke.cjs
@@ -28,6 +28,8 @@ try {
     skippedRowCount: 2,
     columnsJson: JSON.stringify(["name", "lat", "lon"]),
     enabled: 0,
+    recommendedTimelineStartYear: 900,
+    recommendedTimelineEndYear: 1200,
     importedAt: "2026-01-01T00:00:00.000Z",
   });
 
@@ -41,6 +43,7 @@ try {
       totalRows: 8,
       importedFeatureCount: 6,
       skippedRowCount: 2,
+      recommendedTimelineRange: { startYear: 900, endYear: 1200 },
       importedAt: "2026-01-01T00:00:00.000Z",
     },
   ]);
@@ -53,6 +56,8 @@ try {
     skippedRowCount: 0,
     columnsJson: "not-json",
     enabled: 1,
+    recommendedTimelineStartYear: null,
+    recommendedTimelineEndYear: null,
     importedAt: "2026-02-01T00:00:00.000Z",
   });
   insertDataset({
@@ -63,6 +68,8 @@ try {
     skippedRowCount: 0,
     columnsJson: JSON.stringify(["lat", 42, "lon"]),
     enabled: 1,
+    recommendedTimelineStartYear: null,
+    recommendedTimelineEndYear: null,
     importedAt: "2026-02-01T00:00:00.000Z",
   });
 
@@ -182,6 +189,8 @@ function insertDataset({
   skippedRowCount,
   columnsJson,
   enabled,
+  recommendedTimelineStartYear,
+  recommendedTimelineEndYear,
   importedAt,
 }) {
   db.prepare(`
@@ -193,8 +202,10 @@ function insertDataset({
       skipped_row_count,
       columns_json,
       enabled,
+      recommended_timeline_start_year,
+      recommended_timeline_end_year,
       imported_at
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `).run(
     id,
     fileName,
@@ -203,6 +214,8 @@ function insertDataset({
     skippedRowCount,
     columnsJson,
     enabled,
+    recommendedTimelineStartYear,
+    recommendedTimelineEndYear,
     importedAt,
   );
 }

--- a/desktop/sqliteStore.cjs
+++ b/desktop/sqliteStore.cjs
@@ -33,6 +33,8 @@ function initializeSchema(db) {
       skipped_row_count INTEGER NOT NULL DEFAULT 0,
       columns_json TEXT NOT NULL DEFAULT '[]',
       enabled INTEGER NOT NULL DEFAULT 1 CHECK (enabled IN (0, 1)),
+      recommended_timeline_start_year INTEGER,
+      recommended_timeline_end_year INTEGER,
       imported_at TEXT NOT NULL
     );
 
@@ -63,6 +65,7 @@ function initializeSchema(db) {
   `);
 
   ensureDatasetEnabledColumn(db);
+  ensureDatasetRecommendedTimelineColumns(db);
 }
 
 /**
@@ -79,6 +82,19 @@ function ensureDatasetEnabledColumn(db) {
     ALTER TABLE datasets
     ADD COLUMN enabled INTEGER NOT NULL DEFAULT 1 CHECK (enabled IN (0, 1));
   `);
+}
+
+/** Add import-time recommendation columns to databases created by older builds. */
+function ensureDatasetRecommendedTimelineColumns(db) {
+  const columns = db.pragma("table_info(datasets)");
+  const names = new Set(columns.map((column) => column.name));
+
+  if (!names.has("recommended_timeline_start_year")) {
+    db.exec("ALTER TABLE datasets ADD COLUMN recommended_timeline_start_year INTEGER;");
+  }
+  if (!names.has("recommended_timeline_end_year")) {
+    db.exec("ALTER TABLE datasets ADD COLUMN recommended_timeline_end_year INTEGER;");
+  }
 }
 
 /**

--- a/desktop/sqliteStore.smoke.cjs
+++ b/desktop/sqliteStore.smoke.cjs
@@ -30,6 +30,7 @@ function verifyNewDatabase() {
     assert.ok(enabledColumn);
     assert.equal(Number(enabledColumn.notnull), 1);
     assert.equal(String(enabledColumn.dflt_value), "1");
+    assert.equal(countRecommendedTimelineColumns(db), 2);
 
     insertDataset(db, "new-dataset");
     assert.equal(getDatasetEnabled(db, "new-dataset"), 1);
@@ -64,10 +65,12 @@ function verifyLegacyDatabaseMigration() {
 
     assert.equal(countEnabledColumns(db), 1);
     assert.equal(getDatasetEnabled(db, "legacy-dataset"), 1);
+    assert.equal(countRecommendedTimelineColumns(db), 2);
 
     initializeSchema(db);
     assert.equal(countEnabledColumns(db), 1);
     assert.equal(getDatasetEnabled(db, "legacy-dataset"), 1);
+    assert.equal(countRecommendedTimelineColumns(db), 2);
   } finally {
     closeSqliteStore(db);
   }
@@ -95,6 +98,12 @@ function getEnabledColumn(db) {
 function countEnabledColumns(db) {
   return db.pragma("table_info(datasets)")
     .filter((column) => column.name === "enabled")
+    .length;
+}
+
+function countRecommendedTimelineColumns(db) {
+  return db.pragma("table_info(datasets)")
+    .filter((column) => column.name.startsWith("recommended_timeline_"))
     .length;
 }
 

--- a/src/App.css
+++ b/src/App.css
@@ -368,6 +368,53 @@ button.csvBtnPrimary.csvDesktopImportButton {
   background: rgba(56, 189, 248, 0.18);
 }
 
+/* Fixed timeline popovers escape the scrollable CSV list and remain single-line. */
+.csvTimelineHoverMessage {
+  position: fixed;
+  z-index: 2100;
+  width: max-content;
+  max-width: none;
+  padding: 6px 8px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 7px;
+  background: rgba(15, 23, 42, 0.98);
+  color: #e2e8f0;
+  box-shadow: 0 5px 16px rgba(0, 0, 0, 0.35);
+  font-size: 12px;
+  line-height: 1.3;
+  white-space: nowrap;
+  pointer-events: none;
+}
+
+.csvTimelineContextMenu {
+  position: fixed;
+  z-index: 2200;
+  min-width: 240px;
+  padding: 4px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 8px;
+  background: rgba(15, 23, 42, 0.99);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
+}
+
+.csvTimelineContextMenu button {
+  width: 100%;
+  padding: 7px 9px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: #e2e8f0;
+  text-align: left;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.csvTimelineContextMenu button:hover,
+.csvTimelineContextMenu button:focus-visible {
+  background: rgba(56, 189, 248, 0.18);
+  outline: none;
+}
+
 .csvFileNameButton {
   background: none;
   border: none;
@@ -756,4 +803,89 @@ button.csvBtnPrimary.csvDesktopImportButton {
   margin-top: 10px;
   padding-top: 10px;
   border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+/* Percentage-positioned slider visuals do not depend on mount-time width. */
+.dualRangeSlider {
+  position: relative;
+  width: 100%;
+  height: 66px;
+  touch-action: none;
+  user-select: none;
+}
+
+.dualRangeSliderDisabled {
+  opacity: 0.6;
+}
+
+.dualRangeTrack,
+.dualRangeSelection {
+  position: absolute;
+  top: 31px;
+  height: 4px;
+  border-radius: 2px;
+}
+
+.dualRangeTrack {
+  left: 0;
+  width: 100%;
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.dualRangeSelection {
+  z-index: 1;
+  min-width: 0;
+  background: rgba(56, 189, 248, 0.95);
+  cursor: grab;
+}
+
+.dualRangeSliderDisabled .dualRangeSelection,
+.dualRangeSliderDisabled .dualRangeHandle {
+  cursor: default;
+}
+
+.dualRangeHandle {
+  position: absolute;
+  z-index: 2;
+  width: 24px;
+  height: 22px;
+  transform: translateX(-50%);
+  border-radius: 5px;
+  background: rgb(56, 189, 248);
+  cursor: grab;
+}
+
+.dualRangeHandleStart {
+  top: 4px;
+}
+
+.dualRangeHandleEnd {
+  top: 40px;
+}
+
+/* Opposing tips meet the track while their draggable bodies never overlap. */
+.dualRangeHandleStart::after,
+.dualRangeHandleEnd::before {
+  position: absolute;
+  left: 6px;
+  width: 0;
+  height: 0;
+  content: "";
+  border-right: 6px solid transparent;
+  border-left: 6px solid transparent;
+}
+
+.dualRangeHandleStart::after {
+  top: 100%;
+  border-top: 7px solid rgb(56, 189, 248);
+}
+
+.dualRangeHandleEnd::before {
+  bottom: 100%;
+  border-bottom: 7px solid rgb(56, 189, 248);
+}
+
+.dualRangeUnavailable {
+  font-size: 12px;
+  opacity: 0.8;
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -28,7 +28,6 @@ export default function App() {
   const {
     state: timelineState,
     patch: patchTimeline,
-    setYearRange,
   } = useTimelineFilterState();
   const mapToolsApi = useMapToolsState();
   const timelinePlaybackApi = useTimelinePlayback({
@@ -610,10 +609,8 @@ export default function App() {
       .map((dataset) => dataset.id),
     [desktopDatasetState.datasets],
   );
-  const databaseTimelineAvailable = !!desktopDatasetState.timeline;
   const databaseTimelineQuery = useMemo(() => ({
-    timelineEnabled:
-      databaseTimelineAvailable && !!timelineState.timelineEnabled,
+    timelineEnabled: !!timelineState.timelineEnabled,
     startYear: timelineState.startYear ?? null,
     endYear: timelineState.endYear ?? null,
     yearMin: timelineState.yearMin ?? null,
@@ -622,7 +619,6 @@ export default function App() {
     startDay: timelineState.startDay ?? null,
     endDay: timelineState.endDay ?? null,
   }), [
-    databaseTimelineAvailable,
     timelineState.dayFilterEnabled,
     timelineState.endDay,
     timelineState.endYear,
@@ -735,42 +731,6 @@ export default function App() {
     dayOfYearField: databaseSelected?.detectedFields?.dayOfYearField ?? null,
   }), [databaseSelected?.detectedFields]);
 
-  // SQLite exposes only a compact enabled-dataset timeline extent; React must
-  // not load all source rows merely to initialize the year controls.
-  useEffect(() => {
-    if (!usesViewportQueries || !timelineState.timelineEnabled) return;
-    if (timelineState.yearDomainMode === "manual") return;
-    const min = desktopDatasetState.timeline?.yearMin ?? null;
-    const max = desktopDatasetState.timeline?.yearMax ?? null;
-    patchTimeline({
-      yearMin: min,
-      yearMax: max,
-      yearMinDraft: String(min ?? ""),
-      yearMaxDraft: String(max ?? ""),
-    });
-    if (min == null || max == null) return;
-    const nextStart = timelineState.startYear == null
-      ? min
-      : Math.max(min, Math.min(max, timelineState.startYear));
-    const nextEnd = timelineState.endYear == null
-      ? max
-      : Math.max(min, Math.min(max, timelineState.endYear));
-    const start = Math.min(nextStart, nextEnd);
-    const end = Math.max(nextStart, nextEnd);
-    if (start !== timelineState.startYear || end !== timelineState.endYear) {
-      setYearRange(start, end);
-    }
-  }, [
-    desktopDatasetState.timeline,
-    patchTimeline,
-    setYearRange,
-    timelineState.endYear,
-    timelineState.startYear,
-    timelineState.timelineEnabled,
-    timelineState.yearDomainMode,
-    usesViewportQueries,
-  ]);
-
   return (
     <div
       className="appRoot"
@@ -827,7 +787,6 @@ export default function App() {
             initialization={initialization ?? { ok: false }}
             mappingState={databaseMappingState}
             timelineState={timelineState}
-            timelineAvailable={databaseTimelineAvailable}
             timelineFields={timelineFields}
             onTimelinePatch={patchTimeline}
             onTimelinePlaybackStart={timelinePlaybackApi.startPlayback}

--- a/src/components/CsvPanel.jsx
+++ b/src/components/CsvPanel.jsx
@@ -37,7 +37,6 @@ export default function CsvPanel({
   onUpdateMapping,  // Callback when user changes latitude/longitude fields
 
   timelineState,
-  timelineAvailable = true,
   timelineFields,
   onTimelinePatch,
   onTimelinePlaybackStart,
@@ -83,7 +82,7 @@ export default function CsvPanel({
     const nextEnd = Math.max(nextStartRaw, nextEndRaw);
 
     patchTimelineWithStop({
-      // lock the domain so auto-detection does not overwrite it
+      // Record that this range came from an explicit manual action.
       yearDomainMode: "manual",
 
       yearMin: lo,
@@ -98,6 +97,19 @@ export default function CsvPanel({
   const canBeginYearDomain =
     toIntOrNull(yearMinDraft) != null && toIntOrNull(yearMaxDraft) != null;
 
+  /** Apply one stored CSV recommendation without changing Timeline's enabled state. */
+  function useRecommendedTimelineRange(range) {
+    if (!range) return;
+    patchTimelineWithStop({
+      yearDomainMode: "manual",
+      yearMin: range.startYear,
+      yearMax: range.endYear,
+      yearMinDraft: String(range.startYear),
+      yearMaxDraft: String(range.endYear),
+      startYear: range.startYear,
+      endYear: range.endYear,
+    });
+  }
 
   function patchTimelineWithStop(partial) {
     // Stop first, so timer is cleared.
@@ -134,7 +146,6 @@ export default function CsvPanel({
         ========================= */}
       <MapToolsMenu
         timelineState={timelineState}
-        timelineAvailable={timelineAvailable}
         onTimelinePatch={onTimelinePatch}
         mapToolsState={mapToolsState}
         onMapToolsPatch={onMapToolsPatch}
@@ -163,10 +174,11 @@ export default function CsvPanel({
             onUnloadFile={onUnloadFile}
             removeActionLabel={removeActionLabel}
             onToggleEnabled={onToggleEnabled}
+            onUseRecommendedTimelineRange={useRecommendedTimelineRange}
           />
 
           {/* Timeline UI lives inside the panel header (NOT in the dropdown). */}
-          {timelineAvailable && timelineState?.timelineEnabled && (
+          {timelineState?.timelineEnabled && (
             <div className="csvTimelineBlock" aria-label="Timeline filter">
               <div className="csvTimelineTitleRow">
                 <div className="csvTimelineTitle">Timeline filter</div>

--- a/src/components/DualRangeSlider.jsx
+++ b/src/components/DualRangeSlider.jsx
@@ -1,46 +1,9 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
-
-// TODO(refactor / tech-debt):
-// This slider is currently stable and works correctly across several tricky UI scenarios
-// (collapse/expand, hidden mount, ResizeObserver, and layout timing issues).
-//
-// However, the implementation has accumulated some technical debt, including:
-// - Mixed usage of measuredWidth state and direct DOM reads (getBoundingClientRect)
-// - Global pointer event listeners being attached on every render
-// - Complex layout timing dependencies (requestAnimationFrame + ResizeObserver)
-// - Fragile coupling to visibility / mount timing
-//
-// IMPORTANT:
-// Do NOT refactor or "simplify" this component without testing:
-// - Collapse / expand of parent panels
-// - Hidden mount -> visible transitions
-// - Multiple instances on screen
-// - Resizing the window and container
-//
-// This code reached its current shape through real bug-fixing, not over-engineering.
-// Any cleanup should be done together with:
-// - Dedicated test cases
-// - Or a full rewrite with a proper layout + interaction model.
+import React, { useMemo, useRef } from "react";
 
 /**
- * DualRangeSlider
- * - Two handles
- * - Draggable middle range
- * - Mouse + touch support
- * - Step (integer)
- *
- * Props:
- * - min, max, step
- * - start, end (controlled)
- * - onChange({ start, end })
- * - disabled
- * - formatValue (optional)
- *
- * High-level behavior:
- * - This is a *controlled* component: it renders using `start`/`end` props
- *   and reports user interactions via `onChange`, but does not store values in state.
- * - Visually, it is a track with a highlighted range segment and two draggable handles.
- * - The highlighted range segment itself can be dragged to move the whole range together.
+ * Render a controlled two-handle range slider with a draggable selected range.
+ * Visual positions use value-derived percentages; layout is read only while
+ * translating active pointer movement back into values.
  */
 export default function DualRangeSlider({
   min,
@@ -52,367 +15,166 @@ export default function DualRangeSlider({
   disabled = false,
   formatValue,
 }) {
-  // Ref to the root slider element. Used to measure pixel width and convert pixels <-> values.
   const sliderRef = useRef(null);
-
-  // measured width stored in React state.
-  // This solves a common UI issue where the slider mounts while hidden/collapsing (width=0),
-  // then becomes visible later without any React state change to trigger a re-render.
-  const [measuredWidth, setMeasuredWidth] = useState(0);
-
-  // Ref to store drag interaction state without re-rendering on every pointer move.
-  // - mode: which part is being dragged ("start" handle, "end" handle, or the "range" bar)
-  // - pointerId: used to ensure we only respond to the active pointer
-  // - startStart/startEnd: slider values at the moment drag began (baseline for dragging)
-  // - startX: pointer X-coordinate at drag start (baseline for range dragging)
   const dragRef = useRef({
-    mode: null, // "start" | "end" | "range"
+    mode: null,
     pointerId: null,
     startStart: 0,
     startEnd: 0,
     startX: 0,
   });
 
-  // domain:
-  // Normalizes `min`/`max` to integers and validates the slider domain.
-  // If invalid (non-numeric) or degenerate (min === max), domain is null and slider can't render.
   const domain = useMemo(() => {
-    const mi = toInt(min);
-    const ma = toInt(max);
-    if (!Number.isFinite(mi) || !Number.isFinite(ma)) return null;
-    if (mi === ma) return null;
-    return { min: mi, max: ma };
+    const normalizedMin = toInt(min);
+    const normalizedMax = toInt(max);
+    if (!Number.isFinite(normalizedMin) || !Number.isFinite(normalizedMax)) {
+      return null;
+    }
+    if (normalizedMin === normalizedMax) return null;
+    return {
+      min: Math.min(normalizedMin, normalizedMax),
+      max: Math.max(normalizedMin, normalizedMax),
+    };
   }, [min, max]);
 
-  // Convert controlled props `start` and `end` to integers for internal calculations.
-  // (If they are invalid strings, toInt returns NaN.)
-  const s = toInt(start);
-  const e = toInt(end);
-
-  // safe:
-  // Produces a sanitized {start, end} pair that is:
-  // - rounded to `step`
-  // - clamped within [min, max]
-  // - ordered so start <= end (swaps if needed)
-  // This is what the UI uses to render.
   const safe = useMemo(() => {
     if (!domain) return { start: 0, end: 0 };
-    const mi = domain.min;
-    const ma = domain.max;
+    let nextStart = clamp(roundStep(toInt(start), step), domain.min, domain.max);
+    let nextEnd = clamp(roundStep(toInt(end), step), domain.min, domain.max);
+    if (nextStart > nextEnd) [nextStart, nextEnd] = [nextEnd, nextStart];
+    return { start: nextStart, end: nextEnd };
+  }, [domain, end, start, step]);
 
-    let a = clamp(roundStep(s, step), mi, ma);
-    let b = clamp(roundStep(e, step), mi, ma);
-
-    // Ensure consistent ordering so the UI doesn't break if props come in reversed.
-    if (a > b) [a, b] = [b, a];
-    return { start: a, end: b };
-  }, [domain, s, e, step]);
-
-  /**
-   * Keep `measuredWidth` in sync with the actual DOM width.
-   * - ResizeObserver triggers when the element becomes visible or changes size.
-   * - requestAnimationFrame ensures we measure after layout is committed.
-   *
-   * This is the key fix for "handles stuck until some other UI causes a re-render".
-   */
-  useEffect(() => {
-    const el = sliderRef.current;
-    if (!el) return;
-
-    function commitMeasure() {
-      const rect = el.getBoundingClientRect();
-      const w = Math.max(0, Math.round(rect.width));
-      setMeasuredWidth((prev) => (prev === w ? prev : w));
-    }
-
-    // Initial measure after mount (after layout)
-    const rafId = requestAnimationFrame(commitMeasure);
-
-    // Observe size changes (covers collapse/expand and responsive layout)
-    let ro = null;
-    if (typeof ResizeObserver !== "undefined") {
-      ro = new ResizeObserver(() => {
-        // Measure on the next frame to avoid reading layout mid-update.
-        requestAnimationFrame(commitMeasure);
-      });
-      ro.observe(el);
-    } else {
-      // Fallback (older browsers): re-measure on window resize
-      window.addEventListener("resize", commitMeasure);
-    }
-
-    return () => {
-      cancelAnimationFrame(rafId);
-      if (ro) ro.disconnect();
-      else window.removeEventListener("resize", commitMeasure);
-    };
-  }, []);
-
-  /**
-   * Convert a value in [domain.min, domain.max] to a pixel offset from the left edge.
-   * Uses measuredWidth state so render never reads from a ref.
-   */
-  function pxFromValue(v) {
-    if (!domain) return 0;
-    if (measuredWidth <= 0) return 0;
-
-    const t = (v - domain.min) / (domain.max - domain.min);
-    return t * measuredWidth;
-  }
-  /**
-   * Convert a pointer clientX coordinate to a value in the slider domain.
-   * - Computes relative x-position inside the slider element
-   * - Converts to a domain value
-   * - Rounds to step and clamps into [min, max]
-   */
+  /** Convert a pointer coordinate to a stepped value using current layout. */
   function valueFromClientX(clientX) {
-    const el = sliderRef.current;
-    if (!el || !domain) return domain?.min ?? 0;
-
-    const rect = el.getBoundingClientRect();
-    const rel = clamp(clientX - rect.left, 0, rect.width); // pixels from left, clamped to slider width
-    const t = rel / rect.width; // normalized [0..1]
-    const raw = domain.min + t * (domain.max - domain.min);
-    return clamp(roundStep(raw, step), domain.min, domain.max);
+    const rect = sliderRef.current?.getBoundingClientRect();
+    if (!rect || !domain || rect.width <= 0) return domain?.min ?? 0;
+    const fraction = clamp((clientX - rect.left) / rect.width, 0, 1);
+    const rawValue = domain.min + fraction * (domain.max - domain.min);
+    return clamp(roundStep(rawValue, step), domain.min, domain.max);
   }
 
-  /**
-   * setNext:
-   * Centralized "commit" function for changes.
-   * - Applies step rounding + clamping + ordering
-   * - Calls `onChange({start, end})` to notify the parent
-   * - Does nothing if disabled or domain invalid
-   */
+  /** Commit one ordered, stepped range to the controlled parent state. */
   function setNext(nextStart, nextEnd) {
-    if (disabled) return;
-    if (!domain) return;
-
-    let a = clamp(roundStep(nextStart, step), domain.min, domain.max);
-    let b = clamp(roundStep(nextEnd, step), domain.min, domain.max);
-
-    if (a > b) [a, b] = [b, a];
-
-    onChange?.({ start: a, end: b });
+    if (disabled || !domain) return;
+    let normalizedStart = clamp(
+      roundStep(nextStart, step),
+      domain.min,
+      domain.max,
+    );
+    let normalizedEnd = clamp(
+      roundStep(nextEnd, step),
+      domain.min,
+      domain.max,
+    );
+    if (normalizedStart > normalizedEnd) {
+      [normalizedStart, normalizedEnd] = [normalizedEnd, normalizedStart];
+    }
+    onChange?.({ start: normalizedStart, end: normalizedEnd });
   }
 
-  /**
-   * onPointerDown:
-   * Starts a drag interaction on either:
-   * - "start" handle
-   * - "end" handle
-   * - "range" bar
-   *
-   * Stores baseline values in dragRef so pointer moves can compute deltas.
-   * Captures pointer to keep receiving events even if the pointer leaves the element.
-   */
-  function onPointerDown(mode, e) {
-    if (disabled) return;
-    if (!domain) return;
-
-    e.preventDefault();
-    e.stopPropagation();
-
-    const el = sliderRef.current;
-    if (!el) return;
-
-    // Pointer capture keeps subsequent pointer events routed to this element.
-    el.setPointerCapture?.(e.pointerId);
-
-    dragRef.current.mode = mode;
-    dragRef.current.pointerId = e.pointerId;
-    dragRef.current.startStart = safe.start;
-    dragRef.current.startEnd = safe.end;
-    dragRef.current.startX = e.clientX;
+  /** Capture one handle or the selected segment for a pointer drag. */
+  function handlePointerDown(mode, event) {
+    if (disabled || !domain) return;
+    event.preventDefault();
+    event.stopPropagation();
+    sliderRef.current?.setPointerCapture?.(event.pointerId);
+    dragRef.current = {
+      mode,
+      pointerId: event.pointerId,
+      startStart: safe.start,
+      startEnd: safe.end,
+      startX: event.clientX,
+    };
   }
 
-  /**
-   * onPointerMove:
-   * Executes while dragging.
-   * Guard rails:
-   * - ignore when disabled or no domain
-   * - ignore if pointerId doesn't match the active drag
-   * - ignore if not currently dragging (no mode)
-   *
-   * Modes:
-   * - "start": move only the start handle
-   * - "end": move only the end handle
-   * - "range": move the whole range while keeping width constant (clamped at edges)
-   */
-  function onPointerMove(e) {
-    if (disabled) return;
-    if (!domain) return;
-    if (dragRef.current.pointerId !== e.pointerId) return;
-    if (!dragRef.current.mode) return;
-
-    const mode = dragRef.current.mode;
-
-    // Dragging the start handle: update start, keep end fixed.
-    if (mode === "start") {
-      const v = valueFromClientX(e.clientX);
-      setNext(v, safe.end);
+  /** Translate active pointer movement according to the captured drag mode. */
+  function handlePointerMove(event) {
+    const drag = dragRef.current;
+    if (disabled || !domain || drag.pointerId !== event.pointerId || !drag.mode) {
       return;
     }
 
-    // Dragging the end handle: update end, keep start fixed.
-    if (mode === "end") {
-      const v = valueFromClientX(e.clientX);
-      setNext(safe.start, v);
+    if (drag.mode === "start") {
+      setNext(valueFromClientX(event.clientX), safe.end);
+      return;
+    }
+    if (drag.mode === "end") {
+      setNext(safe.start, valueFromClientX(event.clientX));
       return;
     }
 
-    // Dragging the range bar: shift both start/end by the same delta.
-    if (mode === "range") {
-      const el = sliderRef.current;
-      if (!el) return;
+    const rect = sliderRef.current?.getBoundingClientRect();
+    if (!rect || rect.width <= 0) return;
+    const delta = ((event.clientX - drag.startX) / rect.width)
+      * (domain.max - domain.min);
+    const rangeWidth = drag.startEnd - drag.startStart;
+    let nextStart = drag.startStart + delta;
+    let nextEnd = nextStart + rangeWidth;
 
-      const rect = el.getBoundingClientRect();
-      const dxPx = e.clientX - dragRef.current.startX; // pixel delta from drag start
-      const dxT = dxPx / rect.width; // normalized delta
-      const dxVal = dxT * (domain.max - domain.min); // delta in value-space
-
-      const width = dragRef.current.startEnd - dragRef.current.startStart; // keep range width constant
-
-      let ns = dragRef.current.startStart + dxVal;
-      let ne = ns + width;
-
-      // Clamp the entire window to stay within domain bounds.
-      if (ns < domain.min) {
-        ns = domain.min;
-        ne = ns + width;
-      }
-      if (ne > domain.max) {
-        ne = domain.max;
-        ns = ne - width;
-      }
-
-      setNext(ns, ne);
-      return;
+    // Clamp both edges together so dragging preserves the selected width.
+    if (nextStart < domain.min) {
+      nextStart = domain.min;
+      nextEnd = nextStart + rangeWidth;
     }
+    if (nextEnd > domain.max) {
+      nextEnd = domain.max;
+      nextStart = nextEnd - rangeWidth;
+    }
+    setNext(nextStart, nextEnd);
   }
 
-  /**
-   * onPointerUp:
-   * Ends the drag interaction by clearing the stored mode and pointer id.
-   */
-  function onPointerUp(e) {
-    if (dragRef.current.pointerId !== e.pointerId) return;
-
+  /** Release the active drag without changing its last committed values. */
+  function finishPointerDrag(event) {
+    if (dragRef.current.pointerId !== event.pointerId) return;
+    sliderRef.current?.releasePointerCapture?.(event.pointerId);
     dragRef.current.mode = null;
     dragRef.current.pointerId = null;
   }
 
-  /**
-   * Global pointer listeners:
-   * Attaches pointermove/pointerup listeners to the window so dragging continues
-   * even if the pointer leaves the slider element.
-   *
-   * Note:
-   * - As written, this effect runs after every render (no dependency array),
-   *   meaning the listeners are re-attached/removed on each render.
-   *   It still works, but is less efficient than binding once.
-   */
-  useEffect(() => {
-    window.addEventListener("pointermove", onPointerMove);
-    window.addEventListener("pointerup", onPointerUp);
-    return () => {
-      window.removeEventListener("pointermove", onPointerMove);
-      window.removeEventListener("pointerup", onPointerUp);
-    };
-  });
-
-  // If domain is invalid/degenerate, render a small placeholder instead of a broken slider.
   if (!domain) {
-    return (
-      <div style={{ opacity: 0.8, fontSize: 12 }}>
-        No range available.
-      </div>
-    );
+    return <div className="dualRangeUnavailable">No range available.</div>;
   }
 
-  // Convert the selected values to pixel offsets for rendering.
-  const startPx = pxFromValue(safe.start);
-  const endPx = pxFromValue(safe.end);
-
-  // Optional display formatting for tooltips.
-  const fmt = (v) => (formatValue ? formatValue(v) : String(v));
+  const startPercent = valueToPercent(safe.start, domain);
+  const endPercent = valueToPercent(safe.end, domain);
+  const format = (value) => formatValue ? formatValue(value) : String(value);
 
   return (
     <div
       ref={sliderRef}
-      style={{
-        position: "relative",
-        height: 40,
-        width: "100%",
-        opacity: disabled ? 0.6 : 1,
-        touchAction: "none", // prevents browser gestures interfering with pointer interactions
-      }}
+      className={`dualRangeSlider${disabled ? " dualRangeSliderDisabled" : ""}`}
       aria-disabled={disabled}
+      onPointerMove={handlePointerMove}
+      onPointerUp={finishPointerDrag}
+      onPointerCancel={finishPointerDrag}
     >
-      {/* track: full background line */}
+      <div className="dualRangeTrack" />
       <div
+        className="dualRangeSelection"
         style={{
-          position: "absolute",
-          top: 18,
-          height: 4,
-          width: "100%",
-          borderRadius: 2,
-          background: "rgba(255,255,255,0.15)",
+          left: `${startPercent}%`,
+          width: `${Math.max(0, endPercent - startPercent)}%`,
         }}
-      />
-
-      {/* range: highlighted selected interval; also draggable as a whole ("range" mode) */}
-      <div
-        onPointerDown={(e) => onPointerDown("range", e)}
-        style={{
-          position: "absolute",
-          top: 18,
-          height: 4,
-          left: startPx,
-          width: Math.max(0, endPx - startPx),
-          borderRadius: 2,
-          background: "rgba(56,189,248,0.95)",
-          cursor: disabled ? "default" : "grab",
-        }}
+        onPointerDown={(event) => handlePointerDown("range", event)}
         role="presentation"
         aria-label="Selected range"
-        title={`${fmt(safe.start)} – ${fmt(safe.end)}`}
+        title={`${format(safe.start)} – ${format(safe.end)}`}
       />
-
-      {/* start handle: draggable knob controlling the start value */}
       <div
-        onPointerDown={(e) => onPointerDown("start", e)}
-        style={{
-          position: "absolute",
-          top: 12,
-          left: startPx,
-          width: 16,
-          height: 16,
-          transform: "translateX(-50%)",
-          borderRadius: "50%",
-          background: "rgba(56,189,248,0.95)",
-          cursor: disabled ? "default" : "pointer",
-        }}
+        className="dualRangeHandle dualRangeHandleStart"
+        style={{ left: `${startPercent}%` }}
+        onPointerDown={(event) => handlePointerDown("start", event)}
         role="slider"
         aria-label="Start"
         aria-valuemin={domain.min}
         aria-valuemax={domain.max}
         aria-valuenow={safe.start}
       />
-
-      {/* end handle: draggable knob controlling the end value */}
       <div
-        onPointerDown={(e) => onPointerDown("end", e)}
-        style={{
-          position: "absolute",
-          top: 12,
-          left: endPx,
-          width: 16,
-          height: 16,
-          transform: "translateX(-50%)",
-          borderRadius: "50%",
-          background: "rgba(56,189,248,0.95)",
-          cursor: disabled ? "default" : "pointer",
-        }}
+        className="dualRangeHandle dualRangeHandleEnd"
+        style={{ left: `${endPercent}%` }}
+        onPointerDown={(event) => handlePointerDown("end", event)}
         role="slider"
         aria-label="End"
         aria-valuemin={domain.min}
@@ -423,32 +185,24 @@ export default function DualRangeSlider({
   );
 }
 
-/**
- * clamp:
- * Restricts n to the inclusive range [min, max].
- */
-function clamp(n, min, max) {
-  return Math.max(min, Math.min(max, n));
+/** Convert a domain value to its horizontal position as a percentage. */
+function valueToPercent(value, domain) {
+  return ((value - domain.min) / (domain.max - domain.min)) * 100;
 }
 
-/**
- * toInt:
- * Parses a value as a base-10 integer.
- * Returns NaN if parsing fails.
- */
-function toInt(v) {
-  const n = Number.parseInt(v, 10);
-  return Number.isFinite(n) ? n : NaN;
+/** Restrict a number to the inclusive range from min through max. */
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value));
 }
 
-/**
- * roundStep:
- * Rounds v to the nearest multiple of `step`.
- * (step defaults to 1 if invalid.)
- */
-function roundStep(v, step) {
-  const s = Number(step) || 1;
-  return Math.round(v / s) * s;
+/** Parse a base-10 integer, returning NaN when the value is invalid. */
+function toInt(value) {
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) ? parsed : NaN;
 }
 
-
+/** Round a value to the nearest configured step, defaulting to step one. */
+function roundStep(value, step) {
+  const normalizedStep = Number(step) || 1;
+  return Math.round(value / normalizedStep) * normalizedStep;
+}

--- a/src/components/csv-panel/CsvFileControls.jsx
+++ b/src/components/csv-panel/CsvFileControls.jsx
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 
 export default function CsvFileControls({
   files,
@@ -11,12 +11,18 @@ export default function CsvFileControls({
   onUnloadFile,
   removeActionLabel = "Unload",
   onToggleEnabled,
+  onUseRecommendedTimelineRange,
 }) {
   /**
    * Hidden file input reference.
    * We trigger this programmatically when user clicks "Import..."
    */
   const fileInputRef = useRef(null);
+  const contextMenuRef = useRef(null);
+  const hoverTimerRef = useRef(null);
+  const pendingHoverRef = useRef(null);
+  const [hoverMessage, setHoverMessage] = useState(null);
+  const [contextMenu, setContextMenu] = useState(null);
   const isDesktopImporting = desktopImport?.status === "importing";
   const desktopSummary = desktopImport?.summary ?? null;
   const desktopProgress = desktopImport?.progress ?? null;
@@ -28,6 +34,76 @@ export default function CsvFileControls({
   const canSelect = typeof onSelect === "function";
   const canToggleEnabled = typeof onToggleEnabled === "function";
   const canRemove = typeof onUnloadFile === "function";
+
+  /** Close the custom recommendation menu on outside interaction or Escape. */
+  useEffect(() => {
+    if (!contextMenu) return undefined;
+
+    function handlePointerDown(event) {
+      if (contextMenuRef.current?.contains(event.target)) return;
+      setContextMenu(null);
+    }
+
+    function handleKeyDown(event) {
+      if (event.key === "Escape") setContextMenu(null);
+    }
+
+    document.addEventListener("pointerdown", handlePointerDown, true);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown, true);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [contextMenu]);
+
+  useEffect(() => () => {
+    globalThis.clearTimeout(hoverTimerRef.current);
+  }, []);
+
+  /** Start one delayed hover without restarting across row child elements. */
+  function handleRowPointerEnter(event, file) {
+    pendingHoverRef.current = {
+      text: formatRecommendedTimelineMessage(file.recommendedTimelineRange),
+      ...getFloatingPosition(event.clientX, event.clientY, 360, 32),
+    };
+    globalThis.clearTimeout(hoverTimerRef.current);
+    hoverTimerRef.current = globalThis.setTimeout(() => {
+      setHoverMessage(pendingHoverRef.current);
+      hoverTimerRef.current = null;
+    }, 1000);
+  }
+
+  /** Keep the message near the pointer while preserving the same hover target. */
+  function handleRowPointerMove(event) {
+    const position = getFloatingPosition(event.clientX, event.clientY, 360, 32);
+    if (pendingHoverRef.current) {
+      pendingHoverRef.current = { ...pendingHoverRef.current, ...position };
+    }
+    setHoverMessage((current) => current
+      ? { ...current, ...position }
+      : null);
+  }
+
+  /** Cancel pending and visible hover UI when the pointer leaves the row. */
+  function clearHoverMessage() {
+    globalThis.clearTimeout(hoverTimerRef.current);
+    hoverTimerRef.current = null;
+    pendingHoverRef.current = null;
+    setHoverMessage(null);
+  }
+
+  /** Open a custom menu only when the imported CSV has a stored recommendation. */
+  function handleRowContextMenu(event, file) {
+    const range = file.recommendedTimelineRange;
+    if (!range) return;
+
+    event.preventDefault();
+    clearHoverMessage();
+    setContextMenu({
+      range,
+      ...getFloatingPosition(event.clientX, event.clientY, 360, 44),
+    });
+  }
 
   /**
    * Trigger the hidden file input.
@@ -189,6 +265,10 @@ export default function CsvFileControls({
                 file.id === selectedId ? " csvFilesRowSelected" : ""
               }`}
               onClick={canSelect ? () => onSelect(file.id) : undefined}
+              onPointerEnter={(event) => handleRowPointerEnter(event, file)}
+              onPointerMove={handleRowPointerMove}
+              onPointerLeave={clearHoverMessage}
+              onContextMenu={(event) => handleRowContextMenu(event, file)}
             >
               <input
                 type="checkbox"
@@ -231,8 +311,60 @@ export default function CsvFileControls({
           ))
         )}
       </div>
+
+      {hoverMessage && (
+        <div
+          className="csvTimelineHoverMessage"
+          style={{ left: hoverMessage.left, top: hoverMessage.top }}
+          role="tooltip"
+        >
+          {hoverMessage.text}
+        </div>
+      )}
+
+      {contextMenu && (
+        <div
+          ref={contextMenuRef}
+          className="csvTimelineContextMenu"
+          style={{ left: contextMenu.left, top: contextMenu.top }}
+          role="menu"
+          aria-label="CSV timeline actions"
+        >
+          <button
+            type="button"
+            role="menuitem"
+            onClick={() => {
+              // Apply all four values together so the slider never sees a mixed range.
+              onUseRecommendedTimelineRange?.(contextMenu.range);
+              setContextMenu(null);
+            }}
+          >
+            Use recommended timeline range: {formatTimelineRange(contextMenu.range)}
+          </button>
+        </div>
+      )}
     </>
   );
+}
+
+function formatRecommendedTimelineMessage(range) {
+  return range
+    ? `Recommended timeline range: ${formatTimelineRange(range)}`
+    : "No timeline available";
+}
+
+function formatTimelineRange(range) {
+  return `${range.startYear}–${range.endYear}`;
+}
+
+/** Keep pointer-anchored UI inside the visible viewport. */
+function getFloatingPosition(clientX, clientY, width, height) {
+  const viewportWidth = globalThis.innerWidth ?? width;
+  const viewportHeight = globalThis.innerHeight ?? height;
+  return {
+    left: Math.max(8, Math.min(clientX + 12, viewportWidth - width - 8)),
+    top: Math.max(8, Math.min(clientY + 12, viewportHeight - height - 8)),
+  };
 }
 
 /**

--- a/src/components/csv-panel/MapToolsMenu.jsx
+++ b/src/components/csv-panel/MapToolsMenu.jsx
@@ -18,7 +18,6 @@ const DEFAULT_TOOLS_STATE = {
 
 export default function MapToolsMenu({
   timelineState,
-  timelineAvailable = true,
   onTimelinePatch,
   mapToolsState,
   onMapToolsPatch,
@@ -120,12 +119,10 @@ export default function MapToolsMenu({
               className="csvToolToggle"
               role="menuitemcheckbox"
               aria-checked={!!timelineState?.timelineEnabled}
-              aria-disabled={!timelineAvailable}
             >
               <input
                 type="checkbox"
                 checked={!!timelineState?.timelineEnabled}
-                disabled={!timelineAvailable}
                 onChange={(e) =>
                   onTimelinePatch?.({ timelineEnabled: e.target.checked })
                 }

--- a/src/components/useTimelineFilterState.js
+++ b/src/components/useTimelineFilterState.js
@@ -4,19 +4,20 @@ import { useSessionStorageState } from "./useSessionStorageState";
 const STORAGE_KEY = "csv-map-layer-visualizer.timeline.v1";
 
 const DEFAULT_STATE = {
-  timelineEnabled: false,
+  timelineEnabled: true,
 
-  yearDomainMode: "auto",  // "auto" | "manual"
-  yearMinDraft: "",
-  yearMaxDraft: "",
+  // Retained for saved-state compatibility; ranges now change only explicitly.
+  yearDomainMode: "manual",
+  yearMinDraft: "-2100",
+  yearMaxDraft: "2026",
 
-  // Computed domain from data (set when timeline is enabled)
-  yearMin: null,
-  yearMax: null,
+  // Fixed initial domain; only explicit controls may replace it.
+  yearMin: -2100,
+  yearMax: 2026,
 
   // Selected range
-  startYear: null,
-  endYear: null,
+  startYear: -2100,
+  endYear: 2026,
 
   // Optional day filter
   dayFilterEnabled: false,
@@ -68,16 +69,10 @@ export function useTimelineFilterState() {
   }, [setState]);
 
   /*
-   * Sets the computed year domain (data-derived bounds).
+   * Sets the year domain without changing drafts or the selected range.
    *
-   * NOTE:
-   * This helper is kept for backward compatibility, but is no longer used by App.jsx.
-   * The current implementation updates only `yearMin/yearMax` and does NOT:
-   * - update `yearMinDraft/yearMaxDraft`
-   * - respect `yearDomainMode === "manual"`
-   *
-   * For auto-domain updates, prefer a single `patch()` call that
-   * updates domain + draft fields together (see App.jsx).
+   * This legacy helper remains available to callers that intentionally want
+   * that narrow update; imports and dataset changes never call it.
    */
   const setYearDomain = useCallback((yearMin, yearMax) => {
     setState((prev) => ({

--- a/src/data/browserSqlite/browserSqliteDatabase.js
+++ b/src/data/browserSqlite/browserSqliteDatabase.js
@@ -88,6 +88,8 @@ export function initializeBrowserSqliteSchema(database) {
         coordinate_mapping_json TEXT NOT NULL
           DEFAULT '{"latField":null,"lonField":null}'
           CHECK (json_valid(coordinate_mapping_json)),
+        recommended_timeline_start_year INTEGER,
+        recommended_timeline_end_year INTEGER,
         warnings_json TEXT NOT NULL DEFAULT '[]'
           CHECK (json_valid(warnings_json)),
         import_state TEXT NOT NULL DEFAULT 'importing'
@@ -95,6 +97,14 @@ export function initializeBrowserSqliteSchema(database) {
         imported_at TEXT,
         CHECK (
           stored_row_count + skipped_row_count = total_parsed_row_count
+        ),
+        CHECK (
+          (recommended_timeline_start_year IS NULL AND recommended_timeline_end_year IS NULL)
+          OR (
+            recommended_timeline_start_year IS NOT NULL
+            AND recommended_timeline_end_year IS NOT NULL
+            AND recommended_timeline_start_year <= recommended_timeline_end_year
+          )
         ),
         CHECK (
           (import_state = 'importing' AND imported_at IS NULL)

--- a/src/data/browserSqlite/browserSqliteDatabase.smoke.js
+++ b/src/data/browserSqlite/browserSqliteDatabase.smoke.js
@@ -48,6 +48,8 @@ try {
       'enabled',
       'detected_fields_json',
       'coordinate_mapping_json',
+      'recommended_timeline_start_year',
+      'recommended_timeline_end_year',
       'warnings_json',
       'import_state',
       'imported_at',

--- a/src/data/browserSqlite/browserSqliteDatasetMutations.smoke.js
+++ b/src/data/browserSqlite/browserSqliteDatasetMutations.smoke.js
@@ -28,6 +28,7 @@ try {
       dateField: null,
     },
     mapping: { latField: 'lat', lonField: 'lon' },
+    recommendedTimelineRange: { startYear: 900, endYear: 1200 },
   });
   insertDataset(database, {
     id: 'dataset-b',
@@ -160,6 +161,10 @@ try {
   assert.equal(datasetA.enabled, false);
   assert.equal(datasetA.latField, null);
   assert.equal(datasetA.lonField, null);
+  assert.deepEqual(datasetA.recommendedTimelineRange, {
+    startYear: 900,
+    endYear: 1200,
+  });
   assert.equal(datasetB.enabled, true);
   assert.equal(datasetB.latField, 'latitude');
   assert.equal(datasetB.lonField, 'longitude');
@@ -178,15 +183,19 @@ function insertDataset(targetDatabase, fixture) {
       columns_json,
       detected_fields_json,
       coordinate_mapping_json,
+      recommended_timeline_start_year,
+      recommended_timeline_end_year,
       import_state,
       imported_at
-    ) VALUES (?, ?, ?, ?, ?, ?, ?)
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
   `, [
     fixture.id,
     fixture.fileName,
     JSON.stringify(fixture.headers),
     JSON.stringify(fixture.detectedFields),
     JSON.stringify(fixture.mapping),
+    fixture.recommendedTimelineRange?.startYear ?? null,
+    fixture.recommendedTimelineRange?.endYear ?? null,
     importState,
     importState === 'complete' ? '2026-07-26T12:00:00.000Z' : null,
   ]);

--- a/src/data/browserSqlite/browserSqliteDatasetQueries.js
+++ b/src/data/browserSqlite/browserSqliteDatasetQueries.js
@@ -28,6 +28,8 @@ export function getBrowserSqliteDatasetSummary(database) {
       enabled,
       detected_fields_json,
       coordinate_mapping_json,
+      recommended_timeline_start_year,
+      recommended_timeline_end_year,
       warnings_json,
       imported_at
     FROM datasets
@@ -79,6 +81,10 @@ export function getBrowserSqliteDatasetSummary(database) {
         latField: normalizeNullableString(mapping.latField),
         lonField: normalizeNullableString(mapping.lonField),
         detectedFields: parseJsonObject(row.detected_fields_json),
+        recommendedTimelineRange: normalizeRecommendedTimelineRange(
+          row.recommended_timeline_start_year,
+          row.recommended_timeline_end_year,
+        ),
         parseErrors: parseJsonStringList(row.warnings_json),
       };
     }),
@@ -86,6 +92,17 @@ export function getBrowserSqliteDatasetSummary(database) {
     timeline: yearMin == null || yearMax == null
       ? null
       : { yearMin, yearMax },
+  };
+}
+
+/** Normalize the stored import-time range without consulting feature rows. */
+function normalizeRecommendedTimelineRange(startValue, endValue) {
+  const startYear = normalizeStoredYear(startValue);
+  const endYear = normalizeStoredYear(endValue);
+  if (startYear == null || endYear == null) return null;
+  return {
+    startYear: Math.min(startYear, endYear),
+    endYear: Math.max(startYear, endYear),
   };
 }
 

--- a/src/data/browserSqlite/browserSqliteDatasetQueries.smoke.js
+++ b/src/data/browserSqlite/browserSqliteDatasetQueries.smoke.js
@@ -43,6 +43,7 @@ try {
       lonField: 'lon',
       yearField: null,
     },
+    recommendedTimelineRange: { startYear: 900, endYear: 1200 },
     parseErrors: ['One malformed row was skipped.'],
   });
   assert.deepEqual(summary.datasets[1].headers, []);
@@ -154,6 +155,8 @@ function insertFixtures(targetDatabase) {
       yearField: null,
     }),
     mappingJson: JSON.stringify({ latField: 'lat', lonField: 'lon' }),
+    recommendedTimelineStartYear: 900,
+    recommendedTimelineEndYear: 1200,
     warningsJson: JSON.stringify(['One malformed row was skipped.']),
     importState: 'complete',
     importedAt: '2026-07-26T12:00:00.000Z',
@@ -242,10 +245,12 @@ function insertDataset(targetDatabase, fixture) {
       enabled,
       detected_fields_json,
       coordinate_mapping_json,
+      recommended_timeline_start_year,
+      recommended_timeline_end_year,
       warnings_json,
       import_state,
       imported_at
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `, [
     fixture.id,
     fixture.fileName,
@@ -257,6 +262,8 @@ function insertDataset(targetDatabase, fixture) {
     fixture.enabled,
     fixture.detectedFieldsJson,
     fixture.mappingJson,
+    fixture.recommendedTimelineStartYear ?? null,
+    fixture.recommendedTimelineEndYear ?? null,
     fixture.warningsJson,
     fixture.importState,
     fixture.importedAt,

--- a/src/data/browserSqlite/browserSqliteImportTransaction.js
+++ b/src/data/browserSqlite/browserSqliteImportTransaction.js
@@ -5,6 +5,7 @@ import {
 import {
   rebuildBrowserSqliteGeometryFeatures,
 } from './browserSqliteGeometryDerivation.js';
+import { getBrowserSqliteTimelineExtent } from './browserSqliteTimeline.js';
 
 /** Maximum already-normalized rows accepted by one storage call. */
 export const MAX_BROWSER_SQLITE_IMPORT_BATCH_ROWS = 1_000;
@@ -154,6 +155,13 @@ export function completeBrowserSqliteFileImport(activeImport, metadata) {
       metadata,
       state.nextSourceRowIndex,
     );
+    // Capture the file-level recommendation before mapping-derived features are
+    // built. Later mapping changes must not alter this import-time decision.
+    const recommendedTimelineRange = calculateRecommendedTimelineRange(
+      state.database,
+      state.datasetId,
+      normalized.detectedFields,
+    );
     freeActiveStatement(state);
     state.database.run(`
       UPDATE datasets
@@ -163,6 +171,8 @@ export function completeBrowserSqliteFileImport(activeImport, metadata) {
           skipped_row_count = ?,
           detected_fields_json = ?,
           coordinate_mapping_json = ?,
+          recommended_timeline_start_year = ?,
+          recommended_timeline_end_year = ?,
           warnings_json = ?,
           import_state = 'complete',
           imported_at = ?
@@ -174,6 +184,8 @@ export function completeBrowserSqliteFileImport(activeImport, metadata) {
       normalized.skippedRowCount,
       JSON.stringify(normalized.detectedFields),
       JSON.stringify(normalized.coordinateMapping),
+      recommendedTimelineRange?.startYear ?? null,
+      recommendedTimelineRange?.endYear ?? null,
       JSON.stringify(normalized.warnings),
       normalized.importedAt,
       state.datasetId,
@@ -207,6 +219,7 @@ export function completeBrowserSqliteFileImport(activeImport, metadata) {
       skippedLineCount: geometryResult.skippedLineCount,
       regionFeatureCount: geometryResult.regionFeatureCount,
       skippedRegionCount: geometryResult.skippedRegionCount,
+      recommendedTimelineRange,
       importedAt: normalized.importedAt,
     };
   } catch (error) {
@@ -216,6 +229,47 @@ export function completeBrowserSqliteFileImport(activeImport, metadata) {
       'import-finalization-failed',
       'The file import could not be finalized.',
     );
+  }
+}
+
+/** Scan stored source rows once to calculate the immutable import recommendation. */
+function calculateRecommendedTimelineRange(database, datasetId, detectedFields) {
+  const rows = database.prepare(`
+    SELECT row_json
+    FROM source_rows
+    WHERE dataset_id = ?
+    ORDER BY source_row_index
+  `);
+  let startYear = null;
+  let endYear = null;
+
+  try {
+    rows.bind([datasetId]);
+    while (rows.step()) {
+      const stored = rows.getAsObject();
+      const row = parseStoredRow(stored.row_json);
+      const extent = getBrowserSqliteTimelineExtent(row, detectedFields);
+      if (!extent) continue;
+      startYear = startYear == null
+        ? extent.startYear
+        : Math.min(startYear, extent.startYear);
+      endYear = endYear == null
+        ? extent.endYear
+        : Math.max(endYear, extent.endYear);
+    }
+  } finally {
+    rows.free();
+  }
+
+  return startYear == null || endYear == null ? null : { startYear, endYear };
+}
+
+function parseStoredRow(value) {
+  try {
+    const parsed = JSON.parse(String(value ?? ''));
+    return isRecord(parsed) ? parsed : {};
+  } catch {
+    return {};
   }
 }
 

--- a/src/data/browserSqlite/browserSqliteImportTransaction.smoke.js
+++ b/src/data/browserSqlite/browserSqliteImportTransaction.smoke.js
@@ -82,6 +82,7 @@ try {
     skippedLineCount: 0,
     regionFeatureCount: 0,
     skippedRegionCount: 0,
+    recommendedTimelineRange: { startYear: 2020, endYear: 2022 },
     importedAt: '2026-07-26T14:00:00.000Z',
   });
   assert.equal(freedInsertStatementCount, 1);

--- a/src/data/browserSqlite/browserSqliteImporter.smoke.js
+++ b/src/data/browserSqlite/browserSqliteImporter.smoke.js
@@ -109,6 +109,10 @@ try {
   assert.equal(summary.totalRows, 3);
   assert.equal(summary.latField, 'latitude');
   assert.equal(summary.lonField, 'longitude');
+  assert.deepEqual(summary.recommendedTimelineRange, {
+    startYear: 2019,
+    endYear: 2024,
+  });
 
   const preview = getBrowserSqlitePreviewPage(database, {
     datasetId: 'dataset-incremental',
@@ -187,6 +191,9 @@ try {
   assert.ok(headerOnlyResult.warnings.includes(
     'No usable data rows were parsed.',
   ));
+  const headerOnlySummary = getBrowserSqliteDatasetSummary(database).datasets
+    .find((dataset) => dataset.id === 'dataset-header-only');
+  assert.equal(headerOnlySummary.recommendedTimelineRange, null);
 
   const readFailureFile = new TestBrowserFile(
     'name,lat,lon\nFirst,1,2\nSecond,3,4\nThird,5,6',

--- a/src/data/dataSource.js
+++ b/src/data/dataSource.js
@@ -519,6 +519,7 @@ export const BACKEND_FAILURE_CATEGORIES = Object.freeze({
  * @property {string|null} latField
  * @property {string|null} lonField
  * @property {DetectedFields|null} [detectedFields]
+ * @property {{startYear: number, endYear: number}|null} recommendedTimelineRange
  * @property {string[]} parseErrors
  */
 

--- a/src/data/dataSourceNormalization.js
+++ b/src/data/dataSourceNormalization.js
@@ -266,7 +266,22 @@ export function normalizeDatasetSummaryItem(value) {
     latField: normalizeNullableString(value.latField),
     lonField: normalizeNullableString(value.lonField),
     detectedFields: normalizeDetectedFields(value.detectedFields),
+    recommendedTimelineRange: normalizeRecommendedTimelineRange(
+      value.recommendedTimelineRange,
+    ),
     parseErrors: normalizeStringList(value.parseErrors, MAX_STRING_LIST_ITEMS),
+  };
+}
+
+/** Normalize one stored per-dataset recommendation or its explicit absence. */
+function normalizeRecommendedTimelineRange(value) {
+  if (!isRecord(value)) return null;
+  const startYear = normalizeOptionalInteger(value.startYear);
+  const endYear = normalizeOptionalInteger(value.endYear);
+  if (startYear == null || endYear == null) return null;
+  return {
+    startYear: Math.min(startYear, endYear),
+    endYear: Math.max(startYear, endYear),
   };
 }
 

--- a/src/data/dataSourceNormalization.smoke.js
+++ b/src/data/dataSourceNormalization.smoke.js
@@ -129,6 +129,7 @@ const datasetSummary = normalizeDatasetSummary({
       latField: 'lat',
       lonField: 'lon',
       detectedFields: { dayOfYearField: 'doy' },
+      recommendedTimelineRange: { startYear: 2025, endYear: 1000 },
       parseErrors: ['warning'],
       rows: [{ secret: 'must not pass through' }],
     },
@@ -142,6 +143,10 @@ assert.equal(datasetSummary.datasets[0].name, 'places.csv');
 assert.equal(datasetSummary.datasets[0].rowCount, 12);
 assert.equal(datasetSummary.datasets[0].totalRows, 15);
 assert.equal(datasetSummary.datasets[0].skippedRowCount, null);
+assert.deepEqual(datasetSummary.datasets[0].recommendedTimelineRange, {
+  startYear: 1000,
+  endYear: 2025,
+});
 assert.equal(Object.hasOwn(datasetSummary.datasets[0], 'rows'), false);
 assert.equal(datasetSummary.selectedDatasetId, 'dataset-1');
 assert.deepEqual(datasetSummary.timeline, { yearMin: 1000, yearMax: 2025 });


### PR DESCRIPTION
## Summary

- Keep the Timeline control permanently available and enable it by default with the fixed `-2100`–`2026` range.
- Stop imports and dataset visibility changes from automatically modifying the configured timeline range.
- Calculate and store a recommended timeline range for each imported CSV.
- Show the recommendation after hovering over a CSV row and provide a custom right-click action for applying it.
- Redesign the dual-range slider with separated handles and percentage-based positioning.
- Preserve timeline filtering behavior for dated and undated features.
- Add and update browser and desktop SQLite regression coverage.

## Testing

- `npm run lint`
- `npm run build`
- `npm run build:desktop`
- `npm run smoke:browser-sqlite`
- `npm run smoke:csv-import-batch`
- `npm run smoke:sqlite-datasets`
- `npm run smoke:sqlite-store`
- Manual testing of timeline defaults, filtering, playback stopping, CSV-row hover and context-menu interactions, equal slider handles, panel visibility changes, and resizing.

Closes #121
