### PR TITLE
Add close buttons to user messages and warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "smoke:browser-sqlite-worker-client": "node src/data/browserSqlite/browserSqliteWorkerClient.smoke.js",
     "smoke:browser-sqlite-data-source": "node src/data/browserSqlite/browserSqliteDataSource.smoke.js",
     "smoke:browser-sqlite-ui": "node src/components/browserSqliteUiCoordination.smoke.js",
+    "smoke:message-dismissal": "node src/components/messageDismissalState.smoke.js",
     "smoke:marker-proximity": "node src/components/markerProximitySelection.smoke.js",
     "smoke:browser-sqlite-points": "node src/data/browserSqlite/browserSqlitePointQueries.smoke.js",
     "validate:browser-sqlite-worker": "node desktop/run-electron.cjs desktop/browserSqliteWorkerValidation.cjs",

--- a/src/App.css
+++ b/src/App.css
@@ -335,6 +335,62 @@ button.csvBtnPrimary.csvDesktopImportButton {
   margin-bottom: 3px;
   overflow-wrap: anywhere;
 }
+
+.csvDismissibleMessage,
+.csvDismissibleMessageGroup {
+  position: relative;
+}
+
+.csvDismissibleMessage {
+  padding-right: 38px;
+}
+
+.csvDismissibleMessageGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.csvDismissibleMessageGroup > .csvDesktopImportStatus:first-of-type {
+  padding-right: 38px;
+}
+
+.csvDismissButton {
+  position: absolute;
+  z-index: 1;
+  top: 5px;
+  right: 5px;
+  width: 26px;
+  height: 26px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  border-radius: 6px;
+  background: rgba(15, 23, 42, 0.45);
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+}
+
+.csvDismissButtonIcon {
+  width: 14px;
+  height: 14px;
+  display: block;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.75;
+  stroke-linecap: round;
+}
+
+.csvDismissButton:hover {
+  background: rgba(255, 255, 255, 0.16);
+}
+
+.csvDismissButton:focus-visible {
+  outline: 2px solid #93c5fd;
+  outline-offset: 1px;
+}
 .csvFilesList {
   display: flex;
   flex-direction: column;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -112,6 +112,74 @@ export default function App() {
     result: null,
     error: null,
   });
+
+  /** Hide a completed import message without affecting imported datasets. */
+  const dismissImportMessage = useCallback(() => {
+    setDesktopImportState((current) => (
+      current.status === "importing"
+        ? current
+        : { status: "idle", summary: null, error: null, progress: null }
+    ));
+  }, []);
+
+  /** Hide the current dataset-list error until a later load fails. */
+  const dismissDatasetLoadError = useCallback(() => {
+    setDesktopDatasetState((current) => ({
+      ...current,
+      status: current.datasets.length > 0 ? "loaded" : "idle",
+      error: null,
+    }));
+  }, []);
+
+  /** Hide the current dataset visibility error without changing visibility. */
+  const dismissDatasetMutationError = useCallback(() => {
+    setDesktopVisibilityState((current) => ({ ...current, error: null }));
+  }, []);
+
+  /** Hide the current removal error without changing any dataset. */
+  const dismissDatasetRemovalError = useCallback(() => {
+    setDesktopRemovalState((current) => ({ ...current, error: null }));
+  }, []);
+
+  /** Hide the current mapping error while preserving the last valid mapping. */
+  const dismissDatasetMappingError = useCallback(() => {
+    setDatabaseMappingState((current) => ({ ...current, error: null }));
+  }, []);
+
+  /** Hide the current query error while retaining the last successful map result. */
+  const dismissDatasetQueryError = useCallback(() => {
+    setDesktopMapViewState((current) => ({
+      ...current,
+      status: current.result ? "loaded" : "idle",
+      error: null,
+    }));
+  }, []);
+
+  /** Hide the current preview error without discarding loaded preview rows. */
+  const dismissDatasetPreviewError = useCallback(() => {
+    setDatabasePreviewState((current) => ({
+      ...current,
+      error: null,
+    }));
+  }, []);
+
+  const messageDismissal = useMemo(() => ({
+    import: dismissImportMessage,
+    datasetLoad: dismissDatasetLoadError,
+    datasetMutation: dismissDatasetMutationError,
+    datasetRemoval: dismissDatasetRemovalError,
+    datasetQuery: dismissDatasetQueryError,
+    mapping: dismissDatasetMappingError,
+    preview: dismissDatasetPreviewError,
+  }), [
+    dismissDatasetLoadError,
+    dismissDatasetMappingError,
+    dismissDatasetMutationError,
+    dismissDatasetPreviewError,
+    dismissDatasetQueryError,
+    dismissDatasetRemovalError,
+    dismissImportMessage,
+  ]);
   const desktopSqliteMapAvailable =
     usesViewportQueries && desktopCapabilities.points;
   const desktopDatasetSummaryAvailable =
