### PR TITLE
Add coordinate copying and map navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "smoke:browser-sqlite-ui": "node src/components/browserSqliteUiCoordination.smoke.js",
     "smoke:message-dismissal": "node src/components/messageDismissalState.smoke.js",
     "smoke:map-tools": "node src/components/mapToolsState.smoke.js",
+    "smoke:coordinates": "node src/components/coordinateNavigation.smoke.js",
     "smoke:marker-proximity": "node src/components/markerProximitySelection.smoke.js",
     "smoke:browser-sqlite-points": "node src/data/browserSqlite/browserSqlitePointQueries.smoke.js",
     "validate:browser-sqlite-worker": "node desktop/run-electron.cjs desktop/browserSqliteWorkerValidation.cjs",

--- a/src/App.css
+++ b/src/App.css
@@ -471,6 +471,130 @@ button.csvBtnPrimary.csvDesktopImportButton {
   outline: none;
 }
 
+/* Pointer-anchored actions for copying or navigating to map coordinates. */
+.mapCoordinateContextMenu {
+  position: fixed;
+  z-index: 2200;
+  width: 240px;
+  padding: 4px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 8px;
+  background: rgba(15, 23, 42, 0.99);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
+}
+
+.mapCoordinateContextMenu button {
+  width: 100%;
+  padding: 7px 9px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: #e2e8f0;
+  text-align: left;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.mapCoordinateContextMenu button:hover,
+.mapCoordinateContextMenu button:focus-visible {
+  background: rgba(56, 189, 248, 0.18);
+  outline: none;
+}
+
+/* Modal coordinate entry remains above Leaflet controls and application overlays. */
+.mapCoordinateDialogBackdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 2300;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+  background: rgba(15, 23, 42, 0.5);
+}
+
+.mapCoordinateDialog {
+  width: min(360px, 100%);
+  padding: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 12px;
+  background: #0f172a;
+  color: #e2e8f0;
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.5);
+}
+
+.mapCoordinateDialog h2 {
+  margin: 0 0 14px;
+  font-size: 17px;
+}
+
+.mapCoordinateDialog form {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+
+.mapCoordinateDialog label {
+  margin-top: 4px;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.mapCoordinateDialog input {
+  width: 100%;
+  height: 34px;
+  padding: 0 9px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 8px;
+  background: rgba(2, 6, 23, 0.55);
+  color: #e2e8f0;
+  font: inherit;
+}
+
+.mapCoordinateDialog input:focus-visible {
+  border-color: #38bdf8;
+  outline: 2px solid rgba(56, 189, 248, 0.35);
+}
+
+.mapCoordinateDialog input[aria-invalid="true"] {
+  border-color: #f87171;
+}
+
+.mapCoordinateFieldError {
+  color: #fecaca;
+  font-size: 12px;
+}
+
+.mapCoordinateDialogActions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.mapCoordinateDialogActions button {
+  height: 32px;
+  min-width: 72px;
+  padding: 0 12px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 8px;
+  background: rgba(15, 23, 42, 0.8);
+  color: #e2e8f0;
+  cursor: pointer;
+}
+
+.mapCoordinateDialogActions .mapCoordinateGoButton {
+  border-color: rgba(56, 189, 248, 0.5);
+  background: rgba(56, 189, 248, 0.22);
+  font-weight: 700;
+}
+
+.mapCoordinateDialogActions button:hover,
+.mapCoordinateDialogActions button:focus-visible {
+  background: rgba(56, 189, 248, 0.3);
+  outline: none;
+}
+
 .csvFileNameButton {
   background: none;
   border: none;

--- a/src/components/GeoMap.jsx
+++ b/src/components/GeoMap.jsx
@@ -27,6 +27,7 @@ import "leaflet-polylinedecorator";
 
 import { getClusterMarkerIcon, getMarkerIcon } from "./markerIcons";
 import { buildMarkerDetailFields } from "./markerDetailFields";
+import MapCoordinateControls from "./MapCoordinateControls";
 import {
   findMarkersNearClickedMarker,
   MARKER_PROXIMITY_RADIUS_PIXELS,
@@ -439,6 +440,7 @@ export default function GeoMap({
       zoomControl={false}
     >
       <ViewportChangeReporter onViewportChange={onViewportChange} />
+      <MapCoordinateControls />
 
       {/* Zoom controls moved away from the CSV overlay */}
       <ZoomControl position="bottomright" />

--- a/src/components/MapCoordinateControls.jsx
+++ b/src/components/MapCoordinateControls.jsx
@@ -1,0 +1,226 @@
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { useMap } from "react-leaflet";
+import {
+  formatCoordinatePair,
+  parseCoordinatePaste,
+  validateCoordinateInputs,
+} from "./coordinateNavigation";
+
+const CONTEXT_MENU_WIDTH = 240;
+const CONTEXT_MENU_HEIGHT = 84;
+
+/** Keep the pointer-anchored map menu inside the visible viewport. */
+function getContextMenuPosition(clientX, clientY) {
+  const viewportWidth = globalThis.innerWidth ?? CONTEXT_MENU_WIDTH;
+  const viewportHeight = globalThis.innerHeight ?? CONTEXT_MENU_HEIGHT;
+  return {
+    left: Math.max(8, Math.min(clientX + 8, viewportWidth - CONTEXT_MENU_WIDTH - 8)),
+    top: Math.max(8, Math.min(clientY + 8, viewportHeight - CONTEXT_MENU_HEIGHT - 8)),
+  };
+}
+
+/** Add coordinate copying and fixed-zoom navigation to the active Leaflet map. */
+export default function MapCoordinateControls() {
+  const map = useMap();
+  const contextMenuRef = useRef(null);
+  const latitudeInputRef = useRef(null);
+  const [contextMenu, setContextMenu] = useState(null);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [latitude, setLatitude] = useState("");
+  const [longitude, setLongitude] = useState("");
+  const [errors, setErrors] = useState({ latitude: null, longitude: null });
+
+  useEffect(() => {
+    const mapContainer = map.getContainer();
+
+    /** Replace the browser menu and retain both the geographic and screen positions. */
+    function handleContextMenu(event) {
+      event.preventDefault();
+      const latLng = map.mouseEventToLatLng(event);
+      setContextMenu({
+        text: formatCoordinatePair(latLng.lat, latLng.lng),
+        ...getContextMenuPosition(event.clientX, event.clientY),
+      });
+    }
+
+    // Capture before Leaflet layers can stop bubbling from marker or overlay DOM.
+    mapContainer.addEventListener("contextmenu", handleContextMenu, true);
+    return () => mapContainer.removeEventListener("contextmenu", handleContextMenu, true);
+  }, [map]);
+
+  useEffect(() => {
+    if (!contextMenu) return undefined;
+
+    /** Close the map menu unless the pointer action occurred inside it. */
+    function handleOutsidePointerDown(event) {
+      if (!contextMenuRef.current?.contains(event.target)) setContextMenu(null);
+    }
+
+    /** Close the open map menu with the standard Escape interaction. */
+    function handleMenuKeyDown(event) {
+      if (event.key === "Escape") setContextMenu(null);
+    }
+
+    document.addEventListener("pointerdown", handleOutsidePointerDown, true);
+    document.addEventListener("keydown", handleMenuKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", handleOutsidePointerDown, true);
+      document.removeEventListener("keydown", handleMenuKeyDown);
+    };
+  }, [contextMenu]);
+
+  useEffect(() => {
+    if (!dialogOpen) return undefined;
+
+    latitudeInputRef.current?.focus();
+
+    /** Close the coordinate dialog without moving the map when Escape is pressed. */
+    function handleDialogKeyDown(event) {
+      if (event.key === "Escape") closeDialog();
+    }
+
+    document.addEventListener("keydown", handleDialogKeyDown);
+    return () => document.removeEventListener("keydown", handleDialogKeyDown);
+  }, [dialogOpen]);
+
+  /** Copy exactly the six-decimal coordinate string shown in the menu. */
+  async function copyCoordinates() {
+    const text = contextMenu?.text;
+    setContextMenu(null);
+    try {
+      if (!globalThis.navigator?.clipboard?.writeText) {
+        throw new Error("Clipboard writing is unavailable.");
+      }
+      await globalThis.navigator.clipboard.writeText(text);
+      // Successful copying deliberately has no toast or other user notification.
+    } catch (error) {
+      console.error("Could not copy map coordinates.", error);
+    }
+  }
+
+  /** Open a fresh coordinate dialog and discard values from any earlier visit. */
+  function openDialog() {
+    setContextMenu(null);
+    setLatitude("");
+    setLongitude("");
+    setErrors({ latitude: null, longitude: null });
+    setDialogOpen(true);
+  }
+
+  /** Close and reset the coordinate dialog without changing the map. */
+  function closeDialog() {
+    setDialogOpen(false);
+    setLatitude("");
+    setLongitude("");
+    setErrors({ latitude: null, longitude: null });
+  }
+
+  /** Split only complete supported coordinate pairs pasted into Latitude. */
+  function handleLatitudePaste(event) {
+    const pair = parseCoordinatePaste(event.clipboardData.getData("text"));
+    if (!pair) return;
+
+    // Prevent the ordinary paste only after the complete pair is recognized.
+    event.preventDefault();
+    setLatitude(pair.latitude);
+    setLongitude(pair.longitude);
+    setErrors({ latitude: null, longitude: null });
+  }
+
+  /** Validate both fields and centre the map while retaining its current zoom. */
+  function handleSubmit(event) {
+    event.preventDefault();
+    const result = validateCoordinateInputs(latitude, longitude);
+    setErrors(result.errors);
+    if (!result.ok) return;
+
+    map.setView([result.latitude, result.longitude], map.getZoom());
+    closeDialog();
+  }
+
+  if (typeof document === "undefined") return null;
+
+  return createPortal(
+    <>
+      {contextMenu && (
+        <div
+          ref={contextMenuRef}
+          className="mapCoordinateContextMenu"
+          style={{ left: contextMenu.left, top: contextMenu.top }}
+          role="menu"
+          aria-label="Map coordinate actions"
+        >
+          <button type="button" role="menuitem" onClick={copyCoordinates}>
+            {contextMenu.text}
+          </button>
+          <button type="button" role="menuitem" onClick={openDialog}>
+            Go to coordinates…
+          </button>
+        </div>
+      )}
+
+      {dialogOpen && (
+        <div className="mapCoordinateDialogBackdrop">
+          <div
+            className="mapCoordinateDialog"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="mapCoordinateDialogTitle"
+          >
+            <h2 id="mapCoordinateDialogTitle">Go to coordinates</h2>
+            <form onSubmit={handleSubmit} noValidate>
+              <label htmlFor="mapCoordinateLatitude">Latitude</label>
+              <input
+                ref={latitudeInputRef}
+                id="mapCoordinateLatitude"
+                type="text"
+                inputMode="decimal"
+                autoComplete="off"
+                value={latitude}
+                aria-invalid={!!errors.latitude}
+                aria-describedby={errors.latitude ? "mapCoordinateLatitudeError" : undefined}
+                onChange={(event) => {
+                  setLatitude(event.target.value);
+                  setErrors((current) => ({ ...current, latitude: null }));
+                }}
+                onPaste={handleLatitudePaste}
+              />
+              {errors.latitude && (
+                <div id="mapCoordinateLatitudeError" className="mapCoordinateFieldError">
+                  {errors.latitude}
+                </div>
+              )}
+
+              <label htmlFor="mapCoordinateLongitude">Longitude</label>
+              <input
+                id="mapCoordinateLongitude"
+                type="text"
+                inputMode="decimal"
+                autoComplete="off"
+                value={longitude}
+                aria-invalid={!!errors.longitude}
+                aria-describedby={errors.longitude ? "mapCoordinateLongitudeError" : undefined}
+                onChange={(event) => {
+                  setLongitude(event.target.value);
+                  setErrors((current) => ({ ...current, longitude: null }));
+                }}
+              />
+              {errors.longitude && (
+                <div id="mapCoordinateLongitudeError" className="mapCoordinateFieldError">
+                  {errors.longitude}
+                </div>
+              )}
+
+              <div className="mapCoordinateDialogActions">
+                <button type="button" onClick={closeDialog}>Cancel</button>
+                <button type="submit" className="mapCoordinateGoButton">Go</button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+    </>,
+    document.body,
+  );
+}

--- a/src/components/coordinateNavigation.js
+++ b/src/components/coordinateNavigation.js
@@ -1,0 +1,111 @@
+const DECIMAL_NUMBER_SOURCE = String.raw`[+-]?(?:\d+(?:\.\d+)?|\.\d+)`;
+const DECIMAL_NUMBER_PATTERN = new RegExp(`^${DECIMAL_NUMBER_SOURCE}$`);
+const DECIMAL_PAIR_PATTERN = new RegExp(
+  `^\\s*(${DECIMAL_NUMBER_SOURCE})\\s*[,;]\\s*(${DECIMAL_NUMBER_SOURCE})\\s*$`,
+);
+const DMS_PAIR_PATTERN = /^\s*(\d+)\s*°\s*(\d+)\s*['′]\s*(\d+(?:\.\d+)?)\s*["″]\s*([NS])\s+(\d+)\s*°\s*(\d+)\s*['′]\s*(\d+(?:\.\d+)?)\s*["″]\s*([EW])\s*$/i;
+
+/** Format one finite coordinate with the map menu's required precision. */
+function formatCoordinate(value) {
+  if (!Number.isFinite(value)) return "";
+  return value.toFixed(6);
+}
+
+/** Format a latitude-longitude pair exactly as it should be copied. */
+export function formatCoordinatePair(latitude, longitude) {
+  return `${formatCoordinate(latitude)}, ${formatCoordinate(longitude)}`;
+}
+
+/** Validate both coordinate fields without clamping either entered value. */
+export function validateCoordinateInputs(latitudeText, longitudeText) {
+  const latitude = validateCoordinate(latitudeText, "Latitude", -90, 90);
+  const longitude = validateCoordinate(longitudeText, "Longitude", -180, 180);
+
+  return {
+    ok: !latitude.error && !longitude.error,
+    latitude: latitude.value,
+    longitude: longitude.value,
+    errors: {
+      latitude: latitude.error,
+      longitude: longitude.error,
+    },
+  };
+}
+
+/** Recognize only complete supported decimal or Google Earth-style DMS pairs. */
+export function parseCoordinatePaste(text) {
+  if (typeof text !== "string" || /[\r\n]/.test(text)) return null;
+
+  const decimalPair = parseDecimalPair(text);
+  if (decimalPair) return decimalPair;
+
+  return parseDmsPair(text);
+}
+
+/** Parse a complete decimal pair while preserving the entered numeric precision. */
+function parseDecimalPair(text) {
+  const match = DECIMAL_PAIR_PATTERN.exec(text);
+  if (!match) return null;
+
+  return {
+    latitude: match[1],
+    longitude: match[2],
+  };
+}
+
+/** Convert one validated DMS coordinate to signed decimal degrees. */
+function convertDmsCoordinate(degreesText, minutesText, secondsText, hemisphere) {
+  const degrees = Number(degreesText);
+  const minutes = Number(minutesText);
+  const seconds = Number(secondsText);
+  if (minutes >= 60 || seconds >= 60) return null;
+
+  // Hemisphere is the sole sign source for DMS input, avoiding ambiguous signed degrees.
+  const sign = hemisphere === "S" || hemisphere === "W" ? -1 : 1;
+  return sign * (degrees + (minutes / 60) + (seconds / 3600));
+}
+
+/** Parse a complete latitude-then-longitude Google Earth-style DMS pair. */
+function parseDmsPair(text) {
+  const match = DMS_PAIR_PATTERN.exec(text);
+  if (!match) return null;
+
+  const latitude = convertDmsCoordinate(match[1], match[2], match[3], match[4].toUpperCase());
+  const longitude = convertDmsCoordinate(match[5], match[6], match[7], match[8].toUpperCase());
+  if (
+    latitude == null ||
+    longitude == null ||
+    latitude < -90 ||
+    latitude > 90 ||
+    longitude < -180 ||
+    longitude > 180
+  ) {
+    return null;
+  }
+
+  return {
+    latitude: formatCoordinate(latitude),
+    longitude: formatCoordinate(longitude),
+  };
+}
+
+/** Validate one complete decimal field against its coordinate range. */
+function validateCoordinate(text, label, minimum, maximum) {
+  const trimmed = typeof text === "string" ? text.trim() : "";
+  if (!trimmed) {
+    return { value: null, error: `${label} is required.` };
+  }
+  if (!DECIMAL_NUMBER_PATTERN.test(trimmed)) {
+    return { value: null, error: `${label} must be a decimal number.` };
+  }
+
+  const value = Number(trimmed);
+  if (!Number.isFinite(value) || value < minimum || value > maximum) {
+    return {
+      value: null,
+      error: `${label} must be between ${minimum} and ${maximum}.`,
+    };
+  }
+
+  return { value, error: null };
+}

--- a/src/components/coordinateNavigation.smoke.js
+++ b/src/components/coordinateNavigation.smoke.js
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import {
+  formatCoordinatePair,
+  parseCoordinatePaste,
+  validateCoordinateInputs,
+} from "./coordinateNavigation.js";
+
+assert.equal(
+  formatCoordinatePair(59.3293244, 18.0685806),
+  "59.329324, 18.068581",
+);
+assert.equal(
+  formatCoordinatePair(-33.8688, 151.2093),
+  "-33.868800, 151.209300",
+);
+assert.equal(
+  formatCoordinatePair(-0.0000001, -0.0000001),
+  "-0.000000, -0.000000",
+);
+
+for (const [latitude, longitude, expectedLatitude, expectedLongitude] of [
+  ["-90", "-180", -90, -180],
+  ["90", "180", 90, 180],
+  [" +59.25 ", " 18 ", 59.25, 18],
+  [".5", "-.5", 0.5, -0.5],
+]) {
+  const result = validateCoordinateInputs(latitude, longitude);
+  assert.equal(result.ok, true);
+  assert.equal(result.latitude, expectedLatitude);
+  assert.equal(result.longitude, expectedLongitude);
+}
+
+for (const [latitude, longitude] of [
+  ["", "18"],
+  ["59", ""],
+  ["1.", "18"],
+  ["59", "1e2"],
+  ["north", "18"],
+  ["90.0001", "18"],
+  ["59", "-180.0001"],
+]) {
+  assert.equal(validateCoordinateInputs(latitude, longitude).ok, false);
+}
+
+assert.deepEqual(
+  parseCoordinatePaste("59.93462512465285, 17.682585918325277"),
+  { latitude: "59.93462512465285", longitude: "17.682585918325277" },
+);
+assert.deepEqual(
+  parseCoordinatePaste(" 59.93462512465285;17.682585918325277 "),
+  { latitude: "59.93462512465285", longitude: "17.682585918325277" },
+);
+assert.deepEqual(
+  parseCoordinatePaste("-33.8688, 151.2093"),
+  { latitude: "-33.8688", longitude: "151.2093" },
+);
+
+for (const unsupported of [
+  "Latitude 59.1, Longitude 17.2",
+  "59.1, 17.2, 18.3",
+  "59.1,,17.2",
+  "59.1;;17.2",
+  "59.1,",
+  ",17.2",
+  "59.1 17.2",
+  "59.1|17.2",
+  "59,1;17,2",
+  "59.1,\n17.2",
+]) {
+  assert.equal(parseCoordinatePaste(unsupported), null);
+}
+
+assert.deepEqual(
+  parseCoordinatePaste(`18°27'58.17"N 3°42'40.54"W`),
+  { latitude: "18.466158", longitude: "-3.711261" },
+);
+assert.deepEqual(
+  parseCoordinatePaste(`14°33'52.62"S 17°23'51.63"E`),
+  { latitude: "-14.564617", longitude: "17.397675" },
+);
+assert.deepEqual(
+  parseCoordinatePaste(`52°57'23.53"N 10°09'21.70"E`),
+  { latitude: "52.956536", longitude: "10.156028" },
+);
+assert.deepEqual(
+  parseCoordinatePaste("052°057′023.53″N 010°009′021.70″E"),
+  { latitude: "52.956536", longitude: "10.156028" },
+);
+
+for (const unsupportedDms of [
+  `18°27'58.17"E 3°42'40.54"N`,
+  `18°60'00"N 3°42'40.54"W`,
+  `18°27'60"N 3°42'40.54"W`,
+  `91°00'00"N 3°42'40.54"W`,
+  `18°27'58.17"N 181°00'00"W`,
+  `18°27'N 3°42'40.54"W`,
+  `18°27'58.17"N`,
+]) {
+  assert.equal(parseCoordinatePaste(unsupportedDms), null);
+}
+
+console.log("Coordinate navigation smoke checks passed.");


### PR DESCRIPTION
## Summary

- Add a custom map context menu for copying right-clicked coordinates
- Add coordinate-based map navigation without changing the current zoom
- Support strict decimal coordinate-pair pasting with comma or semicolon separators
- Support Google Earth-style DMS coordinate-pair pasting
- Add coordinate validation and focused smoke-test coverage
- Preserve negative signs when coordinates round to six decimal places

## Testing

- `npm.cmd run smoke:coordinates`
- `npm.cmd run smoke:marker-proximity`
- `npm.cmd run lint`
- `npm.cmd run build`
- Manual browser smoke testing

Closes #128
