### PR TITLE
Allow marker cluster radius to be set to zero

### DIFF
--- a/docs/browser-parity-baseline.md
+++ b/docs/browser-parity-baseline.md
@@ -103,7 +103,7 @@ contract migration.
 
 ### Map and panel tools
 
-- Marker clustering is optional and uses the configured 1–300 pixel radius.
+- Marker clustering is optional and uses the configured 0–300 pixel radius. At radius 0, only exact coordinate matches cluster; nearby markers with different coordinates remain separate.
 - The map tools menu closes on an outside click or Escape.
 - The map supports the current blank, OpenStreetMap, imagery, and reference
   layer choices and the existing zoom/pan behavior.

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "smoke:browser-sqlite-data-source": "node src/data/browserSqlite/browserSqliteDataSource.smoke.js",
     "smoke:browser-sqlite-ui": "node src/components/browserSqliteUiCoordination.smoke.js",
     "smoke:message-dismissal": "node src/components/messageDismissalState.smoke.js",
+    "smoke:map-tools": "node src/components/mapToolsState.smoke.js",
     "smoke:marker-proximity": "node src/components/markerProximitySelection.smoke.js",
     "smoke:browser-sqlite-points": "node src/data/browserSqlite/browserSqlitePointQueries.smoke.js",
     "validate:browser-sqlite-worker": "node desktop/run-electron.cjs desktop/browserSqliteWorkerValidation.cjs",

