### PR TITLE
Add two-point map distance measurement tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "smoke:message-dismissal": "node src/components/messageDismissalState.smoke.js",
     "smoke:map-tools": "node src/components/mapToolsState.smoke.js",
     "smoke:coordinates": "node src/components/coordinateNavigation.smoke.js",
+    "smoke:distance-measurement": "node src/components/distanceMeasurement.smoke.js",
     "smoke:marker-proximity": "node src/components/markerProximitySelection.smoke.js",
     "smoke:browser-sqlite-points": "node src/data/browserSqlite/browserSqlitePointQueries.smoke.js",
     "validate:browser-sqlite-worker": "node desktop/run-electron.cjs desktop/browserSqliteWorkerValidation.cjs",

--- a/src/App.css
+++ b/src/App.css
@@ -471,7 +471,7 @@ button.csvBtnPrimary.csvDesktopImportButton {
   outline: none;
 }
 
-/* Pointer-anchored actions for copying or navigating to map coordinates. */
+/* Pointer-anchored actions for coordinates and temporary map measurements. */
 .mapCoordinateContextMenu {
   position: fixed;
   z-index: 2200;
@@ -498,6 +498,59 @@ button.csvBtnPrimary.csvDesktopImportButton {
 .mapCoordinateContextMenu button:hover,
 .mapCoordinateContextMenu button:focus-visible {
   background: rgba(56, 189, 248, 0.18);
+  outline: none;
+}
+
+/* White drag handles remain legible over both street and satellite tiles. */
+.mapDistanceEndpointIcon {
+  box-sizing: border-box;
+  border: 2px solid #0f172a;
+  border-radius: 50%;
+  background: #ffffff;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.55);
+}
+
+/* Keep measurement status visible inside the map while panning or zooming. */
+.mapDistanceInfo {
+  position: absolute;
+  z-index: 1000;
+  bottom: 12px;
+  left: 50%;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  max-width: calc(100% - 96px);
+  padding: 7px 8px 7px 11px;
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  border-radius: 8px;
+  background: rgba(15, 23, 42, 0.96);
+  color: #e2e8f0;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.35);
+  transform: translateX(-50%);
+  font-size: 13px;
+  overflow-wrap: anywhere;
+}
+
+.mapDistanceInfo button {
+  display: grid;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: 0;
+  border-radius: 5px;
+  background: transparent;
+  color: #e2e8f0;
+  cursor: pointer;
+  place-items: center;
+  font: inherit;
+  font-size: 18px;
+  line-height: 1;
+}
+
+.mapDistanceInfo button:hover,
+.mapDistanceInfo button:focus-visible {
+  background: rgba(248, 113, 113, 0.24);
   outline: none;
 }
 

--- a/src/components/MapCoordinateControls.jsx
+++ b/src/components/MapCoordinateControls.jsx
@@ -1,14 +1,28 @@
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { useMap } from "react-leaflet";
+import L from "leaflet";
+import { Marker, Polyline, useMap } from "react-leaflet";
 import {
   formatCoordinatePair,
   parseCoordinatePaste,
   validateCoordinateInputs,
 } from "./coordinateNavigation";
+import {
+  cancelIncompleteDistanceMeasurement,
+  clearDistanceMeasurement,
+  completeDistanceMeasurement,
+  formatMetricDistance,
+  moveDistanceEndpoint,
+  startDistanceMeasurement,
+} from "./distanceMeasurement";
 
 const CONTEXT_MENU_WIDTH = 240;
-const CONTEXT_MENU_HEIGHT = 84;
+const CONTEXT_MENU_HEIGHT = 116;
+const DISTANCE_ENDPOINT_ICON = L.divIcon({
+  className: "mapDistanceEndpointIcon",
+  iconAnchor: [7, 7],
+  iconSize: [14, 14],
+});
 
 /** Keep the pointer-anchored map menu inside the visible viewport. */
 function getContextMenuPosition(clientX, clientY) {
@@ -20,7 +34,32 @@ function getContextMenuPosition(clientX, clientY) {
   };
 }
 
-/** Add coordinate copying and fixed-zoom navigation to the active Leaflet map. */
+/** Keep measurement instructions and cleanup available inside the visible map. */
+function DistanceMeasurementInfo({ children, onClear }) {
+  const infoRef = useRef(null);
+
+  useEffect(() => {
+    if (!infoRef.current) return;
+    // Prevent information-box actions from placing an endpoint or moving the map.
+    L.DomEvent.disableClickPropagation(infoRef.current);
+    L.DomEvent.disableScrollPropagation(infoRef.current);
+  }, []);
+
+  return (
+    <div ref={infoRef} className="mapDistanceInfo" role="status">
+      <span>{children}</span>
+      <button
+        type="button"
+        aria-label="Clear distance measurement"
+        onClick={onClear}
+      >
+        ×
+      </button>
+    </div>
+  );
+}
+
+/** Add shared coordinate and distance actions to the active Leaflet map. */
 export default function MapCoordinateControls() {
   const map = useMap();
   const contextMenuRef = useRef(null);
@@ -30,6 +69,7 @@ export default function MapCoordinateControls() {
   const [latitude, setLatitude] = useState("");
   const [longitude, setLongitude] = useState("");
   const [errors, setErrors] = useState({ latitude: null, longitude: null });
+  const [measurement, setMeasurement] = useState(null);
 
   useEffect(() => {
     const mapContainer = map.getContainer();
@@ -40,6 +80,7 @@ export default function MapCoordinateControls() {
       const latLng = map.mouseEventToLatLng(event);
       setContextMenu({
         text: formatCoordinatePair(latLng.lat, latLng.lng),
+        latLng: { lat: latLng.lat, lng: latLng.lng },
         ...getContextMenuPosition(event.clientX, event.clientY),
       });
     }
@@ -71,6 +112,35 @@ export default function MapCoordinateControls() {
   }, [contextMenu]);
 
   useEffect(() => {
+    if (!measurement || measurement.end) return undefined;
+
+    /** Complete the active measurement with exactly one ordinary map click. */
+    function handleMapClick(event) {
+      setMeasurement((current) => completeDistanceMeasurement(
+        current,
+        { lat: event.latlng.lat, lng: event.latlng.lng },
+      ));
+    }
+
+    map.on("click", handleMapClick);
+    return () => map.off("click", handleMapClick);
+  }, [map, measurement]);
+
+  useEffect(() => {
+    if (!measurement || measurement.end) return undefined;
+
+    /** Let Escape cancel only a measurement that is waiting for its endpoint. */
+    function handleMeasurementKeyDown(event) {
+      if (event.key === "Escape") {
+        setMeasurement(cancelIncompleteDistanceMeasurement);
+      }
+    }
+
+    document.addEventListener("keydown", handleMeasurementKeyDown);
+    return () => document.removeEventListener("keydown", handleMeasurementKeyDown);
+  }, [measurement]);
+
+  useEffect(() => {
     if (!dialogOpen) return undefined;
 
     latitudeInputRef.current?.focus();
@@ -97,6 +167,26 @@ export default function MapCoordinateControls() {
     } catch (error) {
       console.error("Could not copy map coordinates.", error);
     }
+  }
+
+  /** Replace any previous measurement with the context-menu position. */
+  function startMeasurement() {
+    const start = contextMenu?.latLng;
+    setContextMenu(null);
+    if (start) setMeasurement(startDistanceMeasurement(start));
+  }
+
+  /** Update one geographic endpoint continuously during a marker drag. */
+  function handleEndpointDrag(endpoint, event) {
+    const latLng = event.target.getLatLng();
+    // Geographic state keeps the measurement stable through map pans and zooms.
+    setMeasurement((current) => moveDistanceEndpoint(current, endpoint, latLng));
+  }
+
+  /** Remove the complete temporary measurement without touching map or dataset state. */
+  function clearMeasurement() {
+    // Every measurement layer derives from this one state object and unmounts together.
+    setMeasurement(clearDistanceMeasurement());
   }
 
   /** Open a fresh coordinate dialog and discard values from any earlier visit. */
@@ -141,8 +231,53 @@ export default function MapCoordinateControls() {
 
   if (typeof document === "undefined") return null;
 
-  return createPortal(
+  const distanceText = measurement?.end
+    // Leaflet calculates geographic distance from latitude and longitude.
+    ? `Total distance: ${formatMetricDistance(map.distance(measurement.start, measurement.end))}`
+    : "Click the map to place the second point.";
+
+  return (
     <>
+      {measurement && (
+        <>
+          <Marker
+            position={measurement.start}
+            icon={DISTANCE_ENDPOINT_ICON}
+            draggable={!!measurement.end}
+            bubblingMouseEvents={false}
+            eventHandlers={{
+              drag: (event) => handleEndpointDrag("start", event),
+            }}
+          />
+          {measurement.end && (
+            <>
+              <Polyline
+                positions={[measurement.start, measurement.end]}
+                pathOptions={{ color: "#0284c7", weight: 4, opacity: 0.95 }}
+                interactive={false}
+              />
+              <Marker
+                position={measurement.end}
+                icon={DISTANCE_ENDPOINT_ICON}
+                draggable
+                bubblingMouseEvents={false}
+                eventHandlers={{
+                  drag: (event) => handleEndpointDrag("end", event),
+                }}
+              />
+            </>
+          )}
+          {createPortal(
+            <DistanceMeasurementInfo onClear={clearMeasurement}>
+              {distanceText}
+            </DistanceMeasurementInfo>,
+            map.getContainer(),
+          )}
+        </>
+      )}
+
+      {createPortal(
+        <>
       {contextMenu && (
         <div
           ref={contextMenuRef}
@@ -156,6 +291,9 @@ export default function MapCoordinateControls() {
           </button>
           <button type="button" role="menuitem" onClick={openDialog}>
             Go to coordinates…
+          </button>
+          <button type="button" role="menuitem" onClick={startMeasurement}>
+            Measure distance
           </button>
         </div>
       )}
@@ -220,7 +358,9 @@ export default function MapCoordinateControls() {
           </div>
         </div>
       )}
-    </>,
-    document.body,
+        </>,
+        document.body,
+      )}
+    </>
   );
 }

--- a/src/components/distanceMeasurement.js
+++ b/src/components/distanceMeasurement.js
@@ -1,0 +1,38 @@
+/** Format a geographic distance with compact metric units. */
+export function formatMetricDistance(distanceMeters) {
+  if (distanceMeters < 1000) {
+    return `${Math.round(distanceMeters)} m`;
+  }
+
+  return `${(distanceMeters / 1000).toFixed(2)} km`;
+}
+
+/** Start a fresh two-point measurement at one geographic endpoint. */
+export function startDistanceMeasurement(start) {
+  return { start: { ...start }, end: null };
+}
+
+/** Place the second endpoint once and ignore later map clicks. */
+export function completeDistanceMeasurement(measurement, end) {
+  if (!measurement || measurement.end) return measurement;
+  return { ...measurement, end: { ...end } };
+}
+
+/** Move one endpoint of a completed measurement while preserving the other. */
+export function moveDistanceEndpoint(measurement, endpoint, position) {
+  if (!measurement?.end || (endpoint !== "start" && endpoint !== "end")) {
+    return measurement;
+  }
+
+  return { ...measurement, [endpoint]: { ...position } };
+}
+
+/** Cancel only a measurement that is still waiting for its second endpoint. */
+export function cancelIncompleteDistanceMeasurement(measurement) {
+  return measurement && !measurement.end ? null : measurement;
+}
+
+/** Clear the sole temporary measurement and all UI derived from it. */
+export function clearDistanceMeasurement() {
+  return null;
+}

--- a/src/components/distanceMeasurement.smoke.js
+++ b/src/components/distanceMeasurement.smoke.js
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import {
+  cancelIncompleteDistanceMeasurement,
+  clearDistanceMeasurement,
+  completeDistanceMeasurement,
+  formatMetricDistance,
+  moveDistanceEndpoint,
+  startDistanceMeasurement,
+} from "./distanceMeasurement.js";
+
+assert.equal(formatMetricDistance(0), "0 m");
+assert.equal(formatMetricDistance(849.6), "850 m");
+assert.equal(formatMetricDistance(999.4), "999 m");
+assert.equal(formatMetricDistance(1000), "1.00 km");
+assert.equal(formatMetricDistance(23750), "23.75 km");
+assert.equal(formatMetricDistance(2252290), "2252.29 km");
+
+const firstStart = { lat: 59.3293, lng: 18.0686 };
+const replacementStart = { lat: 57.7089, lng: 11.9746 };
+const end = { lat: 55.605, lng: 13.0038 };
+
+const unfinished = startDistanceMeasurement(firstStart);
+assert.deepEqual(unfinished, { start: firstStart, end: null });
+assert.notEqual(unfinished.start, firstStart);
+
+const replacement = startDistanceMeasurement(replacementStart);
+assert.deepEqual(replacement, { start: replacementStart, end: null });
+
+const completed = completeDistanceMeasurement(replacement, end);
+assert.deepEqual(completed, { start: replacementStart, end });
+assert.strictEqual(
+  completeDistanceMeasurement(completed, firstStart),
+  completed,
+);
+
+const movedStart = moveDistanceEndpoint(completed, "start", firstStart);
+assert.deepEqual(movedStart, { start: firstStart, end });
+assert.deepEqual(moveDistanceEndpoint(movedStart, "end", replacementStart), {
+  start: firstStart,
+  end: replacementStart,
+});
+
+assert.equal(cancelIncompleteDistanceMeasurement(unfinished), null);
+assert.strictEqual(cancelIncompleteDistanceMeasurement(completed), completed);
+assert.equal(clearDistanceMeasurement(), null);
+
+console.log("Distance measurement smoke checks passed.");


### PR DESCRIPTION
## Summary

Adds a two-point distance measurement tool to the map context menu.

- Uses the right-clicked map position as the first endpoint
- Places the second endpoint with the next map click
- Displays two draggable endpoint markers and a connecting line
- Updates the geographic distance continuously while dragging
- Displays metres below 1 km and kilometres at or above 1 km
- Provides an accessible button for clearing the measurement
- Allows Escape to cancel an unfinished measurement
- Keeps measurements temporary and independent of imported data

## Testing

- Added focused smoke tests for measurement state and metric formatting
- Verified coordinate-navigation smoke tests
- Verified endpoint placement, dragging, replacement, cancellation, and cleanup manually
- ESLint passes
- Production build passes

Closes #129