@@ -786,6 +854,7 @@ export default function App() {
               : undefined}
             initialization={initialization ?? { ok: false }}
             mappingState={databaseMappingState}
+            messageDismissal={messageDismissal}
             timelineState={timelineState}
             timelineFields={timelineFields}
             onTimelinePatch={patchTimeline}

--- a/src/components/CsvPanel.jsx
+++ b/src/components/CsvPanel.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React, { useMemo, useState } from "react";
 import DualRangeSlider from "./DualRangeSlider";
 import CsvPreviewTable from "./csv-panel/CsvPreviewTable";
 import SelectedFileMetadata from "./csv-panel/SelectedFileMetadata";
@@ -6,6 +6,8 @@ import CoordinateMapping from "./csv-panel/CoordinateMapping";
 import CsvParsingWarnings from "./csv-panel/CsvParsingWarnings";
 import CsvFileControls from "./csv-panel/CsvFileControls";
 import MapToolsMenu from "./csv-panel/MapToolsMenu";
+import { DismissibleMessage } from "./csv-panel/DismissibleMessage";
+import { getParsingWarningsMessageKey } from "./messageDismissalState";
 
 /**
  * CsvPanel
@@ -30,6 +32,7 @@ export default function CsvPanel({
   viewportQueryStats,
   initialization,
   mappingState,
+  messageDismissal,
   onLoadMorePreview,
   onUnloadFile,     // Callback to unload a CSV by ID
   removeActionLabel,
@@ -54,6 +57,24 @@ export default function CsvPanel({
     () => files.find((f) => f.id === selectedId) || null,
     [files, selectedId]
   );
+  const [dismissedInitializationError, setDismissedInitializationError] = useState(null);
+  const [dismissedParsingWarningKeys, setDismissedParsingWarningKeys] = useState(
+    () => new Set(),
+  );
+  const parsingWarningsMessageKey = getParsingWarningsMessageKey(selected);
+  const parsingWarningsDismissed = parsingWarningsMessageKey
+    ? dismissedParsingWarningKeys.has(parsingWarningsMessageKey)
+    : false;
+
+  /** Remember dismissal against this CSV import's parsing-result identity. */
+  function dismissSelectedParsingWarnings() {
+    if (!parsingWarningsMessageKey) return;
+    setDismissedParsingWarningKeys((current) => {
+      const next = new Set(current);
+      next.add(parsingWarningsMessageKey);
+      return next;
+    });
+  }
 
   // local editable inputs for "Year domain" (min/max + Begin)
   // These are UI-only text boxes so the user can type without instantly snapping/clamping.