--- a/src/components/GeoMap.jsx
+++ b/src/components/GeoMap.jsx
@@ -300,6 +300,7 @@ function ExactPointMarkers({
         // It progressively adds markers to the map instead of blocking the UI.
         chunkedLoading
         iconCreateFunction={createMarkerClusterIcon}
+        // Radius zero deliberately limits clustering to exact coordinate matches.
         maxClusterRadius={clusterRadius}
       >
         {points.map((point) => {
@@ -378,7 +379,8 @@ export default function GeoMap({
   regions = [],
   lines = [],
 
-  // When true, nearby markers are grouped into clusters (visual-only feature).
+  // When true, markers within the configured radius are clustered visually;
+  // radius zero limits clustering to markers with identical coordinates.
   // When false, markers are rendered normally (current behavior).
   getSourceRow,
   getFeatureDetails,

--- a/src/components/csv-panel/MapToolsMenu.jsx
+++ b/src/components/csv-panel/MapToolsMenu.jsx
@@ -1,5 +1,11 @@
 import { useCallback, useEffect, useRef } from "react";
 import { useSessionStorageState } from "../useSessionStorageState";
+import {
+  DEFAULT_CLUSTER_RADIUS,
+  MAX_CLUSTER_RADIUS,
+  MIN_CLUSTER_RADIUS,
+  normalizeClusterRadius,
+} from "../useMapToolsState";
 
 // Persisted UI tool state for the CSV panel.
 // - open: whether the dropdown is expanded
@@ -160,8 +166,8 @@ export default function MapToolsMenu({
                 <input
                   className="csvSelect"
                   type="number"
-                  min={1}
-                  max={300}
+                  min={MIN_CLUSTER_RADIUS}
+                  max={MAX_CLUSTER_RADIUS}
                   step={1}
                   // Draft value: can be edited freely without changing the map yet
                   value={mapToolsState?.clusterRadiusDraft ?? ""}
@@ -169,25 +175,19 @@ export default function MapToolsMenu({
                     onMapToolsPatch?.({ clusterRadiusDraft: e.target.value })
                   }
                   onBlur={() => {
-                    // When leaving the input:
-                    // - Parse the number
-                    // - Fix invalid values
-                    // - Clamp to a safe range
-                    // - Commit it as the real cluster radius
+                    // Apply the draft only when focus leaves the field so typing does
+                    // not repeatedly rebuild clusters. Zero remains valid because it
+                    // keeps exact-coordinate clustering without grouping nearby points.
                     const raw = mapToolsState?.clusterRadiusDraft;
-
-                    let n = Number.parseInt(String(raw ?? "").trim(), 10);
-                    if (!Number.isFinite(n)) {
-                      n = mapToolsState?.clusterRadius ?? 80;
-                    }
-
-                    // Clamp to a safe range
-                    n = Math.max(1, Math.min(300, n));
+                    const radius = normalizeClusterRadius(
+                      raw,
+                      mapToolsState?.clusterRadius ?? DEFAULT_CLUSTER_RADIUS,
+                    );
 
                     // Commit value only on blur (leave box)
                     onMapToolsPatch?.({
-                      clusterRadius: n,
-                      clusterRadiusDraft: n,
+                      clusterRadius: radius,
+                      clusterRadiusDraft: radius,
                     });
                   }}
                 />

--- a/src/components/mapToolsState.smoke.js
+++ b/src/components/mapToolsState.smoke.js
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import {
+  DEFAULT_CLUSTER_RADIUS,
+  MAX_CLUSTER_RADIUS,
+  MIN_CLUSTER_RADIUS,
+  getInitialMapToolsState,
+  normalizeClusterRadius,
+} from "./useMapToolsState.js";
+
+assert.equal(MIN_CLUSTER_RADIUS, 0);
+assert.equal(MAX_CLUSTER_RADIUS, 300);
+assert.equal(DEFAULT_CLUSTER_RADIUS, 80);
+
+assert.equal(normalizeClusterRadius("0", 80), 0);
+assert.equal(normalizeClusterRadius("-1", 80), 0);
+assert.equal(normalizeClusterRadius("300", 80), 300);
+assert.equal(normalizeClusterRadius("301", 80), 300);
+assert.equal(normalizeClusterRadius("12.9", 80), 12);
+assert.equal(normalizeClusterRadius("", 42), 42);
+assert.equal(normalizeClusterRadius("not-a-number", 42), 42);
+
+const initialState = getInitialMapToolsState();
+assert.equal(initialState.clusterMarkersEnabled, false);
+assert.equal(initialState.clusterRadius, DEFAULT_CLUSTER_RADIUS);
+assert.equal(initialState.clusterRadiusDraft, DEFAULT_CLUSTER_RADIUS);
+
+console.log("Map tools state smoke checks passed.");

--- a/src/components/useMapToolsState.js
+++ b/src/components/useMapToolsState.js
@@ -1,6 +1,23 @@
 import { useMemo, useState } from "react";
 
-const DEFAULT_CLUSTER_RADIUS = 80;
+export const MIN_CLUSTER_RADIUS = 0;
+export const MAX_CLUSTER_RADIUS = 300;
+export const DEFAULT_CLUSTER_RADIUS = 80;
+
+/**
+ * Convert an editable radius value into the integer accepted by marker clustering.
+ * Zero is intentionally valid: it clusters exact coordinate matches while leaving
+ * nearby markers with different coordinates separate.
+ */
+export function normalizeClusterRadius(raw, fallback = DEFAULT_CLUSTER_RADIUS) {
+  let radius = Number.parseInt(String(raw ?? "").trim(), 10);
+  if (!Number.isFinite(radius)) {
+    radius = fallback;
+  }
+
+  // Preserve zero's exact-coordinate behavior while enforcing the existing upper limit.
+  return Math.max(MIN_CLUSTER_RADIUS, Math.min(MAX_CLUSTER_RADIUS, radius));
+}
 
 /** Create the shared, non-persisted default state used by every runtime mode. */
 export function getInitialMapToolsState() {


### PR DESCRIPTION
## Summary

- Allow the marker cluster radius to be set from `0` through `300`
- Preserve existing decimal parsing, blank-input fallback, default radius, and upper limit
- Document that radius `0` clusters identical coordinates while keeping nearby coordinates separate
- Add focused smoke coverage for radius validation

## Testing

- `npm run smoke:map-tools`
- `npm run smoke:marker-proximity`
- `npm run lint`
- `npm run build`
- Manually verified radius `0`, clamping, identical-coordinate clustering, spiderfying, and nearby-marker separation

Closes #125
