### PR TITLE
Add Save as CSV for loaded datasets

### DIFF
--- a/desktop/main.cjs
+++ b/desktop/main.cjs
@@ -11,6 +11,7 @@ const {
   setSqliteDatasetEnabled,
 } = require("./sqliteDatasetService.cjs");
 const { closeSqliteStore, openSqliteStore } = require("./sqliteStore.cjs");
+const { exportSqliteDatasetCsv } = require("./sqliteDatasetExport.cjs");
 const { querySqliteMapView } = require("./sqliteViewportQuery.cjs");
 const {
   getSqliteLogicalZone,
@@ -129,6 +130,47 @@ function registerDesktopBridgeHandlers() {
       closeSqliteStore(db);
     }
   });
+  ipcMain.handle("desktop:saveDatasetAsCsv", async (event, request = {}) => {
+    const requestedDatasetId = typeof request?.datasetId === "string"
+      ? request.datasetId.trim()
+      : null;
+    let exported;
+
+    try {
+      const db = openDesktopSqliteStore();
+      try {
+        // Serialize before opening the dialog so no partial output can precede a failure.
+        exported = exportSqliteDatasetCsv({ db, datasetId: requestedDatasetId });
+      } finally {
+        closeSqliteStore(db);
+      }
+
+      const owner = BrowserWindow.fromWebContents(event.sender);
+      const saveResult = await dialog.showSaveDialog(owner, {
+        title: "Save CSV dataset",
+        defaultPath: exported.fileName,
+        filters: [
+          { name: "CSV files", extensions: ["csv"] },
+          { name: "All files", extensions: ["*"] },
+        ],
+      });
+
+      if (saveResult.canceled || !saveResult.filePath) {
+        return { ok: false, canceled: true, datasetId: exported.datasetId };
+      }
+
+      writeUtf8FileAtomically(saveResult.filePath, exported.csvText);
+      return {
+        ok: true,
+        canceled: false,
+        datasetId: exported.datasetId,
+        fileName: path.basename(saveResult.filePath),
+      };
+    } catch {
+      // Raw paths, SQLite details, and filesystem errors never cross the preload boundary.
+      return { ok: false, canceled: false, datasetId: requestedDatasetId };
+    }
+  });
   ipcMain.handle('desktop:getFeatureDetails', async (_event, query = {}) => {
     // Keep SQLite access in the main process and return full rows only on demand.
     const db = openDesktopSqliteStore();
@@ -186,6 +228,25 @@ function registerDesktopBridgeHandlers() {
 function sendCsvImportProgress(event, progress) {
   if (!event?.sender || event.sender.isDestroyed()) return;
   event.sender.send("desktop:csvImportProgress", progress);
+}
+
+/** Write beside the destination, then replace it only after UTF-8 output succeeds. */
+function writeUtf8FileAtomically(destination, contents) {
+  const temporaryPath = path.join(
+    path.dirname(destination),
+    `.${path.basename(destination)}.${process.pid}.${Date.now()}.tmp`,
+  );
+  try {
+    fs.writeFileSync(temporaryPath, contents, { encoding: "utf8", flag: "wx" });
+    fs.renameSync(temporaryPath, destination);
+  } catch (error) {
+    try {
+      if (fs.existsSync(temporaryPath)) fs.unlinkSync(temporaryPath);
+    } catch {
+      // Cleanup failure must not replace the original export error.
+    }
+    throw error;
+  }
 }
 
 /**

--- a/desktop/preload.cjs
+++ b/desktop/preload.cjs
@@ -34,6 +34,10 @@ contextBridge.exposeInMainWorld("csvMapDesktop", {
     "desktop:removeDataset",
     { datasetId },
   ),
+  saveDatasetAsCsv: (datasetId) => ipcRenderer.invoke(
+    "desktop:saveDatasetAsCsv",
+    { datasetId },
+  ),
   // Expose structured lookup requests without exposing SQLite or raw SQL.
   getFeatureDetails: (query) => ipcRenderer.invoke('desktop:getFeatureDetails', query),
   getGroupRows: (query) => ipcRenderer.invoke('desktop:getGroupRows', query),

--- a/desktop/sqliteDatasetExport.cjs
+++ b/desktop/sqliteDatasetExport.cjs
@@ -1,0 +1,87 @@
+"use strict";
+
+const Papa = require("papaparse");
+
+/** Reconstruct one desktop dataset from its current committed SQLite rows. */
+function exportSqliteDatasetCsv({ db, datasetId } = {}) {
+  requireOpenDatabase(db);
+  const normalizedId = requireString(datasetId);
+  const dataset = db.prepare(`
+    SELECT file_name, columns_json
+    FROM datasets
+    WHERE id = ?
+  `).get(normalizedId);
+
+  if (!dataset) throw new Error("The requested dataset is unavailable.");
+
+  const headers = parseHeaders(dataset.columns_json);
+  const storedRows = db.prepare(`
+    SELECT row_json
+    FROM features
+    WHERE dataset_id = ?
+    ORDER BY source_row_index
+  `).all(normalizedId);
+
+  // Zone commits update the original coordinate keys in row_json. Header-driven
+  // arrays therefore retain those coordinates and exclude every internal column.
+  const rows = storedRows.map((stored) => {
+    const row = parseStoredRow(stored.row_json);
+    return headers.map((header) => row[header] ?? "");
+  });
+
+  return {
+    datasetId: normalizedId,
+    fileName: ensureCsvExtension(dataset.file_name),
+    csvText: Papa.unparse({ fields: headers, data: rows }),
+  };
+}
+
+/** Parse and validate the persisted import-time column ordering. */
+function parseHeaders(value) {
+  const headers = parseJson(value);
+  if (
+    !Array.isArray(headers)
+    || headers.length === 0
+    || !headers.every((header) => typeof header === "string" && header.length > 0)
+  ) throw new Error("Stored CSV columns are unavailable.");
+  return headers;
+}
+
+/** Parse one accepted source row without accepting internal or array-shaped data. */
+function parseStoredRow(value) {
+  const row = parseJson(value);
+  if (!row || typeof row !== "object" || Array.isArray(row)) {
+    throw new Error("Stored CSV row data is unavailable.");
+  }
+  return row;
+}
+
+/** Parse stored JSON and convert corruption into an export-level failure. */
+function parseJson(value) {
+  try {
+    return JSON.parse(String(value ?? ""));
+  } catch {
+    throw new Error("Stored CSV data is unavailable.");
+  }
+}
+
+/** Keep the imported display name while ensuring the Save As type is CSV. */
+function ensureCsvExtension(value) {
+  const fileName = requireString(value);
+  return /\.csv$/i.test(fileName) ? fileName : `${fileName}.csv`;
+}
+
+/** Reject missing identifiers before preparing any dataset-specific query. */
+function requireString(value) {
+  if (typeof value === "string" && value.trim()) return value.trim();
+  throw new TypeError("A dataset ID is required.");
+}
+
+/** Require the narrow better-sqlite3 surface used by this read-only service. */
+function requireOpenDatabase(db) {
+  if (!db?.open || typeof db.prepare !== "function") {
+    throw new TypeError("An open SQLite database is required.");
+  }
+}
+
+module.exports = { exportSqliteDatasetCsv };

--- a/desktop/sqliteDatasetExport.smoke.cjs
+++ b/desktop/sqliteDatasetExport.smoke.cjs
@@ -1,0 +1,76 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const Papa = require("papaparse");
+const { exportSqliteDatasetCsv } = require("./sqliteDatasetExport.cjs");
+const { closeSqliteStore, openSqliteStore } = require("./sqliteStore.cjs");
+
+const db = openSqliteStore(":memory:");
+
+try {
+  const headers = ["featureType", "featureId", "part", "lat", "lon", "name", "empty"];
+  insertDataset("selected", "desktop-loaded", headers, 3);
+  insertDataset("other", "other.csv", ["name", "lat", "lon"], 1);
+  insertRows("selected", [
+    {
+      featureType: "region", featureId: "zone", part: "main",
+      lat: "60.25", lon: "19.5", name: "Åland, \"adjusted\"\nzone", empty: "",
+    },
+    {
+      featureType: "line", featureId: "route", part: "",
+      lat: "59", lon: "18", name: "Route", empty: "",
+    },
+    {
+      featureType: "marker", featureId: "point", part: "",
+      lat: "58", lon: "17", name: "Marker", empty: "",
+    },
+  ]);
+  insertRows("other", [{ name: "must-not-export", lat: "1", lon: "2" }]);
+
+  const exported = exportSqliteDatasetCsv({ db, datasetId: "selected" });
+  assert.equal(exported.datasetId, "selected");
+  assert.equal(exported.fileName, "desktop-loaded.csv");
+  assert.equal(exported.csvText.includes("must-not-export"), false);
+  assert.equal(exported.csvText.includes("source_row_index"), false);
+
+  const parsed = Papa.parse(exported.csvText, { header: true, skipEmptyLines: true });
+  assert.deepEqual(parsed.meta.fields, headers);
+  assert.deepEqual(parsed.data.map((row) => row.featureType), ["region", "line", "marker"]);
+  assert.equal(parsed.data[0].lat, "60.25");
+  assert.equal(parsed.data[0].name, "Åland, \"adjusted\"\nzone");
+  assert.equal(parsed.data[0].empty, "");
+  assert.throws(() => exportSqliteDatasetCsv({ db, datasetId: "missing" }));
+} finally {
+  closeSqliteStore(db);
+}
+
+console.log("Desktop SQLite dataset CSV export smoke test passed.");
+
+/** Insert desktop dataset metadata with its import-time column ordering. */
+function insertDataset(id, fileName, headers, rowCount) {
+  db.prepare(`
+    INSERT INTO datasets (
+      id, file_name, row_count, imported_feature_count, skipped_row_count,
+      columns_json, imported_at
+    ) VALUES (?, ?, ?, ?, 0, ?, '2026-08-09T00:00:00.000Z')
+  `).run(id, fileName, rowCount, rowCount, JSON.stringify(headers));
+}
+
+/** Insert accepted desktop rows in stable original source order. */
+function insertRows(datasetId, rows) {
+  const statement = db.prepare(`
+    INSERT INTO features (
+      id, dataset_id, source_row_index, lat, lon, compact_json, row_json
+    ) VALUES (?, ?, ?, ?, ?, '{}', ?)
+  `);
+  rows.forEach((row, index) => {
+    statement.run(
+      `${datasetId}:${index}`,
+      datasetId,
+      index,
+      Number(row.lat),
+      Number(row.lon),
+      JSON.stringify(row),
+    );
+  });
+}

--- a/desktop/sqliteZoneService.smoke.cjs
+++ b/desktop/sqliteZoneService.smoke.cjs
@@ -2,6 +2,8 @@
 
 const assert = require("node:assert/strict");
 const Database = require("better-sqlite3");
+const Papa = require("papaparse");
+const { exportSqliteDatasetCsv } = require("./sqliteDatasetExport.cjs");
 const { initializeSchema } = require("./sqliteStore.cjs");
 const { querySqliteMapView } = require("./sqliteViewportQuery.cjs");
 const {
@@ -17,7 +19,10 @@ try {
     INSERT INTO datasets (
       id, file_name, row_count, imported_feature_count, skipped_row_count,
       columns_json, imported_at
-    ) VALUES ('dataset-a', 'zones.csv', 6, 6, 0, '[]', '2026-08-08T00:00:00.000Z')
+    ) VALUES (
+      'dataset-a', 'zones.csv', 6, 6, 0, '["name","lat","lon"]',
+      '2026-08-08T00:00:00.000Z'
+    )
   `).run();
   const insert = db.prepare(`
     INSERT INTO features (
@@ -72,6 +77,11 @@ try {
     db.prepare("SELECT lat, lon FROM features WHERE id = 'dataset-a:0'").get(),
     { lat: 2, lon: 3 },
   );
+  const exportedRows = Papa.parse(
+    exportSqliteDatasetCsv({ db, datasetId: "dataset-a" }).csvText,
+    { header: true, skipEmptyLines: true },
+  ).data;
+  assert.deepEqual(exportedRows[0], { name: "Zone", lat: "2", lon: "3" });
 
   db.exec(`
     CREATE TRIGGER fail_zone_update BEFORE UPDATE ON geometry_features

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "smoke:browser-sqlite-database": "node src/data/browserSqlite/browserSqliteDatabase.smoke.js",
     "smoke:browser-sqlite-dataset-mutations": "node src/data/browserSqlite/browserSqliteDatasetMutations.smoke.js",
     "smoke:browser-sqlite-dataset-queries": "node src/data/browserSqlite/browserSqliteDatasetQueries.smoke.js",
+    "smoke:browser-sqlite-dataset-export": "node src/data/browserSqlite/browserSqliteDatasetExport.smoke.js",
     "smoke:browser-sqlite-dataset-removal": "node src/data/browserSqlite/browserSqliteDatasetRemoval.smoke.js",
     "smoke:browser-sqlite-import-transaction": "node src/data/browserSqlite/browserSqliteImportTransaction.smoke.js",
     "smoke:browser-sqlite-importer": "node src/data/browserSqlite/browserSqliteImporter.smoke.js",
@@ -38,6 +39,7 @@
     "smoke:desktop-data-source": "node src/data/desktopSqliteDataSource.smoke.js",
     "smoke:runtime-data-source": "node src/data/runtimeDataSource.smoke.js",
     "smoke:sqlite-datasets": "electron desktop/sqliteDatasetService.smoke.cjs",
+    "smoke:sqlite-export": "electron desktop/sqliteDatasetExport.smoke.cjs",
     "smoke:sqlite-store": "electron desktop/sqliteStore.smoke.cjs",
     "smoke:sqlite-viewport": "node desktop/sqliteViewportQuery.smoke.cjs",
     "smoke:sqlite-zone": "electron desktop/sqliteZoneService.smoke.cjs",
@@ -46,7 +48,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "smoke:browser-sqlite-geometries": "node src/data/browserSqlite/browserSqliteGeometryQueries.smoke.js",
-    "smoke:browser-sqlite": "npm run smoke:browser-sqlite-database && npm run smoke:browser-sqlite-dataset-mutations && npm run smoke:browser-sqlite-dataset-queries && npm run smoke:browser-sqlite-dataset-removal && npm run smoke:browser-sqlite-import-transaction && npm run smoke:browser-sqlite-importer && npm run smoke:browser-sqlite-import-batch && npm run smoke:browser-sqlite-protocol && npm run smoke:browser-sqlite-worker-runtime && npm run smoke:browser-sqlite-worker-client && npm run smoke:browser-sqlite-data-source && npm run smoke:browser-sqlite-ui && npm run smoke:browser-sqlite-points && npm run smoke:browser-sqlite-geometries"
+    "smoke:browser-sqlite": "npm run smoke:browser-sqlite-database && npm run smoke:browser-sqlite-dataset-mutations && npm run smoke:browser-sqlite-dataset-queries && npm run smoke:browser-sqlite-dataset-export && npm run smoke:browser-sqlite-dataset-removal && npm run smoke:browser-sqlite-import-transaction && npm run smoke:browser-sqlite-importer && npm run smoke:browser-sqlite-import-batch && npm run smoke:browser-sqlite-protocol && npm run smoke:browser-sqlite-worker-runtime && npm run smoke:browser-sqlite-worker-client && npm run smoke:browser-sqlite-data-source && npm run smoke:browser-sqlite-ui && npm run smoke:browser-sqlite-points && npm run smoke:browser-sqlite-geometries"
   },
   "dependencies": {
     "better-sqlite3": "^12.11.1",

--- a/src/App.css
+++ b/src/App.css
@@ -471,6 +471,11 @@ button.csvBtnPrimary.csvDesktopImportButton {
   outline: none;
 }
 
+.csvTimelineContextMenu button:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
 /* Pointer-anchored actions for coordinates and temporary map measurements. */
 .mapCoordinateContextMenu {
   position: fixed;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -78,6 +78,10 @@ export default function App() {
     pendingDatasetIds: [],
     error: null,
   });
+  const [datasetExportState, setDatasetExportState] = useState({
+    pendingDatasetIds: [],
+    error: null,
+  });
   const [databaseMappingState, setDatabaseMappingState] = useState({
     pendingDatasetId: null,
     error: null,
@@ -141,6 +145,11 @@ export default function App() {
     setDesktopRemovalState((current) => ({ ...current, error: null }));
   }, []);
 
+  /** Hide the current CSV export error without changing any stored rows. */
+  const dismissDatasetExportError = useCallback(() => {
+    setDatasetExportState((current) => ({ ...current, error: null }));
+  }, []);
+
   /** Hide the current mapping error while preserving the last valid mapping. */
   const dismissDatasetMappingError = useCallback(() => {
     setDatabaseMappingState((current) => ({ ...current, error: null }));
@@ -168,11 +177,13 @@ export default function App() {
     datasetLoad: dismissDatasetLoadError,
     datasetMutation: dismissDatasetMutationError,
     datasetRemoval: dismissDatasetRemovalError,
+    datasetExport: dismissDatasetExportError,
     datasetQuery: dismissDatasetQueryError,
     mapping: dismissDatasetMappingError,
     preview: dismissDatasetPreviewError,
   }), [
     dismissDatasetLoadError,
+    dismissDatasetExportError,
     dismissDatasetMappingError,
     dismissDatasetMutationError,
     dismissDatasetPreviewError,
@@ -188,6 +199,8 @@ export default function App() {
     usesViewportQueries && desktopCapabilities.datasetVisibility;
   const desktopDatasetRemovalAvailable =
     usesViewportQueries && desktopCapabilities.datasetRemoval;
+  const datasetCsvExportAvailable =
+    usesViewportQueries && desktopCapabilities.datasetCsvExport;
 
   useEffect(() => {
     if (
@@ -253,6 +266,8 @@ export default function App() {
         mutationError: desktopVisibilityState.error,
         pendingRemovalDatasetIds: desktopRemovalState.pendingDatasetIds,
         removalError: desktopRemovalState.error,
+        pendingExportDatasetIds: datasetExportState.pendingDatasetIds,
+        exportError: datasetExportState.error,
         queryError: desktopMapViewState.error,
       }
     : {
@@ -263,6 +278,8 @@ export default function App() {
         mutationError: null,
         pendingRemovalDatasetIds: [],
         removalError: null,
+        pendingExportDatasetIds: [],
+        exportError: null,
         queryError: null,
       };
 
@@ -516,6 +533,39 @@ export default function App() {
     dataSource,
     databaseSelectedId,
   ]);
+
+  /** Save only the requested dataset while treating dialog cancellation as success. */
+  const saveDatasetAsCsv = useCallback(async (datasetId) => {
+    if (!datasetCsvExportAvailable) return;
+    setDatasetExportState((current) => ({
+      pendingDatasetIds: current.pendingDatasetIds.includes(datasetId)
+        ? current.pendingDatasetIds
+        : [...current.pendingDatasetIds, datasetId],
+      error: null,
+    }));
+
+    try {
+      const result = await dataSource.saveDatasetAsCsv(datasetId);
+      if (!result.ok && !result.canceled) {
+        throw new Error(result.error?.message ?? "Could not save the CSV dataset.");
+      }
+      setDatasetExportState((current) => ({
+        pendingDatasetIds: current.pendingDatasetIds.filter(
+          (pendingId) => pendingId !== datasetId,
+        ),
+        error: null,
+      }));
+    } catch (error) {
+      setDatasetExportState((current) => ({
+        pendingDatasetIds: current.pendingDatasetIds.filter(
+          (pendingId) => pendingId !== datasetId,
+        ),
+        error: error?.message
+          ? String(error.message)
+          : "Could not save the CSV dataset.",
+      }));
+    }
+  }, [dataSource, datasetCsvExportAvailable]);
 
   /** Rebuild one dataset mapping while retaining its last valid UI state on failure. */
   const updateDatabaseMapping = useCallback(async (datasetId, mapping) => {
@@ -877,6 +927,9 @@ export default function App() {
             viewportQueryStats={viewportQueryStats}
             onUnloadFile={desktopDatasetRemovalAvailable
               ? removeDesktopDataset
+              : undefined}
+            onSaveAsCsv={datasetCsvExportAvailable
+              ? saveDatasetAsCsv
               : undefined}
             removeActionLabel="Remove"
             onToggleEnabled={desktopDatasetVisibilityAvailable

--- a/src/components/CsvPanel.jsx
+++ b/src/components/CsvPanel.jsx
@@ -17,6 +17,7 @@ import { getParsingWarningsMessageKey } from "./messageDismissalState";
  * - Select one CSV file for preview in browser mode
  * - Enable or disable CSV files for map display
  * - Unload browser files or remove desktop datasets
+ * - Save one loaded dataset's current SQLite state as CSV
  * - Preview basic metadata and a few rows in browser mode
  *
  * This component does NOT parse CSV files itself.
@@ -35,6 +36,7 @@ export default function CsvPanel({
   messageDismissal,
   onLoadMorePreview,
   onUnloadFile,     // Callback to unload a CSV by ID
+  onSaveAsCsv,      // Callback to save the current SQLite rows for one CSV
   removeActionLabel,
   onToggleEnabled,  // Callback to toggle file visibility
   onUpdateMapping,  // Callback when user changes latitude/longitude fields
@@ -193,6 +195,7 @@ export default function CsvPanel({
             datasetListState={datasetListState}
             viewportQueryStats={viewportQueryStats}
             onUnloadFile={onUnloadFile}
+            onSaveAsCsv={onSaveAsCsv}
             removeActionLabel={removeActionLabel}
             onToggleEnabled={onToggleEnabled}
             onUseRecommendedTimelineRange={useRecommendedTimelineRange}

--- a/src/components/csv-panel/CsvFileControls.jsx
+++ b/src/components/csv-panel/CsvFileControls.jsx
@@ -15,6 +15,7 @@ export default function CsvFileControls({
   datasetListState,
   viewportQueryStats,
   onUnloadFile,
+  onSaveAsCsv,
   removeActionLabel = "Unload",
   onToggleEnabled,
   onUseRecommendedTimelineRange,
@@ -45,6 +46,7 @@ export default function CsvFileControls({
   const canSelect = typeof onSelect === "function";
   const canToggleEnabled = typeof onToggleEnabled === "function";
   const canRemove = typeof onUnloadFile === "function";
+  const canSaveAsCsv = typeof onSaveAsCsv === "function";
   const hasTerminalImportMessage = !isDesktopImporting && (
     desktopImportResults.length > 0 ||
     desktopImport?.status === "canceled" ||
@@ -59,7 +61,7 @@ export default function CsvFileControls({
     });
   }, [hiddenByRenderBudget]);
 
-  /** Close the custom recommendation menu on outside interaction or Escape. */
+  /** Close the dataset-row context menu on outside interaction or Escape. */
   useEffect(() => {
     if (!contextMenu) return undefined;
 
@@ -116,16 +118,17 @@ export default function CsvFileControls({
     setHoverMessage(null);
   }
 
-  /** Open a custom menu only when the imported CSV has a stored recommendation. */
+  /** Open the existing dataset menu with actions scoped to the right-clicked row. */
   function handleRowContextMenu(event, file) {
     const range = file.recommendedTimelineRange;
-    if (!range) return;
+    if (!range && !canSaveAsCsv) return;
 
     event.preventDefault();
     clearHoverMessage();
     setContextMenu({
+      datasetId: file.id,
       range,
-      ...getFloatingPosition(event.clientX, event.clientY, 360, 44),
+      ...getFloatingPosition(event.clientX, event.clientY, 360, range ? 80 : 44),
     });
   }
 
@@ -298,6 +301,16 @@ export default function CsvFileControls({
             {datasetListState.removalError}
           </DismissibleMessage>
         )}
+        {datasetListState?.exportError && (
+          <DismissibleMessage
+            className="csvDesktopImportStatus csvDesktopImportStatusError"
+            dismissLabel="Dismiss CSV save error"
+            onDismiss={messageDismissal?.datasetExport}
+            role="alert"
+          >
+            {datasetListState.exportError}
+          </DismissibleMessage>
+        )}
         {datasetListState?.queryError && (
           <DismissibleMessage
             className="csvDesktopImportStatus csvDesktopImportStatusError"
@@ -385,19 +398,37 @@ export default function CsvFileControls({
           className="csvTimelineContextMenu"
           style={{ left: contextMenu.left, top: contextMenu.top }}
           role="menu"
-          aria-label="CSV timeline actions"
+          aria-label="CSV dataset actions"
         >
-          <button
-            type="button"
-            role="menuitem"
-            onClick={() => {
-              // Apply all four values together so the slider never sees a mixed range.
-              onUseRecommendedTimelineRange?.(contextMenu.range);
-              setContextMenu(null);
-            }}
-          >
-            Use recommended timeline range: {formatTimelineRange(contextMenu.range)}
-          </button>
+          {contextMenu.range && (
+            <button
+              type="button"
+              role="menuitem"
+              onClick={() => {
+                // Apply all four values together so the slider never sees a mixed range.
+                onUseRecommendedTimelineRange?.(contextMenu.range);
+                setContextMenu(null);
+              }}
+            >
+              Use recommended timeline range: {formatTimelineRange(contextMenu.range)}
+            </button>
+          )}
+          {canSaveAsCsv && (
+            <button
+              type="button"
+              role="menuitem"
+              disabled={datasetListState?.pendingExportDatasetIds?.includes(
+                contextMenu.datasetId,
+              )}
+              onClick={() => {
+                // Capture the row identity before closing so selection never redirects export.
+                onSaveAsCsv(contextMenu.datasetId);
+                setContextMenu(null);
+              }}
+            >
+              Save as CSV…
+            </button>
+          )}
         </div>
       )}
     </>

--- a/src/data/browserSqlite/browserSqliteDataSource.js
+++ b/src/data/browserSqlite/browserSqliteDataSource.js
@@ -5,6 +5,7 @@ import {
 import {
   normalizeBackendCapabilities,
   normalizeBackendFailure,
+  normalizeDatasetCsvSaveResult,
   normalizeDatasetMutationResult,
   normalizeDatasetSummary,
   normalizeImportBatchResult,
@@ -38,6 +39,7 @@ const CAPABILITIES = normalizeBackendCapabilities({
   datasetSelection: true,
   datasetVisibility: true,
   datasetRemoval: true,
+  datasetCsvExport: true,
   datasetMapping: true,
   previewPaging: true,
   points: true,
@@ -51,6 +53,7 @@ const CAPABILITIES = normalizeBackendCapabilities({
 export function createBrowserSqliteDataSource(options = {}) {
   const fetchImpl = options.fetchImpl ?? globalThis.fetch;
   const baseUrl = options.baseUrl ?? import.meta.env?.BASE_URL ?? '/';
+  const downloadCsv = options.downloadCsv ?? downloadBrowserCsv;
   let workerClient = options.client ?? null;
   let clientCreationFailed = false;
   if (!workerClient) {
@@ -246,6 +249,25 @@ export function createBrowserSqliteDataSource(options = {}) {
       }
     },
 
+    /** Serialize in the worker, then start a renderer-safe local download. */
+    async saveDatasetAsCsv(datasetId) {
+      assertActive(DATA_SOURCE_METHODS.saveDatasetAsCsv);
+      const normalizedId = normalizeId(datasetId);
+      if (!normalizedId) return normalizeDatasetCsvSaveResult(null, normalizedId);
+      try {
+        const exported = await workerClient.exportDatasetCsv(normalizedId);
+        // The renderer handles only a completed CSV payload and never database access.
+        downloadCsv(exported.csvText, exported.fileName);
+        return normalizeDatasetCsvSaveResult({
+          ok: true,
+          datasetId: exported.datasetId,
+          fileName: exported.fileName,
+        }, normalizedId);
+      } catch (error) {
+        return failedDatasetCsvSave(normalizedId, error);
+      }
+    },
+
     async updateDatasetMapping(datasetId, mapping = {}) {
       assertActive(DATA_SOURCE_METHODS.updateDatasetMapping);
       const normalizedId = normalizeId(datasetId) ?? '';
@@ -434,6 +456,35 @@ function failedDatasetMutation(operation, datasetId, error) {
     dataset: null,
     error: workerFailure(operation, error, { datasetId }),
   };
+}
+
+/** Convert worker or download failures into the shared safe save result. */
+function failedDatasetCsvSave(datasetId, error) {
+  const result = normalizeDatasetCsvSaveResult(null, datasetId);
+  return {
+    ...result,
+    error: workerFailure(DATA_SOURCE_METHODS.saveDatasetAsCsv, error, { datasetId }),
+  };
+}
+
+/** Download a completed UTF-8 CSV using APIs available on GitHub Pages. */
+function downloadBrowserCsv(csvText, fileName) {
+  if (typeof csvText !== 'string' || typeof fileName !== 'string' || !fileName) {
+    throw new TypeError('A serialized CSV and filename are required.');
+  }
+  const url = URL.createObjectURL(new Blob([csvText], { type: 'text/csv;charset=utf-8' }));
+  const link = document.createElement('a');
+  try {
+    link.href = url;
+    link.download = fileName;
+    link.hidden = true;
+    document.body.append(link);
+    link.click();
+  } finally {
+    link.remove();
+    // Revocation is deferred so the browser can begin consuming the object URL.
+    globalThis.setTimeout(() => URL.revokeObjectURL(url), 0);
+  }
 }
 
 function unsupportedImport(operation) {

--- a/src/data/browserSqlite/browserSqliteDataSource.smoke.js
+++ b/src/data/browserSqlite/browserSqliteDataSource.smoke.js
@@ -115,6 +115,15 @@ class FakeWorkerClient {
     });
   }
 
+  exportDatasetCsv(datasetId) {
+    this.calls.push(['exportDatasetCsv', datasetId]);
+    return this.result({
+      datasetId,
+      fileName: 'first.csv',
+      csvText: 'name\nFirst',
+    });
+  }
+
   updateDatasetMapping(datasetId, mapping) {
     this.calls.push(['updateDatasetMapping', datasetId, mapping]);
     if (this.failure) return Promise.reject(this.failure);
@@ -208,8 +217,10 @@ class FakeWorkerClient {
 }
 
 const client = new FakeWorkerClient();
+const downloads = [];
 const dataSource = createBrowserSqliteDataSource({
   client,
+  downloadCsv: (csvText, fileName) => downloads.push({ csvText, fileName }),
   baseUrl: '/',
   fetchImpl: async (url) => ({
     ok: url === '/examples/present-day/books.csv',
@@ -235,6 +246,7 @@ assert.equal(initialized.capabilities.lines, true);
 assert.equal(initialized.capabilities.regions, true);
 assert.equal(initialized.capabilities.groupedViewportResults, true);
 assert.equal(initialized.capabilities.zoneEditing, true);
+assert.equal(initialized.capabilities.datasetCsvExport, true);
 assert.deepEqual(dataSource.getCapabilities(), initialized.capabilities);
 
 const observedProgress = [];
@@ -294,6 +306,11 @@ assert.equal(disabled.ok, true);
 assert.equal(disabled.dataset.enabled, false);
 const invalidVisibility = await dataSource.setDatasetEnabled('', false);
 assert.equal(invalidVisibility.ok, false);
+const saved = await dataSource.saveDatasetAsCsv('dataset-1');
+assert.equal(saved.ok, true);
+assert.equal(saved.fileName, 'first.csv');
+assert.deepEqual(downloads, [{ csvText: 'name\nFirst', fileName: 'first.csv' }]);
+assert.deepEqual(client.calls.at(-1), ['exportDatasetCsv', 'dataset-1']);
 const mapped = await dataSource.updateDatasetMapping('dataset-2', {
   latField: 'lat',
   lonField: 'lon',

--- a/src/data/browserSqlite/browserSqliteDatasetExport.js
+++ b/src/data/browserSqlite/browserSqliteDatasetExport.js
@@ -1,0 +1,105 @@
+import Papa from 'papaparse';
+
+/** Reconstruct one complete browser dataset from committed source rows. */
+export function exportBrowserSqliteDatasetCsv(database, datasetId) {
+  requireDatabase(database);
+  const normalizedId = normalizeRequiredString(datasetId);
+  const dataset = readOne(database, `
+    SELECT file_name, columns_json
+    FROM datasets
+    WHERE id = ? AND import_state = 'complete'
+  `, [normalizedId]);
+
+  if (!dataset) throw datasetExportError('dataset-not-found');
+
+  const headers = parseHeaders(dataset.columns_json);
+  const storedRows = readAll(database, `
+    SELECT row_json
+    FROM source_rows
+    WHERE dataset_id = ?
+    ORDER BY source_row_index
+  `, [normalizedId]);
+
+  // Zone commits update the original coordinate keys in row_json. Header-driven
+  // arrays therefore preserve those coordinates and omit every SQLite field.
+  const rows = storedRows.map((stored) => {
+    const row = parseStoredRow(stored.row_json);
+    return headers.map((header) => row[header] ?? '');
+  });
+
+  return {
+    datasetId: normalizedId,
+    fileName: ensureCsvExtension(dataset.file_name),
+    csvText: Papa.unparse({ fields: headers, data: rows }),
+  };
+}
+
+/** Read one metadata row without exposing a live statement. */
+function readOne(database, sql, parameters) {
+  return readAll(database, sql, parameters, 1)[0] ?? null;
+}
+
+/** Read ordered sql.js rows and always release the prepared statement. */
+function readAll(database, sql, parameters = [], maximumRows = Infinity) {
+  const statement = database.prepare(sql);
+  const rows = [];
+  try {
+    statement.bind(parameters);
+    while (rows.length < maximumRows && statement.step()) {
+      rows.push(statement.getAsObject());
+    }
+  } finally {
+    statement.free();
+  }
+  return rows;
+}
+
+/** Parse the persisted import-time header order used for serialization. */
+function parseHeaders(value) {
+  try {
+    const parsed = JSON.parse(String(value ?? ''));
+    if (
+      Array.isArray(parsed)
+      && parsed.length > 0
+      && parsed.every((header) => typeof header === 'string' && header.length > 0)
+    ) return parsed;
+  } catch {
+    // Invalid stored metadata is reported as one safe export failure below.
+  }
+  throw datasetExportError('operation-failed');
+}
+
+/** Parse one complete source row and reject corrupted non-object JSON. */
+function parseStoredRow(value) {
+  try {
+    const parsed = JSON.parse(String(value ?? ''));
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) return parsed;
+  } catch {
+    // Invalid stored row data is reported as one safe export failure below.
+  }
+  throw datasetExportError('operation-failed');
+}
+
+/** Keep the imported display name while ensuring a usable CSV download name. */
+function ensureCsvExtension(value) {
+  const fileName = normalizeRequiredString(value);
+  return /\.csv$/i.test(fileName) ? fileName : `${fileName}.csv`;
+}
+
+/** Normalize dataset metadata and reject empty identifiers or filenames. */
+function normalizeRequiredString(value) {
+  if (typeof value === 'string' && value.trim()) return value.trim();
+  throw datasetExportError('operation-failed');
+}
+
+/** Require the narrow sql.js surface needed by the export query. */
+function requireDatabase(database) {
+  if (!database || typeof database.prepare !== 'function') {
+    throw new TypeError('A sql.js database with prepare() is required.');
+  }
+}
+
+/** Create a worker-safe error code without attaching SQLite details. */
+function datasetExportError(code) {
+  return Object.assign(new Error('The selected CSV dataset could not be exported.'), { code });
+}

--- a/src/data/browserSqlite/browserSqliteDatasetExport.smoke.js
+++ b/src/data/browserSqlite/browserSqliteDatasetExport.smoke.js
@@ -1,0 +1,90 @@
+import assert from 'node:assert/strict';
+import Papa from 'papaparse';
+import initSqlJs from 'sql.js';
+import {
+  closeBrowserSqliteDatabase,
+  createBrowserSqliteDatabase,
+} from './browserSqliteDatabase.js';
+import { exportBrowserSqliteDatasetCsv } from './browserSqliteDatasetExport.js';
+
+const SQL = await initSqlJs();
+const database = createBrowserSqliteDatabase(SQL);
+
+try {
+  const headers = [
+    'featureType', 'featureId', 'part', 'order', 'lat', 'lon', 'name', 'empty',
+  ];
+  insertDataset(database, 'selected', 'loaded-data', headers, 3);
+  insertDataset(database, 'other', 'other.csv', ['name'], 1);
+  insertRows(database, 'selected', [
+    {
+      featureType: 'region', featureId: 'zone-1', part: 'main', order: '0',
+      lat: '60.25', lon: '19.5', name: 'Malmö, "old"\nquarter', empty: '',
+    },
+    {
+      featureType: 'region', featureId: 'zone-1', part: 'island', order: '1',
+      lat: '61', lon: '20', name: 'Island', empty: '',
+    },
+    {
+      featureType: 'marker', featureId: 'marker-1', part: '', order: '',
+      lat: '59', lon: '18', name: 'Marker', empty: '',
+    },
+  ]);
+  insertRows(database, 'other', [{ name: 'must-not-export' }]);
+
+  const exported = exportBrowserSqliteDatasetCsv(database, 'selected');
+  assert.equal(exported.datasetId, 'selected');
+  assert.equal(exported.fileName, 'loaded-data.csv');
+  assert.equal(exported.csvText.includes('must-not-export'), false);
+  assert.equal(exported.csvText.includes('dataset_id'), false);
+  assert.equal(exported.csvText.includes('source_row_index'), false);
+
+  const parsed = Papa.parse(exported.csvText, { header: true, skipEmptyLines: true });
+  assert.deepEqual(parsed.meta.fields, headers);
+  assert.deepEqual(parsed.data, [
+    {
+      featureType: 'region', featureId: 'zone-1', part: 'main', order: '0',
+      lat: '60.25', lon: '19.5', name: 'Malmö, "old"\nquarter', empty: '',
+    },
+    {
+      featureType: 'region', featureId: 'zone-1', part: 'island', order: '1',
+      lat: '61', lon: '20', name: 'Island', empty: '',
+    },
+    {
+      featureType: 'marker', featureId: 'marker-1', part: '', order: '',
+      lat: '59', lon: '18', name: 'Marker', empty: '',
+    },
+  ]);
+
+  assert.throws(
+    () => exportBrowserSqliteDatasetCsv(database, 'missing'),
+    (error) => error?.code === 'dataset-not-found',
+  );
+} finally {
+  closeBrowserSqliteDatabase(database);
+}
+
+console.log('Browser SQLite dataset CSV export smoke test passed.');
+
+/** Insert complete dataset metadata using the same stored header representation as import. */
+function insertDataset(target, id, fileName, headers, rowCount) {
+  target.run(`
+    INSERT INTO datasets (
+      id, file_name, columns_json, total_parsed_row_count, stored_row_count,
+      skipped_row_count, import_state, imported_at
+    ) VALUES (?, ?, ?, ?, ?, 0, 'complete', '2026-08-09T00:00:00.000Z')
+  `, [id, fileName, JSON.stringify(headers), rowCount, rowCount]);
+}
+
+/** Insert source rows in the order the export must preserve. */
+function insertRows(target, datasetId, rows) {
+  const statement = target.prepare(`
+    INSERT INTO source_rows (dataset_id, source_row_index, row_json)
+    VALUES (?, ?, ?)
+  `);
+  try {
+    rows.forEach((row, index) => statement.run([datasetId, index, JSON.stringify(row)]));
+  } finally {
+    statement.free();
+  }
+}

--- a/src/data/browserSqlite/browserSqliteGeometryQueries.smoke.js
+++ b/src/data/browserSqlite/browserSqliteGeometryQueries.smoke.js
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import Papa from 'papaparse';
 import initSqlJs from 'sql.js';
 import {
   closeBrowserSqliteDatabase,
@@ -19,6 +20,7 @@ import {
 import {
   getBrowserSqliteDatasetSummary,
 } from './browserSqliteDatasetQueries.js';
+import { exportBrowserSqliteDatasetCsv } from './browserSqliteDatasetExport.js';
 import {
   getBrowserSqliteFeatureDetails,
 } from './browserSqlitePointDetails.js';
@@ -458,6 +460,12 @@ try {
     SELECT row_json FROM source_rows
     WHERE dataset_id = 'dataset-zone-edit' AND source_row_index = 0
   `)).lon, '3');
+  const exportedZoneRows = Papa.parse(
+    exportBrowserSqliteDatasetCsv(database, 'dataset-zone-edit').csvText,
+    { header: true, skipEmptyLines: true },
+  ).data;
+  assert.equal(exportedZoneRows[0].lat, '2');
+  assert.equal(exportedZoneRows[0].lon, '3');
 
   const committedZone = structuredClone(updatedZone);
   database.run(`

--- a/src/data/browserSqlite/browserSqliteProtocol.js
+++ b/src/data/browserSqlite/browserSqliteProtocol.js
@@ -11,6 +11,7 @@ export const BROWSER_SQLITE_OPERATIONS = Object.freeze({
   GET_DATASET_SUMMARY: 'get-dataset-summary',
   SET_DATASET_ENABLED: 'set-dataset-enabled',
   REMOVE_DATASET: 'remove-dataset',
+  EXPORT_DATASET_CSV: 'export-dataset-csv',
   UPDATE_DATASET_MAPPING: 'update-dataset-mapping',
   GET_PREVIEW_PAGE: 'get-preview-page',
   QUERY_MAP_VIEW: 'query-map-view',
@@ -231,6 +232,7 @@ function normalizeOperationPayload(operation, payload) {
     case BROWSER_SQLITE_OPERATIONS.SET_DATASET_ENABLED:
       return normalizeDatasetEnabledPayload(payload);
     case BROWSER_SQLITE_OPERATIONS.REMOVE_DATASET:
+    case BROWSER_SQLITE_OPERATIONS.EXPORT_DATASET_CSV:
       return normalizeDatasetIdPayload(payload);
     case BROWSER_SQLITE_OPERATIONS.UPDATE_DATASET_MAPPING:
       return normalizeDatasetMappingPayload(payload);

--- a/src/data/browserSqlite/browserSqliteProtocol.smoke.js
+++ b/src/data/browserSqlite/browserSqliteProtocol.smoke.js
@@ -91,6 +91,20 @@ assert.deepEqual(validateBrowserSqliteRequest({
   operation: 'remove-dataset',
   payload: { datasetId: 'dataset-1' },
 });
+assertProtocolError(() => validateBrowserSqliteRequest({
+  requestId: 'request-export-path',
+  operation: BROWSER_SQLITE_OPERATIONS.EXPORT_DATASET_CSV,
+  payload: { datasetId: 'dataset-1', path: 'C:\\private\\export.csv' },
+}), 'invalid-request');
+assert.deepEqual(validateBrowserSqliteRequest({
+  requestId: 'request-export',
+  operation: BROWSER_SQLITE_OPERATIONS.EXPORT_DATASET_CSV,
+  payload: { datasetId: 'dataset-1' },
+}), {
+  requestId: 'request-export',
+  operation: 'export-dataset-csv',
+  payload: { datasetId: 'dataset-1' },
+});
 assert.deepEqual(validateBrowserSqliteRequest({
   requestId: 'request-mapping',
   operation: BROWSER_SQLITE_OPERATIONS.UPDATE_DATASET_MAPPING,
@@ -503,6 +517,7 @@ assert.deepEqual(
     'get-dataset-summary',
     'set-dataset-enabled',
     'remove-dataset',
+    'export-dataset-csv',
     'update-dataset-mapping',
     'get-preview-page',
     'query-map-view',

--- a/src/data/browserSqlite/browserSqliteWorkerClient.js
+++ b/src/data/browserSqlite/browserSqliteWorkerClient.js
@@ -241,6 +241,11 @@ export function createBrowserSqliteWorkerClient(options = {}) {
     return sendRequest(BROWSER_SQLITE_OPERATIONS.REMOVE_DATASET, { datasetId });
   }
 
+  /** Request one complete serialized dataset from the worker-owned database. */
+  function exportDatasetCsv(datasetId) {
+    return sendRequest(BROWSER_SQLITE_OPERATIONS.EXPORT_DATASET_CSV, { datasetId });
+  }
+
   function updateDatasetMapping(datasetId, mapping) {
     return sendRequest(BROWSER_SQLITE_OPERATIONS.UPDATE_DATASET_MAPPING, {
       datasetId,
@@ -323,6 +328,7 @@ export function createBrowserSqliteWorkerClient(options = {}) {
     getDatasetSummary,
     setDatasetEnabled,
     removeDataset,
+    exportDatasetCsv,
     updateDatasetMapping,
     getPreviewPage,
     queryMapView,

--- a/src/data/browserSqlite/browserSqliteWorkerClient.smoke.js
+++ b/src/data/browserSqlite/browserSqliteWorkerClient.smoke.js
@@ -199,6 +199,16 @@ assert.deepEqual(worker.posted.at(-1).payload, {
   datasetId: 'dataset-1',
   enabled: false,
 });
+await completeSuccess(worker, client.exportDatasetCsv('dataset-1'), {
+  datasetId: 'dataset-1',
+  fileName: 'dataset.csv',
+  csvText: 'name\nPlace',
+});
+assert.equal(
+  worker.posted.at(-1).operation,
+  BROWSER_SQLITE_OPERATIONS.EXPORT_DATASET_CSV,
+);
+assert.deepEqual(worker.posted.at(-1).payload, { datasetId: 'dataset-1' });
 await completeSuccess(
   worker,
   client.updateDatasetMapping('dataset-1', {

--- a/src/data/browserSqlite/browserSqliteWorkerRuntime.js
+++ b/src/data/browserSqlite/browserSqliteWorkerRuntime.js
@@ -14,6 +14,7 @@ import {
 import {
   removeBrowserSqliteDataset,
 } from './browserSqliteDatasetRemoval.js';
+import { exportBrowserSqliteDatasetCsv } from './browserSqliteDatasetExport.js';
 import {
   importBrowserSqliteCsvBatch,
 } from './browserSqliteImportBatch.js';
@@ -147,6 +148,12 @@ export function createBrowserSqliteWorkerRuntime({
         );
       case BROWSER_SQLITE_OPERATIONS.REMOVE_DATASET:
         return removeBrowserSqliteDataset(
+          requireDatabase(database),
+          request.payload.datasetId,
+        );
+      case BROWSER_SQLITE_OPERATIONS.EXPORT_DATASET_CSV:
+        // Worker serialization reads committed rows without copying them into app state.
+        return exportBrowserSqliteDatasetCsv(
           requireDatabase(database),
           request.payload.datasetId,
         );

--- a/src/data/browserSqlite/browserSqliteWorkerRuntime.smoke.js
+++ b/src/data/browserSqlite/browserSqliteWorkerRuntime.smoke.js
@@ -120,6 +120,14 @@ try {
     lat: '59.3',
     lon: '18.1',
   }]);
+  const exported = await runtime.handleMessage(request(
+    'export-first',
+    BROWSER_SQLITE_OPERATIONS.EXPORT_DATASET_CSV,
+    { datasetId: firstDatasetId },
+  ));
+  assert.equal(exported.result.fileName, 'first.csv');
+  assert.equal(exported.result.csvText.includes('First,59.3,18.1'), true);
+  assert.equal(exported.result.csvText.includes('dataset_id'), false);
   const disabled = await runtime.handleMessage(request(
     'disable-first',
     BROWSER_SQLITE_OPERATIONS.SET_DATASET_ENABLED,

--- a/src/data/dataSource.js
+++ b/src/data/dataSource.js
@@ -21,6 +21,7 @@ export const DATA_SOURCE_METHODS = Object.freeze({
   selectDataset: "selectDataset",
   setDatasetEnabled: "setDatasetEnabled",
   removeDataset: "removeDataset",
+  saveDatasetAsCsv: "saveDatasetAsCsv",
   updateDatasetMapping: "updateDatasetMapping",
   getPreviewPage: "getPreviewPage",
   queryMapView: "queryMapView",
@@ -83,6 +84,9 @@ export const BACKEND_FAILURE_CATEGORIES = Object.freeze({
  *   Enables or disables one dataset.
  * @property {(datasetId: string) => DatasetMutationResult | Promise<DatasetMutationResult>} removeDataset
  *   Removes one dataset from the active backend without modifying its source file.
+ * @property {(datasetId: string) => DatasetCsvSaveResult | Promise<DatasetCsvSaveResult>} saveDatasetAsCsv
+ *   Saves one dataset's current committed SQLite rows without exposing runtime
+ *   filesystem or database access to presentation code.
  * @property {(datasetId: string, mapping: CoordinateMapping) => MappingMutationResult | Promise<MappingMutationResult>} updateDatasetMapping
  *   Changes coordinate fields and returns normalized detected timeline metadata.
  * @property {(query: PreviewPageQuery) => PreviewPageResult | Promise<PreviewPageResult>} getPreviewPage
@@ -145,6 +149,7 @@ export const BACKEND_FAILURE_CATEGORIES = Object.freeze({
  * @property {boolean} datasetSelection
  * @property {boolean} datasetVisibility
  * @property {boolean} datasetRemoval
+ * @property {boolean} datasetCsvExport
  * @property {boolean} datasetMapping
  * @property {boolean} previewPaging
  * @property {boolean} points
@@ -204,6 +209,18 @@ export const BACKEND_FAILURE_CATEGORIES = Object.freeze({
  * @property {number} skippedRowCount
  * @property {string[]} warnings
  * @property {DetectedFields|null} detectedFields
+ * @property {BackendFailure|null} error
+ */
+
+/**
+ * Expected cancellation is distinct from export failure so the UI can remain
+ * silent when a native Save As dialog is dismissed.
+ *
+ * @typedef {object} DatasetCsvSaveResult
+ * @property {boolean} ok
+ * @property {boolean} canceled
+ * @property {string|null} datasetId
+ * @property {string|null} fileName
  * @property {BackendFailure|null} error
  */
 

--- a/src/data/dataSourceNormalization.js
+++ b/src/data/dataSourceNormalization.js
@@ -39,6 +39,7 @@ const CAPABILITY_KEYS = [
   'datasetSelection',
   'datasetVisibility',
   'datasetRemoval',
+  'datasetCsvExport',
   'datasetMapping',
   'previewPaging',
   'points',
@@ -310,6 +311,30 @@ export function normalizeDatasetMutationResult(value, context = {}) {
           message: context.message ?? 'The selected dataset is unavailable.',
           recoverable: true,
           datasetId,
+        }),
+  };
+}
+
+/** Normalize one runtime-specific CSV save without exposing paths or raw errors. */
+export function normalizeDatasetCsvSaveResult(value, datasetId) {
+  const source = isRecord(value) ? value : {};
+  const normalizedDatasetId = normalizeNullableId(datasetId ?? source.datasetId);
+  const canceled = source.canceled === true;
+  const ok = source.ok === true && !canceled;
+
+  return {
+    ok,
+    canceled,
+    datasetId: normalizedDatasetId,
+    fileName: ok ? normalizeDisplayName(source.fileName) : null,
+    error: ok || canceled
+      ? null
+      : normalizeBackendFailure(source.error, {
+          category: BACKEND_FAILURE_CATEGORIES.QUERY_FAILED,
+          operation: DATA_SOURCE_METHODS.saveDatasetAsCsv,
+          message: 'The selected CSV dataset could not be saved.',
+          recoverable: true,
+          datasetId: normalizedDatasetId,
         }),
   };
 }

--- a/src/data/dataSourceNormalization.smoke.js
+++ b/src/data/dataSourceNormalization.smoke.js
@@ -7,6 +7,7 @@ import {
 import {
   normalizeBackendCapabilities,
   normalizeBackendFailure,
+  normalizeDatasetCsvSaveResult,
   normalizeDatasetMutationResult,
   normalizeDatasetSummary,
   normalizeFeatureDetailsResult,
@@ -52,6 +53,22 @@ assert.equal(capabilities.browserFileImport, false);
 assert.equal(capabilities.nativeFilePickerImport, true);
 assert.equal(capabilities.points, true);
 assert.equal(capabilities.lines, false);
+assert.equal(capabilities.datasetCsvExport, false);
+
+assert.deepEqual(normalizeDatasetCsvSaveResult({
+  ok: true,
+  datasetId: 'dataset-1',
+  fileName: 'places.csv',
+}, 'dataset-1'), {
+  ok: true,
+  canceled: false,
+  datasetId: 'dataset-1',
+  fileName: 'places.csv',
+  error: null,
+});
+assert.equal(normalizeDatasetCsvSaveResult({
+  canceled: true,
+}, 'dataset-1').error, null);
 
 const initialization = normalizeInitializationResult({
   ok: false,

--- a/src/data/desktopSqliteDataSource.js
+++ b/src/data/desktopSqliteDataSource.js
@@ -6,6 +6,7 @@ import {
 import {
   normalizeBackendCapabilities,
   normalizeBackendFailure,
+  normalizeDatasetCsvSaveResult,
   normalizeDatasetMutationResult,
   normalizeDatasetSummary,
   normalizeFeatureDetailsResult,
@@ -40,6 +41,7 @@ export function createDesktopSqliteDataSource({ desktopApi } = {}) {
     datasetSelection: false,
     datasetVisibility: typeof desktopApi?.setDatasetEnabled === 'function',
     datasetRemoval: typeof desktopApi?.removeDataset === 'function',
+    datasetCsvExport: typeof desktopApi?.saveDatasetAsCsv === 'function',
     datasetMapping: false,
     previewPaging: false,
     points: typeof desktopApi?.queryMapView === 'function',
@@ -204,6 +206,23 @@ export function createDesktopSqliteDataSource({ desktopApi } = {}) {
         });
       } catch {
         return failedMutation(DATA_SOURCE_METHODS.removeDataset, normalizedId);
+      }
+    },
+
+    /** Ask the restricted desktop bridge to own both the dialog and file write. */
+    async saveDatasetAsCsv(datasetId) {
+      assertActive(DATA_SOURCE_METHODS.saveDatasetAsCsv);
+      const normalizedId = normalizeId(datasetId);
+      if (!capabilities.datasetCsvExport || !normalizedId) {
+        return normalizeDatasetCsvSaveResult(null, normalizedId);
+      }
+      try {
+        return normalizeDatasetCsvSaveResult(
+          await desktopApi.saveDatasetAsCsv(normalizedId),
+          normalizedId,
+        );
+      } catch {
+        return normalizeDatasetCsvSaveResult(null, normalizedId);
       }
     },
 

--- a/src/data/desktopSqliteDataSource.smoke.js
+++ b/src/data/desktopSqliteDataSource.smoke.js
@@ -72,6 +72,13 @@ const desktopApi = {
   }),
   setDatasetEnabled: async () => ({ updated: true, private: 'ignored' }),
   removeDataset: async () => ({ removed: true, private: 'ignored' }),
+  saveDatasetAsCsv: async (datasetId) => ({
+    ok: true,
+    canceled: false,
+    datasetId,
+    fileName: 'places.csv',
+    private: 'ignored',
+  }),
   queryMapView: async () => ({
     points: [{
       id: 'point-1',
@@ -118,6 +125,7 @@ assert.equal(initialization.capabilities.browserFileImport, false);
 assert.equal(initialization.capabilities.datasetMapping, false);
 assert.equal(initialization.capabilities.previewPaging, false);
 assert.equal(initialization.capabilities.zoneEditing, true);
+assert.equal(initialization.capabilities.datasetCsvExport, true);
 
 const progressEvents = [];
 const unsubscribe = dataSource.subscribeImportProgress((progress) => {
@@ -162,6 +170,13 @@ assert.equal(
   true,
 );
 assert.equal((await dataSource.removeDataset(' dataset-1 ')).changed, true);
+assert.deepEqual(await dataSource.saveDatasetAsCsv(' dataset-1 '), {
+  ok: true,
+  canceled: false,
+  datasetId: 'dataset-1',
+  fileName: 'places.csv',
+  error: null,
+});
 
 const mapView = await dataSource.queryMapView({ renderBudget: 10 });
 assert.equal(mapView.points.length, 1);


### PR DESCRIPTION
## Summary

Adds “Save as CSV” to the context menu for loaded datasets.

- Supports browser and desktop runtimes
- Exports committed SQLite dataset rows in their original order
- Preserves original headers and valid CSV escaping
- Includes saved zone coordinate adjustments
- Uses browser downloads or the desktop native Save dialog
- Handles cancellation silently and displays export errors
- Adds focused smoke tests for export behavior and runtime integration

## Testing

- `npm run smoke:sqlite-datasets`
- `npm run smoke:desktop-workflow`
- Browser SQLite smoke-test suite
- Desktop and browser builds
- Lint
- Manual smoke testing in the desktop application

Closes #131