@@ -175,6 +196,7 @@ export default function CsvPanel({
             removeActionLabel={removeActionLabel}
             onToggleEnabled={onToggleEnabled}
             onUseRecommendedTimelineRange={useRecommendedTimelineRange}
+            messageDismissal={messageDismissal}
           />
 
           {/* Timeline UI lives inside the panel header (NOT in the dropdown). */}
@@ -474,14 +496,22 @@ export default function CsvPanel({
          ========================= */}
       <div className="csvPanelBody">
         {initialization && initialization.ok !== true && (
-          <div
-            className={initialization.error
-              ? "csvDesktopImportStatus csvDesktopImportStatusError"
-              : "csvEmptyState"}
-            role={initialization.error ? "alert" : "status"}
-          >
-            {initialization.error?.message ?? "Initializing data..."}
-          </div>
+          initialization.error ? (
+            initialization.error !== dismissedInitializationError && (
+              <DismissibleMessage
+                className="csvDesktopImportStatus csvDesktopImportStatusError"
+                dismissLabel="Dismiss initialization error"
+                onDismiss={() => setDismissedInitializationError(initialization.error)}
+                role="alert"
+              >
+                {initialization.error.message}
+              </DismissibleMessage>
+            )
+          ) : (
+            <div className="csvEmptyState" role="status">
+              Initializing data...
+            </div>
+          )
         )}
         {/* No CSV selected */}
         {!selected ? (
@@ -526,13 +556,23 @@ export default function CsvPanel({
               disabled={mappingState?.pendingDatasetId === selected.id}
             />
             {mappingState?.error && (
-              <div className="csvDesktopImportStatus csvDesktopImportStatusError" role="alert">
+              <DismissibleMessage
+                className="csvDesktopImportStatus csvDesktopImportStatusError"
+                dismissLabel="Dismiss dataset mapping error"
+                onDismiss={messageDismissal?.mapping}
+                role="alert"
+              >
                 {mappingState.error}
-              </div>
+              </DismissibleMessage>
             )}
 
             {/* CSV parsing warnings (non-fatal) */}
-            <CsvParsingWarnings errors={selected.parseErrors} />
+            {!parsingWarningsDismissed && (
+              <CsvParsingWarnings
+                errors={selected.parseErrors}
+                onDismiss={dismissSelectedParsingWarnings}
+              />
+            )}
 
             {/* Preview table */}
             <CsvPreviewTable
@@ -544,6 +584,7 @@ export default function CsvPanel({
               status={selected.previewStatus}
               error={selected.previewError}
               onShowMore={onLoadMorePreview}
+              onDismissError={messageDismissal?.preview}
             />
 
           </>

--- a/src/components/csv-panel/CsvFileControls.jsx
+++ b/src/components/csv-panel/CsvFileControls.jsx
@@ -1,5 +1,11 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useReducer, useRef, useState } from "react";
+import { DismissButton, DismissibleMessage } from "./DismissibleMessage";
+import {
+  INITIAL_CONDITION_DISMISSAL,
+  reduceConditionDismissal,
+} from "../messageDismissalState";
 
+/** Render import controls, persistent operation messages, and the dataset list. */
 export default function CsvFileControls({
   files,
   selectedId,
@@ -12,6 +18,7 @@ export default function CsvFileControls({
   removeActionLabel = "Unload",
   onToggleEnabled,
   onUseRecommendedTimelineRange,
+  messageDismissal,
 }) {
   /**
    * Hidden file input reference.
@@ -30,10 +37,27 @@ export default function CsvFileControls({
     ? desktopSummary.results
     : [];
   const hiddenByRenderBudget = normalizeCount(viewportQueryStats?.hiddenByRenderBudget);
+  const [renderWarningDismissal, dispatchRenderWarningDismissal] = useReducer(
+    reduceConditionDismissal,
+    INITIAL_CONDITION_DISMISSAL,
+  );
   const browserImportAvailable = typeof onImportFiles === "function";
   const canSelect = typeof onSelect === "function";
   const canToggleEnabled = typeof onToggleEnabled === "function";
   const canRemove = typeof onUnloadFile === "function";
+  const hasTerminalImportMessage = !isDesktopImporting && (
+    desktopImportResults.length > 0 ||
+    desktopImport?.status === "canceled" ||
+    desktopImport?.status === "error"
+  );
+
+  useEffect(() => {
+    // A changing positive count belongs to the same warning cycle. Only zero resets it.
+    dispatchRenderWarningDismissal({
+      type: "sync",
+      active: hiddenByRenderBudget > 0,
+    });
+  }, [hiddenByRenderBudget]);
 
   /** Close the custom recommendation menu on outside interaction or Escape. */
   useEffect(() => {
@@ -162,51 +186,64 @@ export default function CsvFileControls({
             </div>
           )}
 
-          {desktopImportResults.length > 0 && (
-            <div className="csvDesktopImportStatus" role="status">
-              {desktopImportResults.map((result, index) => (
-                <div
-                  key={`${result.fileName}-${index}`}
-                  className={result.ok ? undefined : "csvDesktopImportStatusError"}
-                >
-                  <div className="csvDesktopImportTitle">{result.fileName}</div>
-                  {result.ok ? (
-                    <>
-                      <div>
-                        Imported {result.importedFeatureCount} of {result.rowCount} rows
-                        {result.skippedRowCount
-                          ? `, skipped ${result.skippedRowCount}`
-                          : ""}.
-                      </div>
-                      <div>Fields: {formatFieldList(result.detectedFields)}</div>
-                      {result.warnings?.length > 0 && (
-                        <div>{result.warnings.length} parsing warning(s).</div>
+          {hasTerminalImportMessage && (
+            <div className="csvDismissibleMessageGroup">
+              <DismissButton
+                label="Dismiss import message"
+                onDismiss={messageDismissal?.import}
+              />
+              {desktopImportResults.length > 0 && (
+                <div className="csvDesktopImportStatus" role="status">
+                  {desktopImportResults.map((result, index) => (
+                    <div
+                      key={`${result.fileName}-${index}`}
+                      className={result.ok ? undefined : "csvDesktopImportStatusError"}
+                    >
+                      <div className="csvDesktopImportTitle">{result.fileName}</div>
+                      {result.ok ? (
+                        <>
+                          <div>
+                            Imported {result.importedFeatureCount} of {result.rowCount} rows
+                            {result.skippedRowCount
+                              ? `, skipped ${result.skippedRowCount}`
+                              : ""}.
+                          </div>
+                          <div>Fields: {formatFieldList(result.detectedFields)}</div>
+                          {result.warnings?.length > 0 && (
+                            <div>{result.warnings.length} parsing warning(s).</div>
+                          )}
+                        </>
+                      ) : (
+                        <div>{getImportErrorMessage(result.error)}</div>
                       )}
-                    </>
-                  ) : (
-                    <div>{getImportErrorMessage(result.error)}</div>
-                  )}
+                    </div>
+                  ))}
                 </div>
-              ))}
+              )}
+
+              {desktopImport.status === "canceled" && (
+                <div className="csvDesktopImportStatus" role="status">
+                  Import canceled.
+                </div>
+              )}
+
+              {desktopImport.status === "error" && (
+                <div className="csvDesktopImportStatus csvDesktopImportStatusError" role="alert">
+                  {desktopImport.error ?? "Import failed."}
+                </div>
+              )}
             </div>
           )}
 
-          {desktopImport.status === "canceled" && (
-            <div className="csvDesktopImportStatus" role="status">
-              Import canceled.
-            </div>
-          )}
-
-
-          {hiddenByRenderBudget > 0 && (
-            <div className="csvDesktopImportStatus" role="status">
+          {hiddenByRenderBudget > 0 && !renderWarningDismissal.dismissed && (
+            <DismissibleMessage
+              className="csvDesktopImportStatus"
+              dismissLabel="Dismiss warning"
+              onDismiss={() => dispatchRenderWarningDismissal({ type: "dismiss" })}
+              role="status"
+            >
               {hiddenByRenderBudget.toLocaleString()} datapoints are not being displayed
-            </div>
-          )}
-          {desktopImport.status === "error" && (
-            <div className="csvDesktopImportStatus csvDesktopImportStatusError" role="alert">
-              {desktopImport.error ?? "Import failed."}
-            </div>
+            </DismissibleMessage>
           )}
         </div>
       )}
@@ -232,24 +269,44 @@ export default function CsvFileControls({
         </div>
 
         {datasetListState?.status === "error" && (
-          <div className="csvDesktopImportStatus csvDesktopImportStatusError" role="alert">
+          <DismissibleMessage
+            className="csvDesktopImportStatus csvDesktopImportStatusError"
+            dismissLabel="Dismiss dataset loading error"
+            onDismiss={messageDismissal?.datasetLoad}
+            role="alert"
+          >
             {datasetListState.error ?? "Could not load datasets."}
-          </div>
+          </DismissibleMessage>
         )}
         {datasetListState?.mutationError && (
-          <div className="csvDesktopImportStatus csvDesktopImportStatusError" role="alert">
+          <DismissibleMessage
+            className="csvDesktopImportStatus csvDesktopImportStatusError"
+            dismissLabel="Dismiss dataset mutation error"
+            onDismiss={messageDismissal?.datasetMutation}
+            role="alert"
+          >
             {datasetListState.mutationError}
-          </div>
+          </DismissibleMessage>
         )}
         {datasetListState?.removalError && (
-          <div className="csvDesktopImportStatus csvDesktopImportStatusError" role="alert">
+          <DismissibleMessage
+            className="csvDesktopImportStatus csvDesktopImportStatusError"
+            dismissLabel="Dismiss dataset removal error"
+            onDismiss={messageDismissal?.datasetRemoval}
+            role="alert"
+          >
             {datasetListState.removalError}
-          </div>
+          </DismissibleMessage>
         )}
         {datasetListState?.queryError && (
-          <div className="csvDesktopImportStatus csvDesktopImportStatusError" role="alert">
+          <DismissibleMessage
+            className="csvDesktopImportStatus csvDesktopImportStatusError"
+            dismissLabel="Dismiss dataset query error"
+            onDismiss={messageDismissal?.datasetQuery}
+            role="alert"
+          >
             {datasetListState.queryError}
-          </div>
+          </DismissibleMessage>
         )}
 
         {datasetListState?.status === "loading" && files.length === 0 ? (

--- a/src/components/csv-panel/CsvParsingWarnings.jsx
+++ b/src/components/csv-panel/CsvParsingWarnings.jsx
@@ -1,21 +1,30 @@
-export default function CsvParsingWarnings({ errors }) {
+import { DismissButton } from "./DismissibleMessage";
+
+/** Show the selected CSV's non-fatal parsing results as one dismissible section. */
+export default function CsvParsingWarnings({ errors, onDismiss }) {
   if (!errors?.length) return null;
 
   return (
-    <details className="csvErrors">
-      <summary>Parsing warnings ({errors.length})</summary>
+    <div className="csvErrors csvDismissibleMessage">
+      <DismissButton
+        label="Dismiss parsing warnings"
+        onDismiss={onDismiss}
+      />
+      <details>
+        <summary>Parsing warnings ({errors.length})</summary>
 
-      <ul>
-        {errors.slice(0, 15).map((err, idx) => (
-          <li key={idx}>{err}</li>
-        ))}
-      </ul>
+        <ul>
+          {errors.slice(0, 15).map((err, idx) => (
+            <li key={idx}>{err}</li>
+          ))}
+        </ul>
 
-      {errors.length > 15 && (
-        <div className="csvErrorsMore">
-          Showing first 15. More warnings exist.
-        </div>
-      )}
-    </details>
+        {errors.length > 15 && (
+          <div className="csvErrorsMore">
+            Showing first 15. More warnings exist.
+          </div>
+        )}
+      </details>
+    </div>
   );
 }

--- a/src/components/csv-panel/CsvPreviewTable.jsx
+++ b/src/components/csv-panel/CsvPreviewTable.jsx
@@ -1,7 +1,9 @@
 import { useMemo, useState } from "react";
+import { DismissibleMessage } from "./DismissibleMessage";
 
 const PREVIEW_ROWS_INCREMENT = 30;
 
+/** Render bounded CSV preview rows and any completed preview-loading error. */
 export default function CsvPreviewTable({
   headers,
   rows,
@@ -10,6 +12,7 @@ export default function CsvPreviewTable({
   status = "loaded",
   error,
   onShowMore,
+  onDismissError,
 }) {
   const controlledPaging = typeof onShowMore === "function";
   const [previewRowLimit, setPreviewRowLimit] = useState(
@@ -29,16 +32,27 @@ export default function CsvPreviewTable({
   const canShowMorePreviewRows = controlledPaging
     ? !!hasMore
     : previewRows.length < previewTotalRows;
+  // A dismissed initial-load error must not be replaced with a misleading empty-data message.
+  const previewErrorDismissed = status === "error" && !error;
 
   return (
     <>
       <div className="csvPreviewTitle">Preview</div>
 
-      {error && <div className="csvEmptyPreview" role="alert">{error}</div>}
+      {error && (
+        <DismissibleMessage
+          className="csvEmptyPreview"
+          dismissLabel="Dismiss dataset loading error"
+          onDismiss={onDismissError}
+          role="alert"
+        >
+          {error}
+        </DismissibleMessage>
+      )}
 
       {status === "loading" ? (
         <div className="csvEmptyPreview">Loading preview rows...</div>
-      ) : error && previewTotalRows === 0 ? null : headers.length === 0 ? (
+      ) : previewErrorDismissed || (error && previewTotalRows === 0) ? null : headers.length === 0 ? (
         <div className="csvEmptyPreview">No headers detected.</div>
       ) : previewTotalRows === 0 ? (
         <div className="csvEmptyPreview">No data rows detected.</div>

--- a/src/components/csv-panel/DismissibleMessage.jsx
+++ b/src/components/csv-panel/DismissibleMessage.jsx
@@ -1,0 +1,38 @@
+/** Render the shared close control used by persistent user-facing messages. */
+export function DismissButton({ label, onDismiss }) {
+  return (
+    <button
+      type="button"
+      className="csvDismissButton"
+      aria-label={label}
+      onClick={(event) => {
+        event.stopPropagation();
+        onDismiss?.();
+      }}
+    >
+      <svg
+        className="csvDismissButtonIcon"
+        viewBox="0 0 16 16"
+        aria-hidden="true"
+      >
+        <path d="M4 4l8 8M12 4l-8 8" />
+      </svg>
+    </button>
+  );
+}
+
+/** Preserve a message's existing role and severity while adding dismissal UI. */
+export function DismissibleMessage({
+  children,
+  className = "",
+  dismissLabel,
+  onDismiss,
+  role,
+}) {
+  return (
+    <div className={`${className} csvDismissibleMessage`.trim()} role={role}>
+      <DismissButton label={dismissLabel} onDismiss={onDismiss} />
+      {children}
+    </div>
+  );
+}

--- a/src/components/messageDismissalState.js
+++ b/src/components/messageDismissalState.js
@@ -1,0 +1,22 @@
+export const INITIAL_CONDITION_DISMISSAL = Object.freeze({
+  active: false,
+  dismissed: false,
+});
+
+/** Track dismissal for one warning condition until that condition fully resolves. */
+export function reduceConditionDismissal(state, action) {
+  if (action.type === "dismiss") {
+    return { active: true, dismissed: true };
+  }
+
+  if (action.type !== "sync") return state;
+  if (!action.active) return INITIAL_CONDITION_DISMISSAL;
+  if (state.active) return state;
+  return { active: true, dismissed: false };
+}
+
+/** Identify one CSV's parsing results without relying on its display name. */
+export function getParsingWarningsMessageKey(file) {
+  if (!file?.id) return null;
+  return `${file.id}:${file.importedAt ?? ""}`;
+}

--- a/src/components/messageDismissalState.smoke.js
+++ b/src/components/messageDismissalState.smoke.js
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import {
+  getParsingWarningsMessageKey,
+  INITIAL_CONDITION_DISMISSAL,
+  reduceConditionDismissal,
+} from "./messageDismissalState.js";
+
+let warningState = reduceConditionDismissal(
+  INITIAL_CONDITION_DISMISSAL,
+  { type: "sync", active: true },
+);
+warningState = reduceConditionDismissal(warningState, { type: "dismiss" });
+assert.equal(warningState.dismissed, true);
+
+warningState = reduceConditionDismissal(
+  warningState,
+  { type: "sync", active: true },
+);
+assert.equal(
+  warningState.dismissed,
+  true,
+  "an active warning remains dismissed when only its count changes",
+);
+
+warningState = reduceConditionDismissal(
+  warningState,
+  { type: "sync", active: false },
+);
+warningState = reduceConditionDismissal(
+  warningState,
+  { type: "sync", active: true },
+);
+assert.equal(
+  warningState.dismissed,
+  false,
+  "a resolved warning can appear when its condition occurs again",
+);
+
+assert.equal(
+  getParsingWarningsMessageKey({ id: "dataset-a", importedAt: "first" }),
+  "dataset-a:first",
+);
+assert.notEqual(
+  getParsingWarningsMessageKey({ id: "dataset-a", importedAt: "first" }),
+  getParsingWarningsMessageKey({ id: "dataset-a", importedAt: "second" }),
+  "reimported parsing results receive a new dismissal identity",
+);
+assert.notEqual(
+  getParsingWarningsMessageKey({ id: "dataset-a", importedAt: "first" }),
+  getParsingWarningsMessageKey({ id: "dataset-b", importedAt: "first" }),
+  "parsing-warning dismissal remains independent per CSV",
+);
+
+const dismissedParsingWarnings = new Set([
+  getParsingWarningsMessageKey({ id: "dataset-a", importedAt: "first" }),
+]);
+assert.equal(
+  dismissedParsingWarnings.has(
+    getParsingWarningsMessageKey({ id: "dataset-a", importedAt: "first" }),
+  ),
+  true,
+  "reselecting the same CSV preserves its parsing-warning dismissal",
+);
+assert.equal(
+  dismissedParsingWarnings.has(
+    getParsingWarningsMessageKey({ id: "dataset-b", importedAt: "first" }),
+  ),
+  false,
+  "selecting a different CSV does not inherit another CSV's dismissal",
+);
+assert.equal(
+  dismissedParsingWarnings.has(
+    getParsingWarningsMessageKey({ id: "dataset-a", importedAt: "second" }),
+  ),
+  false,
+  "new parsing results are not hidden by an earlier dismissal",
+);
+
+console.log("Message dismissal state smoke checks passed.");


### PR DESCRIPTION
## Summary

- Add accessible close buttons to completed import messages, warnings, and dataset-operation errors
- Treat multi-file import results as one dismissible message group
- Preserve active import, initialization, and loading progress as non-dismissible
- Remember render-budget and per-CSV parsing-warning dismissal according to their required lifecycles
- Add focused smoke coverage for dismissal and reset behavior

## Testing

- `npm run smoke:message-dismissal`
- `npm run smoke:browser-sqlite-ui`
- `npm run smoke:data-source-normalization`
- `npm run lint`
- `npm run build`
- `npm run build:desktop`

Closes #122
