### PR TITLE
Disable timeline filtering by default

### DIFF
--- a/docs/browser-parity-baseline.md
+++ b/docs/browser-parity-baseline.md
@@ -71,11 +71,16 @@ future backend may implement it differently.
 ### Timeline
 
 - The Map tools menu enables or disables the timeline and marker clustering.
+- The timeline starts disabled, so dated, undated, and out-of-range features are
+  initially visible. Browser and desktop modes share this default.
 - A detected `year` field takes precedence over a detected date field. Explicit
   year/date range fields are also supported.
-- Enabling the timeline derives the available year domain from the selected
-  dataset. The visible year range filters points, lines, and regions and reports
-  the number skipped.
+- Enabling the timeline uses the configured `-2100` to `2026` default domain and
+  selected range. The visible year range filters points, lines, and regions,
+  excludes undated features, and reports the number skipped.
+- Importing, selecting, showing, hiding, or removing a dataset does not change
+  the configured range. Each dataset can provide a recommended range, which is
+  applied only through its explicit context-menu action.
 - The year domain can be entered manually. Timeline playback advances the
   selected range using the configured year step and interval.
 - Timeline state is kept in session storage.

--- a/src/components/useTimelineFilterState.js
+++ b/src/components/useTimelineFilterState.js
@@ -4,14 +4,14 @@ import { useSessionStorageState } from "./useSessionStorageState";
 const STORAGE_KEY = "csv-map-layer-visualizer.timeline.v1";
 
 const DEFAULT_STATE = {
-  timelineEnabled: true,
+  timelineEnabled: false,
 
   // Retained for saved-state compatibility; ranges now change only explicitly.
   yearDomainMode: "manual",
   yearMinDraft: "-2100",
   yearMaxDraft: "2026",
 
-  // Fixed initial domain; only explicit controls may replace it.
+  // Keep the configured range ready without filtering the initial map view.
   yearMin: -2100,
   yearMax: 2026,
 


### PR DESCRIPTION
Start fresh browser and desktop sessions with timeline filtering disabled while preserving the configured -2100 to 2026 range and existing session choices.

Update the browser parity documentation to describe the opt-in timeline behavior and explicit recommended-range action.

Closes #141
